### PR TITLE
Removing restart_policy from example

### DIFF
--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -42,7 +42,6 @@ resource "kubernetes_cron_job" "demo" {
               image   = "busybox"
               command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
             }
-            restart_policy = "OnFailure"
           }
         }
       }


### PR DESCRIPTION
Setting restart_policy=OnFailure will make hard time to new users that they will not be able to get to logs of their cronjobs, better if it is not there for the example (which will obviously be used as a template for their new jobs).