### PR TITLE
Add Kubernetes Job - `wait_for_completion` functionality

### DIFF
--- a/_examples/job/README.md
+++ b/_examples/job/README.md
@@ -1,0 +1,6 @@
+# Example: Job
+
+## Prerequsites
+
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*

--- a/_examples/job/main.tf
+++ b/_examples/job/main.tf
@@ -1,7 +1,7 @@
-provider kubernetes {
+provider "kubernetes" {
 }
 
-resource kubernetes_job test-pr {
+resource "kubernetes_job" "test-pr" {
   metadata {
     name = "job-with-wait"
     namespace = "default"

--- a/_examples/job/main.tf
+++ b/_examples/job/main.tf
@@ -1,0 +1,27 @@
+provider kubernetes {
+}
+
+resource kubernetes_job test-pr {
+  metadata {
+    name = "job-with-wait"
+    namespace = "default"
+  }
+  spec {
+    completions = 1
+    template {
+      metadata {}
+      spec {
+        container {
+          name = "sleep"
+          image = "busybox:latest"
+          command = ["sleep", "30"]
+        }
+        restart_policy = "Never"
+      }
+    }
+  }
+  wait_for_completion = true
+  timeouts {
+    create = "40s"
+  }
+}

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -85,7 +85,7 @@ func resourceKubernetesJobCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	if d.Get("wait_for_completion").(bool) {
 		return resource.Retry(d.Timeout(schema.TimeoutCreate),
-			retryUntilJobCondition(conn, namespace, name, batchv1.JobComplete))
+			retryUntilJobIsFinished(conn, namespace, name))
 	}
 
 	return resourceKubernetesJobRead(d, meta)
@@ -121,7 +121,7 @@ func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.Get("wait_for_completion").(bool) {
 		return resource.Retry(d.Timeout(schema.TimeoutUpdate),
-			retryUntilJobCondition(conn, namespace, name, batchv1.JobComplete))
+			retryUntilJobIsFinished(conn, namespace, name))
 	}
 	return resourceKubernetesJobRead(d, meta)
 }
@@ -238,7 +238,8 @@ func resourceKubernetesJobExists(d *schema.ResourceData, meta interface{}) (bool
 	return true, err
 }
 
-func retryUntilJobCondition(conn *kubernetes.Clientset, ns, name string, condition batchv1.JobConditionType) resource.RetryFunc {
+// retryUntilJobIsFinished checks if a give job finished its execution and either in Complete or Failed state
+func retryUntilJobIsFinished(conn *kubernetes.Clientset, ns, name string) resource.RetryFunc {
 	return func() *resource.RetryError {
 		job, err := conn.BatchV1().Jobs(ns).Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -246,12 +247,17 @@ func retryUntilJobCondition(conn *kubernetes.Clientset, ns, name string, conditi
 		}
 
 		for _, c := range job.Status.Conditions {
-			if c.Type == condition && c.Status == corev1.ConditionTrue {
-				return nil
+			if c.Status == corev1.ConditionTrue {
+				log.Printf("[DEBUG] Current condition of job: %s/%s: %s\n", ns, name, c.Type)
+				switch c.Type {
+				case batchv1.JobComplete:
+					return nil
+				case batchv1.JobFailed:
+					return resource.NonRetryableError(fmt.Errorf("job: %s/%s is in failed sate", ns, name))
+				}
 			}
-			log.Printf("[DEBUG] Current condition of job: %s/%s: %s\n", ns, name, c.Type)
 		}
 
-		return resource.RetryableError(fmt.Errorf("job: %s/%s is not in: %s condition", ns, name, condition))
+		return resource.RetryableError(fmt.Errorf("job: %s/%s is not in complete state", ns, name))
 	}
 }

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -28,6 +28,7 @@ func resourceKubernetesJob() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 
@@ -119,7 +120,7 @@ func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(buildId(out.ObjectMeta))
 
 	if d.Get("wait_for_completion").(bool) {
-		return resource.Retry(d.Timeout(schema.TimeoutCreate),
+		return resource.Retry(d.Timeout(schema.TimeoutUpdate),
 			waitForJobCondition(conn, namespace, name, batchv1.JobComplete))
 	}
 	return resourceKubernetesJobRead(d, meta)

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -249,7 +249,7 @@ func waitForJobCondition(conn *kubernetes.Clientset, ns, name string, condition 
 			if c.Status != corev1.ConditionTrue {
 				continue
 			}
-			log.Printf("[DEBUG] Current contions of job: %s/%s: %s\n", ns, name, c.Type)
+			log.Printf("[DEBUG] Current condition of job: %s/%s: %s\n", ns, name, c.Type)
 			if c.Type == condition {
 				return nil
 			}

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -42,7 +42,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "false"),
+					resource.TestCheckNoResourceAttr("kubernetes_job.test", "wait_for_completion"),
 				),
 			},
 			{

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -42,7 +42,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "true"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "false"),
 				),
 			},
 			{
@@ -231,5 +231,9 @@ resource "kubernetes_job" "test" {
 			}
 		}
 	}
