### PR TITLE
Allow ttl_seconds_after_finished = 0 in kubernetes_job resource

### DIFF
--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -131,7 +131,7 @@ func jobSpecFields() map[string]*schema.Schema {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,
-			ValidateFunc: validatePositiveInteger,
+			ValidateFunc: validateNonNegativeInteger,
 			Description:  "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
 		},
 	}

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -94,7 +94,7 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 	}
 	obj.Template = *template
 
-	if v, ok := in["ttl_seconds_after_finished"].(int); ok && v > 0 {
+	if v, ok := in["ttl_seconds_after_finished"].(int); ok && v >= 0 {
 		obj.TTLSecondsAfterFinished = ptrToInt32(int32(v))
 	}
 


### PR DESCRIPTION
### Description
Passing zero to ttl_seconds_after_finished fails with the following error:
`Error: spec.0.job_template.0.spec.0.ttl_seconds_after_finished must be greater than 0`
Even though it's allowed and documented in both k8s / provider docs.
