### PR TITLE
allow base64 data such as JKS secrets to be passed to the secret object

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,7 @@ github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -42,7 +42,7 @@ resource "kubernetes_secret" "example" {
   }
 
   data = {
-    ".dockerconfigjson" = "${file("${path.module}/.docker/config.json")}"
+    ".dockerconfigjson" = file("${path.module}/.docker/config.json")
   }
 
   type = "kubernetes.io/dockerconfigjson"
@@ -63,11 +63,33 @@ resource "kubernetes_secret" "example" {
 }
 ```
 
+## Example Usage (Base64 Data)
+
+```hcl
+resource "kubernetes_secret" "example" {
+  metadata {
+    name = "jvm-keystore"
+  }
+
+  data = {
+    password = "P4ssw0rd"
+  }
+
+  base64data = {
+    keystore = filebase64("${path.module}/client.keystore.p12")
+  }
+
+  type = "kubernetes.io/basic-auth"
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `data` - (Optional) A map of the secret data.
+* `data` - (Optional) A map of the secret data. This data must not be base64-encoded.
+* `base64data` - (Optional) A map of secret data that is already base64-encoded. Keys in the `base64data` map always take precedence over those in `data`.
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
 


### PR DESCRIPTION
With Terraform 12, binary objects such as Java Keystores (JKS) can only be correctly loaded into terraform with `filebase64`. Unfortunately, as described in https://github.com/terraform-providers/terraform-provider-kubernetes/issues/518 this breaks the ability for this provider to properly create secrets for these kinds of files, since the data is encoded once by Terraform, and a second time by the Kubernetes control plane. 

As suggested in https://github.com/terraform-providers/terraform-provider-kubernetes/issues/518, this adds another attribute to the kubernetes secret which allows users to specify `base64data`. This data will be decoded from Base64 just prior to being sent to Kubernetes. Additionally, this change should be backward compatible as it adds a new field and does not change the functionality of existing secrets created with this provider.