### PR TITLE
Support optional on env valueFrom for secret key/configmap key

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -42,7 +42,11 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value_from.0.secret_key_ref.0.name", secretName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value_from.0.secret_key_ref.0.key", "one"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value_from.0.secret_key_ref.0.optional", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.1.value_from.0.config_map_key_ref.0.name", configMapName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.1.value_from.0.config_map_key_ref.0.key", "one"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.1.value_from.0.config_map_key_ref.0.optional", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.0.config_map_ref.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.0.config_map_ref.0.name", fmt.Sprintf("%s-from", configMapName)),
@@ -853,8 +857,9 @@ resource "kubernetes_pod" "test" {
 
         value_from {
           secret_key_ref {
-            name = "${kubernetes_secret.test.metadata.0.name}"
-            key  = "one"
+            name     = "${kubernetes_secret.test.metadata.0.name}"
+            key      = "one"
+            optional = true
           }
         }
       }
@@ -862,8 +867,9 @@ resource "kubernetes_pod" "test" {
         name = "EXPORTED_VARIBALE_FROM_CONFIG_MAP"
 				value_from {
 					config_map_key_ref {
-						name = "${kubernetes_config_map.test.metadata.0.name}"
-						key  = "one"
+						name     = "${kubernetes_config_map.test.metadata.0.name}"
+						key      = "one"
+						optional = true
 					}
 				}
 			}

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -259,6 +259,11 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Optional:    true,
 												Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
 											},
+											"optional": {
+												Type:        schema.TypeBool,
+												Optional:    true,
+												Description: "Specify whether the ConfigMap or its key must be defined.",
+											},
 										},
 									},
 								},
@@ -266,7 +271,7 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 									Type:        schema.TypeList,
 									Optional:    true,
 									MaxItems:    1,
