### PR TITLE
Fix kubernetes_job updates

### DIFF
--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -106,7 +106,13 @@ func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
-
+	if d.HasChange("spec") {
+		specOps, err := patchJobSpec("/spec", "spec.0.", d)
+		if err != nil {
+			return err
+		}
+		ops = append(ops, specOps...)
+	}
 	data, err := ops.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("Failed to marshal update operations: %s", err)

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -67,7 +67,8 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckKubernetesJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesJobConfig_basic(name),
+				Config:              testAccKubernetesJobConfig_basic(name),
+				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffCreate},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
@@ -86,7 +87,8 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobConfig_modified(name),
+				Config:              testAccKubernetesJobConfig_modified(name),
+				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffUpdate},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
@@ -106,7 +108,8 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobConfig_recreated_selector(name),
+				Config:              testAccKubernetesJobConfig_recreated_selector(name),
+				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffDestroyCreate},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
@@ -129,7 +132,8 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobConfig_recreated_image(name),
+				Config:              testAccKubernetesJobConfig_recreated_image(name),
+				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffDestroyCreate},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -67,8 +67,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckKubernetesJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:              testAccKubernetesJobConfig_basic(name),
-				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffCreate},
+				Config: testAccKubernetesJobConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
@@ -87,8 +86,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:              testAccKubernetesJobConfig_modified(name),
-				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffUpdate},
+				Config: testAccKubernetesJobConfig_modified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
@@ -108,8 +106,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:              testAccKubernetesJobConfig_recreated_selector(name),
-				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffDestroyCreate},
+				Config: testAccKubernetesJobConfig_recreated_selector(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
@@ -132,8 +129,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:              testAccKubernetesJobConfig_recreated_image(name),
-				ExpectedDiffChanges: map[string]terraform.DiffChangeType{"kubernetes_job.test": terraform.DiffDestroyCreate},
+				Config: testAccKubernetesJobConfig_recreated_image(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -394,6 +394,7 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 		},
 		"image": {
 			Type:        schema.TypeString,
+			ForceNew:    !isUpdatable,
 			Optional:    true,
 			Description: "Docker image name. More info: http://kubernetes.io/docs/user-guide/images",
 		},

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -36,14 +36,12 @@ func jobSpecFields() map[string]*schema.Schema {
 		"active_deadline_seconds": {
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
 		},
 		"backoff_limit": {
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: validateNonNegativeInteger,
 			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
 		},
@@ -64,7 +62,6 @@ func jobSpecFields() map[string]*schema.Schema {
 		"parallelism": {
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ForceNew:     true,
 			Default:      1,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -112,5 +112,21 @@ func patchJobSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOpera
 		})
 	}
 
+	if d.HasChange(prefix + "backoff_limit") {
+		v := d.Get(prefix + "backoff_limit").(int)
+		ops = append(ops, &ReplaceOperation{
+			Path:  pathPrefix + "/backoffLimit",
+			Value: v,
+		})
+	}
+
+	if d.HasChange(prefix + "parallelism") {
+		v := d.Get(prefix + "parallelism").(int)
+		ops = append(ops, &ReplaceOperation{
+			Path:  pathPrefix + "/parallelism",
+			Value: v,
+		})
+	}
+
 	return ops, nil
 }


### PR DESCRIPTION
This is marked as WIP because it needs:

- [ ] complete acceptance test run
- [ ] documentation updates
- [ ] ~https://github.com/hashicorp/terraform-plugin-sdk/pull/329~

This PR allows to update the following fields of a `kubernetes_job` resource without recreating it:

- `active_deadline_seconds`
- `backoff_limit`
- `parallelism`

It also forces the recreation of a job resource when its pod template `image` field is modified.
Previously, it would detect a change was needed:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # kubernetes_job.terraform will be updated in-place
  ~ resource "kubernetes_job" "terraform" {
        id = "default/terraform"

        metadata {
            annotations      = {}
            generation       = 0
            labels           = {}
            name             = "terraform"
            namespace        = "default"
            resource_version = "10107"
            self_link        = "/apis/batch/v1/namespaces/default/jobs/terraform"
            uid              = "c1f56d3b-b9cb-40ad-abb3-0ca76a677329"
        }

      ~ spec {
            active_deadline_seconds = 0
            backoff_limit           = 1
            completions             = 1
            manual_selector         = false
            parallelism             = 1

          ~ selector {
              + match_labels = {}
            }

          ~ template {
                metadata {
                    annotations = {}
                    generation  = 0
                    labels      = {}
                }

              ~ spec {
                    active_deadline_seconds          = 0
                    automount_service_account_token  = true
                    dns_policy                       = "ClusterFirst"
                    host_ipc                         = false
                    host_network                     = false
                    host_pid                         = false
                    node_selector                    = {}
                    restart_policy                   = "Never"
                    service_account_name             = "terraform"
                    share_process_namespace          = false
                    termination_grace_period_seconds = 30

                  ~ container {
                        args                     = []
                        command                  = [
                            "sh",
                            "-c",
2020/02/18 16:44:31 [DEBUG] command: asking for input: "Do you want to perform these actions?"
                            "set && set -x && apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl https://storage.googleapis.com/pdecat-builds/terraform-provider-kubernet
es_v1.11.1-dev > ~/.terraform.d/plugins/terraform-provider-kubernetes_v1.11.1-dev && chmod +x ~/.terraform.d/plugins/* && mkdir /tf && cd /tf && cp /configuration/main.tf . && TF_LOG=TR
ACE terraform init && TF_LOG=TRACE terraform plan && TF_LOG=TRACE terraform apply -auto-approve ; sleep 60 && terraform destroy -auto-approve",
                        ]
                      ~ image                    = "hashicorp/terraform:0.12.20" -> "hashicorp/terraform:0.12.13"
                        image_pull_policy        = "IfNotPresent"
                        name                     = "terraform"
                        stdin                    = false
                        stdin_once               = false
                        termination_message_path = "/dev/termination-log"
                        tty                      = false

                        resources {
                        }

                        volume_mount {
                            mount_path        = "/configuration"
                            mount_propagation = "None"
                            name              = "configuration"
                            read_only         = false
                        }
                        volume_mount {
                            mount_path        = "/root"
                            mount_propagation = "None"
                            name              = "home"
                            read_only         = false
                        }
                    }

                    volume {
                        name = "configuration"

                        config_map {
                            default_mode = "0644"
                            name         = "terraform"
                        }
                    }
                    volume {
                        name = "home"

                        empty_dir {}
                    }
                }
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
```

But submit an empty patch operation:

```
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: 2020/02/18 16:46:07 [DEBUG] Kubernetes API Request Details:
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: ---[ REQUEST ]---------------------------------------
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: PATCH /apis/batch/v1/namespaces/default/jobs/terraform HTTP/1.1
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: Host: 192.168.39.222:8443
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: User-Agent: HashiCorp/1.0 Terraform/0.12.20
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: Content-Length: 2
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: Accept: application/json, */*
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: Content-Type: application/json-patch+json
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: Accept-Encoding: gzip
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev:
2020-02-18T16:46:07.508+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.11.1-dev: []
```