### PR TITLE
bugfix: should not force new resource for deployment when affinity la…

### DIFF
--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -153,7 +153,7 @@ func podAffinityTermFields() map[string]*schema.Schema {
 			Description: "A label query over a set of resources, in this case pods.",
 			Optional:    true,
 			Elem: &schema.Resource{
-				Schema: labelSelectorFields(false),
+				Schema: labelSelectorFields(true),
 			},
 		},
 		"namespaces": {


### PR DESCRIPTION
…bel selectors change

fix for issue #703 , details there.

it seems that commit f8f43352adec6bd019405ba8d0ee4df9d18118d6 used the incorrect value, when focusing on another task? idk.