### PR TITLE
allow base64 data such as JKS secrets to be passed to the secret object

### DIFF
--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -67,8 +67,8 @@ func TestAccKubernetesSecret_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.%", "2"),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.one", "first"),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.two", "second"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64data.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64data.three", base64.StdEncoding.EncodeToString([]byte("third"))),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64_data.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64_data.three", base64.StdEncoding.EncodeToString([]byte("third"))),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "type", "Opaque"),
 					testAccCheckSecretData(&conf, map[string]string{"one": "first", "two": "second", "three": "third"}),
 				),
@@ -248,17 +248,17 @@ func TestAccKubernetesSecret_binaryData(t *testing.T) {
 				Config: testAccKubernetesSecretConfig_binaryData(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64data.%", "1"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64data.one"),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64_data.%", "1"),
+					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64_data.one"),
 				),
 			},
 			{
 				Config: testAccKubernetesSecretConfig_binaryData2(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64data.%", "2"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64data.one"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64data.two"),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64_data.%", "2"),
+					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64_data.one"),
+					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64_data.two"),
 				),
 			},
 			{
@@ -267,9 +267,9 @@ func TestAccKubernetesSecret_binaryData(t *testing.T) {
 					testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.%", "3"),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.two", "second"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64data.%", "2"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64data.one"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64data.three"),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "base64_data.%", "2"),
+					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64_data.one"),
+					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "base64_data.three"),
 				),
 			},
 		},
@@ -391,7 +391,7 @@ resource "kubernetes_secret" "test" {
     two = "second"
   }
 
-  base64data = {
+  base64_data = {
     three = base64encode("third")
   }
 }
@@ -473,7 +473,7 @@ resource "kubernetes_secret" "test" {
     generate_name = "%s"
   }
 
-  base64data = {
+  base64_data = {
     one = "${filebase64("./test-fixtures/binary.data")}"
   }
 }
@@ -487,7 +487,7 @@ resource "kubernetes_secret" "test" {
     generate_name = "%s"
   }
 
-  base64data = {
+  base64_data = {
     one = "${filebase64("./test-fixtures/binary2.data")}"
     two = "${filebase64("./test-fixtures/binary.data")}"
   }
@@ -506,7 +506,7 @@ resource "kubernetes_secret" "test" {
     one = "to be overwritten"
     two = "second"
   }
-  base64data = {
+  base64_data = {
     one = "${filebase64("./test-fixtures/binary2.data")}"
     three = "${filebase64("./test-fixtures/binary.data")}"
   }

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -42,7 +42,7 @@ resource "kubernetes_secret" "example" {
   }
 
   data = {
-    ".dockerconfigjson" = "${file("${path.module}/.docker/config.json")}"
+    ".dockerconfigjson" = file("${path.module}/.docker/config.json")
   }
 
   type = "kubernetes.io/dockerconfigjson"
@@ -63,11 +63,33 @@ resource "kubernetes_secret" "example" {
 }
 ```
 
+## Example Usage (Base64 Data)
+
+```hcl
+resource "kubernetes_secret" "example" {
+  metadata {
+    name = "jvm-keystore"
+  }
+
+  data = {
+    password = "P4ssw0rd"
+  }
+
+  base64data = {
+    keystore = filebase64("${path.module}/client.keystore.p12")
+  }
+
+  type = "kubernetes.io/basic-auth"
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `data` - (Optional) A map of the secret data.
+* `data` - (Optional) A map of the secret data. This data must not be base64-encoded.
+* `base64data` - (Optional) A map of secret data that is already base64-encoded. Keys in the `base64data` map always take precedence over those in `data`.
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
 

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -75,7 +75,7 @@ resource "kubernetes_secret" "example" {
     password = "P4ssw0rd"
   }
 
-  base64data = {
+  base64_data = {
     keystore = filebase64("${path.module}/client.keystore.p12")
   }
 
@@ -89,7 +89,7 @@ resource "kubernetes_secret" "example" {
 The following arguments are supported:
 
 * `data` - (Optional) A map of the secret data. This data must not be base64-encoded.
-* `base64data` - (Optional) A map of secret data that is already base64-encoded. Keys in the `base64data` map always take precedence over those in `data`.
+* `base64_data` - (Optional) A map of secret data that is already base64-encoded. Keys in the `base64_data` map always take precedence over those in `data`.
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
 


### PR DESCRIPTION
This PR is based on @benjigoldberg's #604. Added some commits to resolve review comments on #604.

Here's a copy&pasted description from #604.
> With Terraform 12, binary objects such as Java Keystores (JKS) can only be correctly loaded into terraform with filebase64. Unfortunately, as described in #518 this breaks the ability for this provider to properly create secrets for these kinds of files, since the data is encoded once by Terraform, and a second time by the Kubernetes control plane.
> 
> As suggested in #518, this adds another attribute to the kubernetes secret which allows users to specify base64data. This data will be decoded from Base64 just prior to being sent to Kubernetes. Additionally, this change should be backward compatible as it adds a new field and does not change the functionality of existing secrets created with this provider.