### PR TITLE
Add wait_for_rollout attribute to kubernetes_deployment.

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -955,6 +955,7 @@ resource "kubernetes_deployment" "test" {
       }
     }
   }
+  wait_for_rollout = true
 }
 `, name)
 }


### PR DESCRIPTION
This controls whether the provider will wait for a create or update
operation to be completely applied on the server side. For some
situations this is desirable behaviour, but in other situations where a
gradual rollout using the builtin Kubernetes controls can take hours
this is undesirable.

It is set to true by default (matching current behaviour).

This should be done for kubernetes_stateful_set too, but it wasn't clear
how to wait for a StatefulSet change to complete.

Updates #605.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
