### PR TITLE
Added Kind property to persistent volume resource for azure_disk

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -190,6 +190,13 @@ func skipIfNoGoogleCloudSettingsFound(t *testing.T) {
 	}
 }
 
+func skipIfNoAzureCloudSettingsFound(t *testing.T) {
+	if os.Getenv("TF_VAR_aks_client_id") == "" || os.Getenv("TF_VAR_aks_client_secret") == "" || os.Getenv("TF_VAR_location") == "" {
+		t.Skip("The environment variables TF_VAR_aks_client_id, TF_VAR_aks_client_secret and TF_VAR_location" +
+			" must be set to run Azure Cloud tests - skipping")
+	}
+}
+
 func skipIfNoAwsSettingsFound(t *testing.T) {
 	if os.Getenv("AWS_DEFAULT_REGION") == "" || os.Getenv("AWS_ZONE") == "" || os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
 		t.Skip("The environment variables AWS_DEFAULT_REGION, AWS_ZONE, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY" +

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -188,6 +188,117 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPersistentVolume_azure_basic(t *testing.T) {
+	var conf api.PersistentVolume
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+	diskName := fmt.Sprintf("tf-acc-test-disk-%s", randString)
+
+	region := os.Getenv("TF_VAR_location")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoAzureSettingsFound(t) },
+		IDRefreshName: "kubernetes_persistent_volume.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_azure_basic(name, diskName, region),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists("kubernetes_persistent_volume.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "kind", "Replace this"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPersistentVolume_azure_managed_disk(t *testing.T) {
+	var conf api.PersistentVolume
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+	diskName := fmt.Sprintf("tf-acc-test-disk-%s", randString)
+
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	zone := os.Getenv("AWS_ZONE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoAwsSettingsFound(t) },
+		IDRefreshName: "kubernetes_persistent_volume.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_aws_basic(name, diskName, zone),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists("kubernetes_persistent_volume.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.TestLabelThree", "three"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{
+						"TestLabelOne":   "one",
+						"TestLabelTwo":   "two",
+						"TestLabelThree": "three",
+						"failure-domain.beta.kubernetes.io/region": region,
+						"failure-domain.beta.kubernetes.io/zone":   zone,
+					}),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.#", "1"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.0.volume_id"),
+				),
+			},
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_aws_modified(name, diskName, zone),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists("kubernetes_persistent_volume.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.labels.TestLabelThree", "three"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{
+						"TestLabelOne":   "one",
+						"TestLabelTwo":   "two",
+						"TestLabelThree": "three",
+						"failure-domain.beta.kubernetes.io/region": region,
+						"failure-domain.beta.kubernetes.io/zone":   zone,
+					}),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "42Mi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.#", "1"),
+					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.0.volume_id"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.0.fs_type", "io1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.0.partition", "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.0.read_only", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesPersistentVolume_googleCloud_importBasic(t *testing.T) {
 	resourceName := "kubernetes_persistent_volume.test"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -820,6 +931,54 @@ resource "aws_ebs_volume" "test" {
   }
 }
 `, name, zone, diskName)
+}
+
+func testAccKubernetesPersistentVolumeConfig_azure_basic(name, diskName, region string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_persistent_volume" "test" {
+		metadata {
+			annotations {
+				TestAnnotationOne = "one"
+				TestAnnotationTwo = "two"
+			}
+	
+			labels {
+				TestLabelOne   = "one"
+				TestLabelTwo   = "two"
+				TestLabelThree = "three"
+			}
+	
+			name = "%s"
+		}
+		spec {
+			capacity {
+				storage = "2Gi"
+			}
+			access_modes = ["ReadWriteOnce"]
+			persistent_volume_source {
+				azure_disk {
+					caching_mode = "None"
+					data_disk_uri = "${azurerm_managed_disk.dbstorage.id}"
+					disk_name = "%s"
+					kind = "Managed"
+				}
+			}
+		}
+	}
+	resource "azurerm_managed_disk" "dbstorage" {
+		name                 = "%s"
+		location             = "West US 2"
+		resource_group_name  = "${azurerm_resource_group.tf-k8s-acc.name}"
+		storage_account_type = "Standard_LRS"
+		create_option        = "Empty"
+		disk_size_gb         = "10"
+	
+		tags {
+			environment = "Production"
+		}
+	}
+
+`, name, region, diskName)
 }
 
 func testAccKubernetesPersistentVolumeConfig_hostPath_volumeSource(name, path string) string {

--- a/kubernetes/schema_volume_source.go
+++ b/kubernetes/schema_volume_source.go
@@ -90,6 +90,12 @@ func commonVolumeSources() map[string]*schema.Schema {
 						Description: "The URI the data disk in the blob storage",
 						Required:    true,
 					},
+					"kind": {
+						Type:        schema.TypeString,
+						Description: "The type for the data disk. Expected values: Shared, Dedicated, Managed. Defaults to Shared",
+						Optional:    true,
+						Default:     "Shared",
+					},
 					"disk_name": {
 						Type:        schema.TypeString,
 						Description: "The Name of the data disk in the blob storage",

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -27,6 +27,7 @@ func flattenAzureDiskVolumeSource(in *v1.AzureDiskVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["disk_name"] = in.DiskName
 	att["data_disk_uri"] = in.DataDiskURI
+	att["kind"] = string(*in.Kind)
 	att["caching_mode"] = string(*in.CachingMode)
 	if in.FSType != nil {
 		att["fs_type"] = *in.FSType
@@ -491,10 +492,15 @@ func expandAzureDiskVolumeSource(l []interface{}) *v1.AzureDiskVolumeSource {
 	}
 	in := l[0].(map[string]interface{})
 	cachingMode := v1.AzureDataDiskCachingMode(in["caching_mode"].(string))
+
 	obj := &v1.AzureDiskVolumeSource{
 		CachingMode: &cachingMode,
 		DiskName:    in["disk_name"].(string),
 		DataDiskURI: in["data_disk_uri"].(string),
+	}
+	if v, ok := in["kind"].(string); ok {
+		kind := v1.AzureDataDiskKind(v)
+		obj.Kind = &kind
 	}
 	if v, ok := in["fs_type"].(string); ok {
 		obj.FSType = ptrToString(v)

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -27,7 +27,9 @@ func flattenAzureDiskVolumeSource(in *v1.AzureDiskVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["disk_name"] = in.DiskName
 	att["data_disk_uri"] = in.DataDiskURI
-	att["kind"] = string(*in.Kind)
+	if in.Kind != nil {
+		att["kind"] = string(*in.Kind)
+	}
 	att["caching_mode"] = string(*in.CachingMode)
 	if in.FSType != nil {
 		att["fs_type"] = *in.FSType

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -89,10 +89,11 @@ The following arguments are supported:
 #### Arguments
 
 * `caching_mode` - (Required) Host Caching mode: None, Read Only, Read Write.
-* `data_disk_uri` - (Required) The URI the data disk in the blob storage
-* `disk_name` - (Required) The Name of the data disk in the blob storage
+* `data_disk_uri` - (Required) The URI the data disk in the blob storage OR the resourceID of an Azure managed data disk if Kind is Managed
+* `disk_name` - (Required) The Name of the data disk in the blob storage OR the name of an Azure managed data disk if Kind is Managed.
 * `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 * `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
+* `kind` - (Optional) The type for the data disk. Expected values: Shared, Dedicated, Managed. Defaults to Shared
 
 ### `azure_file`
 


### PR DESCRIPTION
My first contribution and I am not a GoLang developer so be gentle :-)

(fixes #202)

Enabled support for Azure managed disks by adding support for "kind" property in the existing persistent volume resource for azure_disk. Also updated documentation and ran manual tests. There are no existing tests for Azure_Disk so I did not add one for this change.