-									Description: "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..",
+									Description: "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP.",
 									Elem: &schema.Resource{
 										Schema: map[string]*schema.Schema{
 											"api_version": {
@@ -287,7 +292,7 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 									Type:        schema.TypeList,
 									Optional:    true,
 									MaxItems:    1,
-									Description: "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..",
+									Description: "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
 									Elem: &schema.Resource{
 										Schema: map[string]*schema.Schema{
 											"container_name": {
@@ -306,7 +311,7 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 									Type:        schema.TypeList,
 									Optional:    true,
 									MaxItems:    1,
-									Description: "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..",
+									Description: "Selects a key of a secret in the pod's namespace.",
 									Elem: &schema.Resource{
 										Schema: map[string]*schema.Schema{
 											"key": {
@@ -318,6 +323,11 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Type:        schema.TypeString,
 												Optional:    true,
 												Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+											},
+											"optional": {
+												Type:        schema.TypeBool,
+												Optional:    true,
+												Description: "Specify whether the Secret or its key must be defined.",
 											},
 										},
 									},

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -178,6 +178,9 @@ func flattenConfigMapKeyRef(in *v1.ConfigMapKeySelector) []interface{} {
 	if in.Name != "" {
 		att["name"] = in.Name
 	}
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
+	}
 	return []interface{}{att}
 }
 
@@ -225,6 +228,9 @@ func flattenSecretKeyRef(in *v1.SecretKeySelector) []interface{} {
 	}
 	if in.Name != "" {
 		att["name"] = in.Name
+	}
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
 	}
 	return []interface{}{att}
 }
@@ -817,6 +823,9 @@ func expandConfigMapKeyRef(r []interface{}) (*v1.ConfigMapKeySelector, error) {
 	if v, ok := in["name"].(string); ok {
 		obj.Name = v
 	}
+	if v, ok := in["optional"]; ok {
+		obj.Optional = ptrToBool(v.(bool))
+	}
 	return obj, nil
 
 }
@@ -880,6 +889,9 @@ func expandSecretKeyRef(r []interface{}) (*v1.SecretKeySelector, error) {
 	}
 	if v, ok := in["name"].(string); ok {
 		obj.Name = v
+	}
+	if v, ok := in["optional"]; ok {
+		obj.Optional = ptrToBool(v.(bool))
 	}
 	return obj, nil
 }

--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -1,0 +1,214 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestFlattenSecretKeyRef(t *testing.T) {
+	cases := []struct {
+		Input          *v1.SecretKeySelector
+		ExpectedOutput []interface{}
+	}{
+		{
+			&v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "Secret1",
+				},
+				Key:      "key1",
+				Optional: ptrToBool(true),
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"key":      "key1",
+					"name":     "Secret1",
+					"optional": true,
+				},
+			},
+		},
+		{
+			&v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "Secret2",
+				},
+				Key: "key2",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"key":  "key2",
+					"name": "Secret2",
+				},
+			},
+		},
+		{
+			&v1.SecretKeySelector{},
+			[]interface{}{map[string]interface{}{}},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenSecretKeyRef(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandSecretKeyRef(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *v1.SecretKeySelector
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"key":      "key1",
+					"name":     "Secret1",
+					"optional": true,
+				},
+			},
+			&v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "Secret1",
+				},
+				Key:      "key1",
+				Optional: ptrToBool(true),
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"key":  "key2",
+					"name": "Secret2",
+				},
+			},
+			&v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "Secret2",
+				},
+				Key: "key2",
+			},
+		},
+		{
+			[]interface{}{},
+			&v1.SecretKeySelector{},
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandSecretKeyRef(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected failure in expander.\nInput: %#v, error: %#v", tc.Input, err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenConfigMapKeyRef(t *testing.T) {
+	cases := []struct {
+		Input          *v1.ConfigMapKeySelector
+		ExpectedOutput []interface{}
+	}{
+		{
+			&v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "configmap1",
+				},
+				Key:      "key1",
+				Optional: ptrToBool(true),
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"key":      "key1",
+					"name":     "configmap1",
+					"optional": true,
+				},
+			},
+		},
+		{
+			&v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "configmap2",
+				},
+				Key: "key2",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"key":  "key2",
+					"name": "configmap2",
+				},
+			},
+		},
+		{
+			&v1.ConfigMapKeySelector{},
+			[]interface{}{map[string]interface{}{}},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenConfigMapKeyRef(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandConfigMapKeyRef(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *v1.ConfigMapKeySelector
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"key":      "key1",
+					"name":     "configmap1",
+					"optional": true,
+				},
+			},
+			&v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "configmap1",
+				},
+				Key:      "key1",
+				Optional: ptrToBool(true),
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"key":  "key2",
+					"name": "configmap2",
+				},
+			},
+			&v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "configmap2",
+				},
+				Key: "key2",
+			},
+		},
+		{
+			[]interface{}{},
+			&v1.ConfigMapKeySelector{},
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandConfigMapKeyRef(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected failure in expander.\nInput: %#v, error: %#v", tc.Input, err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -360,6 +360,7 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/an
 
 * `key` - (Optional) The key to select.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the ConfigMap or its key must be defined
 
 ### `dns_config`
 
@@ -692,6 +693,7 @@ The `items` block supports the following:
 
 * `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the Secret or its key must be defined
 
 ### `secret_ref`
 
@@ -739,9 +741,9 @@ The `items` block supports the following:
 #### Arguments
 
 * `config_map_key_ref` - (Optional) Selects a key of a ConfigMap.
-* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `resource_field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `secret_key_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
+* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP.
+* `resource_field_ref` - (Optional) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+* `secret_key_ref` - (Optional) Selects a key of a secret in the pod's namespace.
 
 ### `toleration`
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -364,6 +364,7 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/an
 
 * `key` - (Optional) The key to select.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the ConfigMap or its key must be defined
 
 ### `dns_config`
 
@@ -696,6 +697,7 @@ The `items` block supports the following:
 
 * `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the Secret or its key must be defined
 
 ### `secret_ref`
 
@@ -745,9 +747,9 @@ The `items` block supports the following:
 #### Arguments
 
 * `config_map_key_ref` - (Optional) Selects a key of a ConfigMap.
-* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `resource_field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `secret_key_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
+* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP.
+* `resource_field_ref` - (Optional) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+* `secret_key_ref` - (Optional) Selects a key of a secret in the pod's namespace.
 
 ### `toleration`
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -414,6 +414,7 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/la
 
 * `key` - (Optional) The key to select.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the Secret or its key must be defined
 
 ### `dns_config`
 
@@ -746,6 +747,7 @@ The `items` block supports the following:
 
 * `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the Secret or its key must be defined
 
 ### `secret_ref`
 
@@ -805,9 +807,9 @@ The `items` block supports the following:
 #### Arguments
 
 * `config_map_key_ref` - (Optional) Selects a key of a ConfigMap.
-* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `resource_field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `secret_key_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
+* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP.
+* `resource_field_ref` - (Optional) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+* `secret_key_ref` - (Optional) Selects a key of a secret in the pod's namespace.
 
 ### `volume`
 


### PR DESCRIPTION
### Description
Adds ability for secret key and config map key refs used in value_from for environment variables to be optional. Fixes documentation typos. Adds structures_container unit tests.

Picks back up where #295 left off.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
Closes #240. Closes #531.

```
==> Checking that code complies with gofmt requirements...
go test "./kubernetes" || exit 1
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	5.776s
echo "./kubernetes" | \
		xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 ./kubernetes
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	3.231s
```