### PR TITLE
accept PATH-style kubeconfig

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -3,17 +3,17 @@ package kubernetes
 import (
 	"bytes"
 	"fmt"
-	"log"
-	"os"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
-	kubernetes "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"log"
+	"os"
+	"strings"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -240,7 +240,7 @@ func tryLoadingConfigFile(d *schema.ResourceData) (*restclient.Config, error) {
 	}
 
 	loader := &clientcmd.ClientConfigLoadingRules{
-		ExplicitPath: path,
+		Precedence: strings.Split(path, string(':')),
 	}
 
 	overrides := &clientcmd.ConfigOverrides{}


### PR DESCRIPTION
The env var KUBECONFIG may be set in the style of $PATH, i.e., mutliple
files divided by a colon, so that the actual configuration may be spread
out over multiple files. THis may be desirable so that the non-secret
cluster configuration may be checked into a source code repo leaving
actual credentials separate.