### PR TITLE
No need to skip TestProvider_configure unit test if TEST_ACC is set

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -40,11 +40,6 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func TestProvider_configure(t *testing.T) {
-	if os.Getenv("TF_ACC") != "" {
-		t.Skip("The environment variable TF_ACC is set, and this test prevents acceptance tests" +
-			" from running as it alters environment variables - skipping")
-	}
-
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 
@@ -95,6 +90,15 @@ func unsetEnv(t *testing.T) func() {
 	if err := os.Unsetenv("KUBE_CLUSTER_CA_CERT_DATA"); err != nil {
 		t.Fatalf("Error unsetting env var KUBE_CLUSTER_CA_CERT_DATA: %s", err)
 	}
+	if err := os.Unsetenv("KUBE_INSECURE"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_INSECURE: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_LOAD_CONFIG_FILE"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_LOAD_CONFIG_FILE: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_TOKEN"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_TOKEN: %s", err)
+	}
 
 	return func() {
 		if err := os.Setenv("KUBE_CONFIG", e.Config); err != nil {
@@ -103,7 +107,7 @@ func unsetEnv(t *testing.T) func() {
 		if err := os.Setenv("KUBECONFIG", e.Config); err != nil {
 			t.Fatalf("Error resetting env var KUBECONFIG: %s", err)
 		}
-		if err := os.Setenv("KUBE_CTX", e.Config); err != nil {
+		if err := os.Setenv("KUBE_CTX", e.Ctx); err != nil {
 			t.Fatalf("Error resetting env var KUBE_CTX: %s", err)
 		}
 		if err := os.Setenv("KUBE_CTX_AUTH_INFO", e.CtxAuthInfo); err != nil {
@@ -130,6 +134,15 @@ func unsetEnv(t *testing.T) func() {
 		if err := os.Setenv("KUBE_CLUSTER_CA_CERT_DATA", e.ClusterCACertData); err != nil {
 			t.Fatalf("Error resetting env var KUBE_CLUSTER_CA_CERT_DATA: %s", err)
 		}
+		if err := os.Setenv("KUBE_INSECURE", e.Insecure); err != nil {
+			t.Fatalf("Error resetting env var KUBE_INSECURE: %s", err)
+		}
+		if err := os.Setenv("KUBE_LOAD_CONFIG_FILE", e.LoadConfigFile); err != nil {
+			t.Fatalf("Error resetting env var KUBE_LOAD_CONFIG_FILE: %s", err)
+		}
+		if err := os.Setenv("KUBE_TOKEN", e.Token); err != nil {
+			t.Fatalf("Error resetting env var KUBE_TOKEN: %s", err)
+		}
 	}
 }
 
@@ -144,6 +157,9 @@ func getEnv() *currentEnv {
 		ClientCertData:    os.Getenv("KUBE_CLIENT_CERT_DATA"),
 		ClientKeyData:     os.Getenv("KUBE_CLIENT_KEY_DATA"),
 		ClusterCACertData: os.Getenv("KUBE_CLUSTER_CA_CERT_DATA"),
+		Insecure:          os.Getenv("KUBE_INSECURE"),
+		LoadConfigFile:    os.Getenv("KUBE_LOAD_CONFIG_FILE"),
+		Token:             os.Getenv("KUBE_TOKEN"),
 	}
 	if cfg := os.Getenv("KUBE_CONFIG"); cfg != "" {
 		e.Config = cfg
@@ -351,4 +367,7 @@ type currentEnv struct {
 	ClientCertData    string
 	ClientKeyData     string
 	ClusterCACertData string
+	Insecure          string
+	LoadConfigFile    string
+	Token             string
 }


### PR DESCRIPTION
Follow up on https://github.com/terraform-providers/terraform-provider-kubernetes/pull/314#issuecomment-553364140

The underlying cause was that the `KUBE_CTX` environment variables was improperly restored at the end of `TestProvider_configure`.

Also, `KUBE_INSECURE`, `KUBE_LOAD_CONFIG_FILE` and `KUBE_TOKEN` were added to the list of potentially altered environment variables to unset and restore.