### PR TITLE
add resource_field_ref/ResourceFieldSelector divisor field

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -284,6 +284,13 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Type:     schema.TypeString,
 												Optional: true,
 											},
+											"divisor": {
+												Type:             schema.TypeString,
+												Optional:         true,
+												Computed:         true,
+												ValidateFunc:     validateResourceQuantity,
+												DiffSuppressFunc: suppressEquivalentResourceQuantity,
+											},
 											"resource": {
 												Type:        schema.TypeString,
 												Required:    true,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -496,6 +496,13 @@ func volumeSchema() *schema.Resource {
 											Type:     schema.TypeString,
 											Required: true,
 										},
+										"divisor": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Computed:         true,
+											ValidateFunc:     validateResourceQuantity,
+											DiffSuppressFunc: suppressEquivalentResourceQuantity,
+										},
 										"resource": {
 											Type:        schema.TypeString,
 											Required:    true,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -496,10 +496,6 @@ func volumeSchema() *schema.Resource {
 											Type:     schema.TypeString,
 											Required: true,
 										},
-										"quantity": {
-											Type:     schema.TypeString,
-											Optional: true,
-										},
 										"resource": {
 											Type:        schema.TypeString,
 											Required:    true,

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -838,7 +838,7 @@ func expandFieldRef(r []interface{}) (*v1.ObjectFieldSelector, error) {
 	}
 	return obj, nil
 }
-func expandResourceFieldRef(r []interface{}) (*v1.ResourceFieldSelector, error) {
+func expandResourceFieldSelector(r []interface{}) (*v1.ResourceFieldSelector, error) {
 	if len(r) == 0 || r[0] == nil {
 		return &v1.ResourceFieldSelector{}, nil
 	}
@@ -914,7 +914,7 @@ func expandEnvValueFrom(r []interface{}) (*v1.EnvVarSource, error) {
 		}
 	}
 	if v, ok := in["resource_field_ref"].([]interface{}); ok && len(v) > 0 {
-		obj.ResourceFieldRef, err = expandResourceFieldRef(v)
+		obj.ResourceFieldRef, err = expandResourceFieldSelector(v)
 		if err != nil {
 			return obj, err
 		}

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -215,6 +216,9 @@ func flattenResourceFieldSelector(in *v1.ResourceFieldSelector) []interface{} {
 	if in.ContainerName != "" {
 		att["container_name"] = in.ContainerName
 	}
+
+	att["divisor"] = in.Divisor.String()
+
 	if in.Resource != "" {
 		att["resource"] = in.Resource
 	}
@@ -847,6 +851,13 @@ func expandResourceFieldSelector(r []interface{}) (*v1.ResourceFieldSelector, er
 
 	if v, ok := in["container_name"].(string); ok {
 		obj.ContainerName = v
+	}
+	if v, ok := in["divisor"].(string); ok && v != "" {
+		q, err := resource.ParseQuantity(v)
+		if err != nil {
+			return obj, err
+		}
+		obj.Divisor = q
 	}
 	if v, ok := in["resource"].(string); ok {
 		obj.Resource = v

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -695,7 +695,7 @@ func expandDownwardAPIVolumeFile(in []interface{}) ([]v1.DownwardAPIVolumeFile, 
 			}
 		}
 		if v, ok := p["resource_field_ref"].([]interface{}); ok && len(v) > 0 {
-			dapivf[i].ResourceFieldRef, err = expandResourceFieldRef(v)
+			dapivf[i].ResourceFieldRef, err = expandResourceFieldSelector(v)
 			if err != nil {
 				return dapivf, err
 			}


### PR DESCRIPTION
The `divisor` field is part of v1 core since at least 1.10.  See:

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#resourcefieldselector-v1-core
..
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcefieldselector-v1-core

Note that there is no existing provider documentation for `resource_field_ref` fields, so documentation for `divisor` is not part of this PR.