### PR TITLE
Allow specifying generated kubeconfig file

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -230,9 +230,10 @@ func tryLoadingConfigFile(d *schema.ResourceData) (*restclient.Config, error) {
 	if err != nil {
 		if pathErr, ok := err.(*os.PathError); ok && os.IsNotExist(pathErr.Err) {
 			log.Printf("[INFO] Unable to load config file as it doesn't exist at %q", path)
-			return nil, nil
+			return &restclient.Config{}, nil
 		}
-		return nil, fmt.Errorf("Failed to load config (%s%s): %s", path, ctxSuffix, err)
+		log.Printf("[INFO] Failed to load config (%s%s): %s", path, ctxSuffix, err)
+		return &restclient.Config{}, nil
 	}
 
 	log.Printf("[INFO] Successfully loaded config file (%s%s)", path, ctxSuffix)


### PR DESCRIPTION
This PR fixes https://github.com/terraform-providers/terraform-provider-kubernetes/issues/142. When failed to load kubeconfig, fallback to use `rest.Config{}`.