### PR TITLE
a more common provider example usage

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -16,8 +16,7 @@ Use the navigation to the left to read about the available resources.
 
 ```hcl
 provider "kubernetes" {
-  config_context_auth_info = "ops"
-  config_context_cluster   = "mycluster"
+  config_context = "my-context"
 }
 
 resource "kubernetes_namespace" "example" {


### PR DESCRIPTION
Fixes #176. Detailed comments on that issue but in summary, kubectl users are accustomed to using and thinking about kubeconfig contexts. The getting started example should show folks what they're used to thinking about. More involved methods of authentication are well described for folks who need them.