### PR TITLE
host_aliases' ForceNew determined by isUpdatable

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -112,7 +112,6 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 		"host_aliases": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			ForceNew:    true,
 			Computed:    isComputed,
 			Description: "List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty.",
 			Deprecated:  deprecatedMessage,


### PR DESCRIPTION
In the context of things like a `kubernetes_deployment`, `host_aliases` are updatable and should not force the creation of a new resource. This removes the hard-coded `true` and lets the check for `isUpdatable` handle the setting.