### PR TITLE
Update Cronjob Resource documentation to remove suspend = true from example

### DIFF
--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -28,7 +28,6 @@ resource "kubernetes_cron_job" "demo" {
     schedule                      = "1 0 * * *"
     starting_deadline_seconds     = 10
     successful_jobs_history_limit = 10
-    suspend                       = true
     job_template {
       metadata {}
       spec {


### PR DESCRIPTION
This Pull Requests updates the documentation for the [Kubernetes Cronjob ](https://www.terraform.io/docs/providers/kubernetes/r/cron_job.html) resource.

The current **Example Usage** resource block in the documentation contains the `suspend                       = true` configuration value which stops the Cronjob from ever executing.

This should change because:

1. `suspend = true` prevents the Cronjob from executing. While this is valid behaviour in some circumstances, the majority of use cases would not see users set `suspend` to `true`.
2. It deviates from the default value of `false`, and in my opinion there is no value in having it set to `true` for the sake of an example.
3. It is confusing for users who are copying and pasting the example resource block, because the Cronjob never fires unless users notices and corrects the `suspend = true` which deviates from the default.