+    wait_for_completion = "true"
+    timeouts {
+		create = "2m"
+    }
 }`, name)
 }

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -260,9 +260,9 @@ resource "kubernetes_job" "test" {
 		}
 	}
 	wait_for_completion = true
-    timeouts {
+	timeouts {
 		create = "1m"
-    }
+	}
 }`, name)
 }
 

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -14,6 +15,44 @@ import (
 
 func ttlAfterDisabled() (bool, string) {
 	return os.Getenv("FEATURE_GATE_TTL_AFTER_FINISHED") != "enabled", "TTLAfterFinished is not enabled"
+}
+
+func TestAccKubernetesJob_wait_for_completion(t *testing.T) {
+	var conf api.Job
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_job.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesJobConfig_wait_for_completion(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// NOTE this is to check that Terraform actually waited for the Job to complete
+					// before considering the Job resource as created
+					testAccCheckJobWaited(time.Duration(10)*time.Second),
+					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckJobWaited(minDuration time.Duration) func(*terraform.State) error {
+	// NOTE this works because this function is called when setting up the test
+	// and the function it returns is called after the resource has been created
+	startTime := time.Now()
+
+	return func(_ *terraform.State) error {
+		testDuration := time.Since(startTime)
+		if testDuration < minDuration {
+			return fmt.Errorf("the job should have waited at least %s before being created", minDuration)
+		}
+		return nil
+	}
 }
 
 func TestAccKubernetesJob_basic(t *testing.T) {
@@ -64,7 +103,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.manual_selector", "true"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "true"),
+					resource.TestCheckNoResourceAttr("kubernetes_job.test", "wait_for_completion"),
 				),
 			},
 		},
@@ -200,6 +239,33 @@ resource "kubernetes_job" "test" {
 }`, name)
 }
 
+func testAccKubernetesJobConfig_wait_for_completion(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_job" "test" {
+	metadata {
+		name = "%s"
+	}
+	spec {
+		template {
+			metadata {
+				name = "wait-test"
+			}
+			spec {
+				container {
+					name = "wait-test"
+					image = "busybox"
+					command = ["sleep", "10"]
+				}
+			}
+		}
+	}
+	wait_for_completion = true
+    timeouts {
+		create = "1m"
+    }
+}`, name)
+}
+
 func testAccKubernetesJobConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_job" "test" {
@@ -231,9 +297,5 @@ resource "kubernetes_job" "test" {
 			}
 		}
 	}
