### PR TITLE
Update memory's unit

### DIFF
--- a/website/docs/r/limit_range.html.markdown
+++ b/website/docs/r/limit_range.html.markdown
@@ -25,7 +25,7 @@ resource "kubernetes_limit_range" "example" {
       type = "Pod"
       max = {
         cpu    = "200m"
-        memory = "1024M"
+        memory = "1024Mi"
       }
     }
     limit {
@@ -38,7 +38,7 @@ resource "kubernetes_limit_range" "example" {
       type = "Container"
       default = {
         cpu    = "50m"
-        memory = "24M"
+        memory = "24Mi"
       }
     }
   }


### PR DESCRIPTION
Should be Mi (mebibyte) not M.

```  
k describe rs app-8586b6658d
...
    Limits:
      cpu:     300m
      memory:  256Mi
    Requests:
      cpu:     100m
      memory:  128Mi
...
Warning  FailedCreate  2m57s                replicaset-controller  Error creating: Pod "app-8586b6658d-spbf8" is invalid: spec.initContainers[0].resources.requests: Invalid value: "256Mi": must be less than or equal to memory limit
  Warning  FailedCreate  2m57s                replicaset-controller  Error creating: Pod "app-8586b6658d-ftf5z" is invalid: spec.initContainers[0].resources.requests: Invalid value: "256Mi": must be less than or equal to memory limit
  Warning  FailedCreate  14s (x7 over 2m55s)  replicaset-controller  (combined from similar events): Error creating: Pod "app-8586b6658d-grh5r" is invalid: spec.initContainers[0].resources.requests: Invalid value: "256Mi": must be less than or equal to memory limit

k describe limitrange limit-range
Name:       limit-range
Namespace:  default
Type        Resource  Min  Max    Default Request  Default Limit  Max Limit/Request Ratio
----        --------  ---  ---    ---------------  -------------  -----------------------
Container   memory    64M  2048M  64M              256M           -
Container   cpu       50m  2048m  50m              200m           -```