### PR TITLE
Check if Generation is newer than the ObservedGeneration

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -367,7 +367,7 @@ func waitForDeploymentReplicasFunc(conn *kubernetes.Clientset, ns, name string) 
 			return resource.NonRetryableError(err)
 		}
 
-		if dply.Generation <= dply.Status.ObservedGeneration {
+		if dply.Generation >= dply.Status.ObservedGeneration {
 			cond := GetDeploymentCondition(dply.Status, appsv1.DeploymentProgressing)
 			if cond != nil && cond.Reason == TimedOutReason {
 				err := fmt.Errorf("Deployment exceeded its progress deadline")


### PR DESCRIPTION
When checking to see whether or not a deployment has succeeded, we should be checking if the generation as defined in the spec is newer than the last observed generation.

In its current form, the deployment is created and then immediately read from. This is resulting in every property (UpdatedReplicas, AvailableReplicas, etc) on the Status response to be zero, causing the `waitForDeploymentReplicasFunc()` to immediately return without waiting for the pods to become ready.