-    wait_for_completion = "true"
-    timeouts {
-		create = "2m"
-    }
 }`, name)
 }

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -42,6 +42,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "true"),
 				),
 			},
 			{
@@ -63,6 +64,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.manual_selector", "true"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "wait_for_completion", "true"),
 				),
 			},
 		},

--- a/vendor/gopkg.in/yaml.v2/go.sum
+++ b/vendor/gopkg.in/yaml.v2/go.sum
@@ -1,0 +1,1 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -127,7 +127,8 @@ Please see the [Pod resource](pod.html#spec-1) for reference.
 
 The following [Timeout](/docs/configuration/resources.html#operation-timeouts) configuration options are available for the `kubernetes_job` resource when used with `wait_for_completion = true`:
 
-* `create` - (Default `1 minute`) Used for creating new job and waiting for a successful job completion.
+* `create` - (Default `1 minute`) Used for creating a new job and waiting for a successful job completion.
+* `update - (Default `1 minute`) Used for updating an existing job and waiting for a successful job completion.
 
 Note: 
 - Kubernetes provider will treat update operations that change the Job spec resulting in the job re-run as "# forces replacement". 

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -122,3 +122,14 @@ More info: http://kubernetes.io/docs/user-guide/labels
 These arguments are the same as the for the `spec` block of a Pod.
 
 Please see the [Pod resource](pod.html#spec-1) for reference.
+
+## Timeouts
+
+The following [Timeout](/docs/configuration/resources.html#operation-timeouts) configuration options are available for the `kubernetes_job` resource when used with `wait_for_completion = true`:
+
+* `create` - (Default `1 minute`) Used for creating new job and waiting for a successful job completion.
+
+Note: 
+- Kubernetes provider will treat update operations that change the Job spec resulting in the job re-run as "# forces replacement". 
+In such cases, the `create` timeout value is used for both Create and Update operations.
+- `wait_for_completion` is not applicable during Delete operations; thus, there is no "delete" timeout value for Delete operation. 

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard resource's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 * `spec` - (Required) Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
 * `wait_for_completion` - 
-(Optional) If `true` blocks job `create` or `update` until the status of the job reached the `Complete` condition. 
+(Optional) If `true` blocks job `create` or `update` until the status of the job has a `Complete` or `Failed` condition.
 
 ## Nested Blocks
 

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
   You can also use a Job to run multiple Pods in parallel.
 
-## Example Usage
+## Example Usage - No waiting
 
 ```hcl
 resource "kubernetes_job" "demo" {
@@ -38,12 +38,39 @@ resource "kubernetes_job" "demo" {
 }
 ```
 
+## Example Usage - waiting for job successful completion
+
+```hcl
+resource "kubernetes_job" "demo" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "pi"
+          image   = "perl"
+          command = ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 4
+  }
+  wait_for_completion = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `metadata` - (Required) Standard resource's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 * `spec` - (Required) Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+* `wait_for_completion` - 
+(Optional) If `true` blocks job `create` or `update` until the status of the job reached the `Complete` condition. 
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Overview
The current behavior of `kubernetes_job` resource is to return immediately once it successfully creates the Kubernetes job resource. This behavior, however, creates a problem when we are using Kubernetes Jobs as a dependency step. For example, one may use Kubernetes Job to prepare/update the environment, before advancing to using the environment (database migration, etc.) In such cases, it is essential to wait until the successful completion of Kubernetes Job to proceed to the next step.

### Changes
This commit adds `wait_for_completion = true/false` attribute to the
`kubernetes_job` resource. The default value (if not provided) is `false`,
thus `kubernetes_job` has the same functionality as in the original.

When enabled `wait_for_completion = true`, upon resource create or update
the process will wait until said Kubernetes Job reaches "Complete" state

### Tracking
#534

### Examples
#### Default (current) Behavior 
```yaml
resource kubernetes_job test-pr {
  metadata {
    name = "job-with-wait"
    namespace = "default"
  }
  spec {
    completions = 1
    active_deadline_seconds = 60
    template {
      metadata {}
      spec {
        container {
          name = "sleep"
          image = "busybox:latest"
          command = ["sleep", "30"]
        }
        restart_policy = "Never"
      }
    }
  }
}
```
Results in:
```
Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

kubernetes_job.test-pr: Creating...
kubernetes_job.test-pr: Creation complete after 0s [id=default/job-with-wait]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
While the actual Job and Job's Pod is 
```
> kubectl get job
NAME            COMPLETIONS   DURATION   AGE
job-with-wait   0/1           7s         7s
⋊> kubectl get job job-with-wait -ojson | jq '.status'
{
  "active": 1,
  "startTime": "2019-09-22T21:19:42Z"
}
⋊> kubectl get pod
NAME                  READY   STATUS    RESTARTS   AGE
job-with-wait-k4wzm   1/1     Running   0          28s
```

#### With Wait
Same as the above, but with `wait_for_completion = true` 

```yaml
resource kubernetes_job test-pr {
  metadata {
    name = "job-with-wait"
    namespace = "default"
  }
  spec {
    completions = 1
    active_deadline_seconds = 60
    template {
      metadata {}
      spec {
        container {
          name = "sleep"
          image = "busybox:latest"
          command = ["sleep", "30"]
        }
        restart_policy = "Never"
      }
    }
  }
  wait_for_completion = true
}
```
Results in:
```
Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

kubernetes_job.test-pr: Creating...
kubernetes_job.test-pr: Still creating... [10s elapsed]
kubernetes_job.test-pr: Still creating... [20s elapsed]
kubernetes_job.test-pr: Still creating... [30s elapsed]
kubernetes_job.test-pr: Creation complete after 37s [id=default/job-with-wait]
```