### PR TITLE
Replace all instances of old github org with new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,11 @@ IMPROVEMENTS:
 BUG FIXES:
 
  * Do not force base64 encoding for the `ca_bundle` on `kubernetes_api_service` (#679)
- * Allow 3s age gap between `service account` and `secret` [(issue)](https://github.com/terraform-providers/terraform-provider-kubernetes/pull/377#issuecomment-540126765)
+ * Allow 3s age gap between `service account` and `secret` [(issue)](https://github.com/hashicorp/terraform-provider-kubernetes/pull/377#issuecomment-540126765)
  * Add `load_config_file = false` to documented provider configurations
  * Add support for `startup_probe` on container spec
  * Fix (cluster-)role bindings and rules updates (#713)
- * Fix namespacing issues on kubernetes_priority_class (#680) **See [comment](https://github.com/terraform-providers/terraform-provider-kubernetes/pull/682#issuecomment-576475875) on backward compatibility**
+ * Fix namespacing issues on kubernetes_priority_class (#680) **See [comment](https://github.com/hashicorp/terraform-provider-kubernetes/pull/682#issuecomment-576475875) on backward compatibility**
   * Documentation fixes
 
 ## 1.10.0 (November 08, 2019)
@@ -212,16 +212,16 @@ BUG FIXES:
 
 FEATURES:
 
-* **New Resource:** `kubernetes_network_policy` ([#118](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/118))
+* **New Resource:** `kubernetes_network_policy` ([#118](https://github.com/hashicorp/terraform-provider-kubernetes/issues/118))
 * **New Resource:** `kubernetes_role`
 * **New Resource:** `kubernetes_role_binding`
-* **New Datasource:** `kubernetes_secret datasource` ([#241](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/241))
+* **New Datasource:** `kubernetes_secret datasource` ([#241](https://github.com/hashicorp/terraform-provider-kubernetes/issues/241))
 
 
 IMPROVEMENTS:
 
-* `resource/kubernetes_deployment`, `resource/kubernetes_pod`, `resource/kubernetes_replication_controller`, `resource/kubernetes_stateful_set`: Add `allow_privilege_escalation` to container security contexts attributes ([#249](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/249))
-* Add pod metadata to replication controller spec template ([#193](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/193))
+* `resource/kubernetes_deployment`, `resource/kubernetes_pod`, `resource/kubernetes_replication_controller`, `resource/kubernetes_stateful_set`: Add `allow_privilege_escalation` to container security contexts attributes ([#249](https://github.com/hashicorp/terraform-provider-kubernetes/issues/249))
+* Add pod metadata to replication controller spec template ([#193](https://github.com/hashicorp/terraform-provider-kubernetes/issues/193))
 * Add support for `volume_binding_mode` attribute in `kubernetes_storage_class`
 * Add `node_affinity` attribute to persistent volumes.
 * Add support for `local` type persistent volumes.
@@ -229,13 +229,13 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* `resource/kubernetes_stateful_set`: Fix updates of stateful set images ([#252](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/252))
+* `resource/kubernetes_stateful_set`: Fix updates of stateful set images ([#252](https://github.com/hashicorp/terraform-provider-kubernetes/issues/252))
 
 ## 1.4.0 (November 29, 2018)
 
 FEATURES:
 
-* **New Resource:** `kubernetes_stateful_set` ([#100](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/100))
+* **New Resource:** `kubernetes_stateful_set` ([#100](https://github.com/hashicorp/terraform-provider-kubernetes/issues/100))
 
 IMPROVEMENTS:
 
@@ -244,34 +244,34 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* Fix waiting for Deployment rollout status ([#210](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/210))
+* Fix waiting for Deployment rollout status ([#210](https://github.com/hashicorp/terraform-provider-kubernetes/issues/210))
 
 ## 1.3.0 (October 23, 2018)
 
 FEATURES:
 
-* **New Resource:** `kubernetes_cluster_role_binding` ([#73](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/73))
-* **New Resource:** `kubernetes_deployment` ([#101](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/101))
+* **New Resource:** `kubernetes_cluster_role_binding` ([#73](https://github.com/hashicorp/terraform-provider-kubernetes/issues/73))
+* **New Resource:** `kubernetes_deployment` ([#101](https://github.com/hashicorp/terraform-provider-kubernetes/issues/101))
 
 IMPROVEMENTS:
 
-* Update Kubernetes client library to 1.10 ([#162](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/162))
-* Add support for `env_from` on container definitions ([#82](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/82))
+* Update Kubernetes client library to 1.10 ([#162](https://github.com/hashicorp/terraform-provider-kubernetes/issues/162))
+* Add support for `env_from` on container definitions ([#82](https://github.com/hashicorp/terraform-provider-kubernetes/issues/82))
 
 ## 1.2.0 (August 15, 2018)
 
 IMPROVEMENTS:
 
-* resource/kubernetes_pod: Add timeout to pod resource create and delete ([#151](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/151))
-* resource/kubernetes_pod: Add support for init containers ([#156](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/156))
+* resource/kubernetes_pod: Add timeout to pod resource create and delete ([#151](https://github.com/hashicorp/terraform-provider-kubernetes/issues/151))
+* resource/kubernetes_pod: Add support for init containers ([#156](https://github.com/hashicorp/terraform-provider-kubernetes/issues/156))
 
 BUG FIXES:
 
-* name label: All name labels will now allow DNS1123 subdomain format ex: `my.label123` ([#152](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/152))
-* resource/kubernetes_service: Switch targetPort to string ([#154](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/154))
-* data/kubernetes_service: Switch targetPort to string ([#159](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/159))
-* resource/kubernetes_pod: env var value change forces new pod ([#155](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/155))
-* Fix example in docs for an image pull secret ([#165](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/165))
+* name label: All name labels will now allow DNS1123 subdomain format ex: `my.label123` ([#152](https://github.com/hashicorp/terraform-provider-kubernetes/issues/152))
+* resource/kubernetes_service: Switch targetPort to string ([#154](https://github.com/hashicorp/terraform-provider-kubernetes/issues/154))
+* data/kubernetes_service: Switch targetPort to string ([#159](https://github.com/hashicorp/terraform-provider-kubernetes/issues/159))
+* resource/kubernetes_pod: env var value change forces new pod ([#155](https://github.com/hashicorp/terraform-provider-kubernetes/issues/155))
+* Fix example in docs for an image pull secret ([#165](https://github.com/hashicorp/terraform-provider-kubernetes/issues/165))
 
 ## 1.1.0 (March 23, 2018)
 
@@ -281,88 +281,88 @@ NOTES:
 
 IMPROVEMENTS:
 
-* resource/kubernetes_persistent_volume_claim: Improve event log polling for warnings ([#125](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/125))
-* resource/kubernetes_persistent_volume: Add support for `storage_class_name` ([#111](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/111))
+* resource/kubernetes_persistent_volume_claim: Improve event log polling for warnings ([#125](https://github.com/hashicorp/terraform-provider-kubernetes/issues/125))
+* resource/kubernetes_persistent_volume: Add support for `storage_class_name` ([#111](https://github.com/hashicorp/terraform-provider-kubernetes/issues/111))
 
 BUG FIXES:
 
-* resource/kubernetes_secret: Prevent binary data corruption ([#103](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/103))
-* resource/kubernetes_persistent_volume: Update `persistent_volume_reclaim_policy` correctly ([#111](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/111))
-* resource/kubernetes_service: Update external_ips correctly on K8S 1.8+ ([#127](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/127))
-* resource/kubernetes_*: Fix adding labels/annotations to resources when those were empty ([#116](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/116))
-* resource/kubernetes_*: Treat non-string label values as invalid ([#135](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/135))
-* resource/kubernetes_config_map: Fix adding `data` when it was empty ([#116](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/116))
-* resource/kubernetes_secret: Fix adding `data` when it was empty ([#116](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/116))
-* resource/kubernetes_limit_range: Avoid spurious diff when spec is empty ([#132](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/132))
-* resource/kubernetes_persistent_volume: Use correct operation when updating `persistent_volume_source` (`1.8`) ([#133](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/133))
-* resource/kubernetes_persistent_volume: Mark persistent_volume_source as ForceNew on `1.9+` ([#139](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/139))
-* resource/kubernetes_pod: Bump deletion timeout to 5 mins ([#136](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/136))
+* resource/kubernetes_secret: Prevent binary data corruption ([#103](https://github.com/hashicorp/terraform-provider-kubernetes/issues/103))
+* resource/kubernetes_persistent_volume: Update `persistent_volume_reclaim_policy` correctly ([#111](https://github.com/hashicorp/terraform-provider-kubernetes/issues/111))
+* resource/kubernetes_service: Update external_ips correctly on K8S 1.8+ ([#127](https://github.com/hashicorp/terraform-provider-kubernetes/issues/127))
+* resource/kubernetes_*: Fix adding labels/annotations to resources when those were empty ([#116](https://github.com/hashicorp/terraform-provider-kubernetes/issues/116))
+* resource/kubernetes_*: Treat non-string label values as invalid ([#135](https://github.com/hashicorp/terraform-provider-kubernetes/issues/135))
+* resource/kubernetes_config_map: Fix adding `data` when it was empty ([#116](https://github.com/hashicorp/terraform-provider-kubernetes/issues/116))
+* resource/kubernetes_secret: Fix adding `data` when it was empty ([#116](https://github.com/hashicorp/terraform-provider-kubernetes/issues/116))
+* resource/kubernetes_limit_range: Avoid spurious diff when spec is empty ([#132](https://github.com/hashicorp/terraform-provider-kubernetes/issues/132))
+* resource/kubernetes_persistent_volume: Use correct operation when updating `persistent_volume_source` (`1.8`) ([#133](https://github.com/hashicorp/terraform-provider-kubernetes/issues/133))
+* resource/kubernetes_persistent_volume: Mark persistent_volume_source as ForceNew on `1.9+` ([#139](https://github.com/hashicorp/terraform-provider-kubernetes/issues/139))
+* resource/kubernetes_pod: Bump deletion timeout to 5 mins ([#136](https://github.com/hashicorp/terraform-provider-kubernetes/issues/136))
 
 ## 1.0.1 (November 13, 2017)
 
 BUG FIXES:
 
-* resource/pod: Avoid crash in reading `spec.container.security_context` `capability` ([#53](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/53))
-* resource/replication_controller: Avoid crash in reading `template.container.security_context` `capability` ([#53](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/53))
-* resource/service: Make spec.port.target_port optional ([#69](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/69))
-* resource/pod: Fix `mode` conversion in `config_map` volume items ([#83](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/83))
-* resource/replication_controller: Fix `mode` conversion in `config_map` volume items ([#83](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/83))
+* resource/pod: Avoid crash in reading `spec.container.security_context` `capability` ([#53](https://github.com/hashicorp/terraform-provider-kubernetes/issues/53))
+* resource/replication_controller: Avoid crash in reading `template.container.security_context` `capability` ([#53](https://github.com/hashicorp/terraform-provider-kubernetes/issues/53))
+* resource/service: Make spec.port.target_port optional ([#69](https://github.com/hashicorp/terraform-provider-kubernetes/issues/69))
+* resource/pod: Fix `mode` conversion in `config_map` volume items ([#83](https://github.com/hashicorp/terraform-provider-kubernetes/issues/83))
+* resource/replication_controller: Fix `mode` conversion in `config_map` volume items ([#83](https://github.com/hashicorp/terraform-provider-kubernetes/issues/83))
 
 ## 1.0.0 (August 18, 2017)
 
 IMPROVEMENTS:
 
-* resource/kubernetes_pod: Add support for `default_mode`, `items` and `optional` in Secret Volume ([#44](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/44))
-* resource/kubernetes_replication_controller: Add support for `default_mode`, `items` and `optional` in Secret Volume ([#44](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/44))
+* resource/kubernetes_pod: Add support for `default_mode`, `items` and `optional` in Secret Volume ([#44](https://github.com/hashicorp/terraform-provider-kubernetes/issues/44))
+* resource/kubernetes_replication_controller: Add support for `default_mode`, `items` and `optional` in Secret Volume ([#44](https://github.com/hashicorp/terraform-provider-kubernetes/issues/44))
 
 BUG FIXES:
 
-* resource/kubernetes_pod: Respect previously ignored `node_selectors` field ([#42](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/42))
-* resource/kubernetes_pod: Represent update-ability of spec correctly ([#49](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/49))
-* resource/kubernetes_replication_controller: Respect previously ignored `node_selectors` field ([#42](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/42))
-* all namespaced resources: Avoid crash when importing invalid ID ([#46](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/46))
+* resource/kubernetes_pod: Respect previously ignored `node_selectors` field ([#42](https://github.com/hashicorp/terraform-provider-kubernetes/issues/42))
+* resource/kubernetes_pod: Represent update-ability of spec correctly ([#49](https://github.com/hashicorp/terraform-provider-kubernetes/issues/49))
+* resource/kubernetes_replication_controller: Respect previously ignored `node_selectors` field ([#42](https://github.com/hashicorp/terraform-provider-kubernetes/issues/42))
+* all namespaced resources: Avoid crash when importing invalid ID ([#46](https://github.com/hashicorp/terraform-provider-kubernetes/issues/46))
 * meta: Treat internal k8s annotations as invalid #50
 
 ## 0.1.2 (August 04, 2017)
 
 FEATURES:
 
-* **New Resource:** `kubernetes_storage_class` ([#22](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/22))
-* **New Data Source:** `kubernetes_service` ([#23](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/23))
-* **New Data Source:** `kubernetes_storage_class` ([#33](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/33))
+* **New Resource:** `kubernetes_storage_class` ([#22](https://github.com/hashicorp/terraform-provider-kubernetes/issues/22))
+* **New Data Source:** `kubernetes_service` ([#23](https://github.com/hashicorp/terraform-provider-kubernetes/issues/23))
+* **New Data Source:** `kubernetes_storage_class` ([#33](https://github.com/hashicorp/terraform-provider-kubernetes/issues/33))
 
 IMPROVEMENTS: 
 
-* provider: Add support of token in auth ([#35](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/35))
-* provider: Add switch to disable loading file config (`load_config_file`) ([#36](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/36))
+* provider: Add support of token in auth ([#35](https://github.com/hashicorp/terraform-provider-kubernetes/issues/35))
+* provider: Add switch to disable loading file config (`load_config_file`) ([#36](https://github.com/hashicorp/terraform-provider-kubernetes/issues/36))
 
 BUG FIXES:
 
-* resource/kubernetes_service: Make port field optional ([#27](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/27))
-* all resources: Escape '/' in JSON Patch path correctly ([#40](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/40))
+* resource/kubernetes_service: Make port field optional ([#27](https://github.com/hashicorp/terraform-provider-kubernetes/issues/27))
+* all resources: Escape '/' in JSON Patch path correctly ([#40](https://github.com/hashicorp/terraform-provider-kubernetes/issues/40))
 
 ## 0.1.1 (July 05, 2017)
 
 FEATURES:
 
-* **New Resource:** `kubernetes_replication_controller` ([#9](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/9))
-* **New Resource:** `kubernetes_service_account` ([#17](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/17))
+* **New Resource:** `kubernetes_replication_controller` ([#9](https://github.com/hashicorp/terraform-provider-kubernetes/issues/9))
+* **New Resource:** `kubernetes_service_account` ([#17](https://github.com/hashicorp/terraform-provider-kubernetes/issues/17))
 
 IMPROVEMENTS:
 
-* resource/kubernetes_service: Wait for LoadBalancer ingress ([#12](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/12))
-* resource/persistent_volume_claim: Expose last warnings from the eventlog ([#16](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/16))
-* resource/pod: Expose last warnings from the eventlog ([#16](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/16))
-* resource/service: Expose last warnings from the eventlog ([#16](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/16))
+* resource/kubernetes_service: Wait for LoadBalancer ingress ([#12](https://github.com/hashicorp/terraform-provider-kubernetes/issues/12))
+* resource/persistent_volume_claim: Expose last warnings from the eventlog ([#16](https://github.com/hashicorp/terraform-provider-kubernetes/issues/16))
+* resource/pod: Expose last warnings from the eventlog ([#16](https://github.com/hashicorp/terraform-provider-kubernetes/issues/16))
+* resource/service: Expose last warnings from the eventlog ([#16](https://github.com/hashicorp/terraform-provider-kubernetes/issues/16))
 
 BUG FIXES:
 
-* Register auth plugins (gcp, oidc) automatically ([#6](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/6))
-* resource/pod: Fix a crash caused by wrong field name (config map volume source) ([#19](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/19))
-* resource/pod: Add validation for `default_mode` (mode bits) ([#19](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/19))
+* Register auth plugins (gcp, oidc) automatically ([#6](https://github.com/hashicorp/terraform-provider-kubernetes/issues/6))
+* resource/pod: Fix a crash caused by wrong field name (config map volume source) ([#19](https://github.com/hashicorp/terraform-provider-kubernetes/issues/19))
+* resource/pod: Add validation for `default_mode` (mode bits) ([#19](https://github.com/hashicorp/terraform-provider-kubernetes/issues/19))
 
 ## 0.1.0 (June 20, 2017)
 
 FEATURES:
 
-* **New Resource:** `kubernetes_pod` [[#13571](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/13571)](https://github.com/hashicorp/terraform/pull/13571)
+* **New Resource:** `kubernetes_pod` [[#13571](https://github.com/hashicorp/terraform-provider-kubernetes/issues/13571)](https://github.com/hashicorp/terraform/pull/13571)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Terraform Provider for Kubernetes [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/terraform-providers/terraform-provider-kubernetes?label=release)](https://github.com/terraform-providers/terraform-provider-kubernetes/releases) [![license](https://img.shields.io/github/license/terraform-providers/terraform-provider-kubernetes.svg)]()
+# Terraform Provider for Kubernetes [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hashicorp/terraform-provider-kubernetes?label=release)](https://github.com/hashicorp/terraform-provider-kubernetes/releases) [![license](https://img.shields.io/github/license/hashicorp/terraform-provider-kubernetes.svg)]()
 
 <a href="https://terraform.io">
     <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" alt="Terraform logo" title="Terrafpr," align="right" height="50" />
@@ -8,7 +8,7 @@
 - [Getting Started](https://learn.hashicorp.com/terraform?track=kubernetes#kubernetes)
 - Usage 
   - [Documentation](https://www.terraform.io/docs/providers/kubernetes/index.html)
-  - [Examples](https://github.com/terraform-providers/terraform-provider-kubernetes/tree/master/_examples)
+  - [Examples](https://github.com/hashicorp/terraform-provider-kubernetes/tree/master/_examples)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 - Chat: [#terraform-providers in Kubernetes](https://kubernetes.slack.com/messages/CJY6ATQH4) ([Sign up here](http://slack.k8s.io/))
 
@@ -27,7 +27,7 @@ Please note: We take Terraform's security and our users' trust very seriously. I
 
 The Terraform Kubernetes Provider is the work of many contributors. We appreciate your help!
 
-To contribute, please read the [contribution guidelines](_about/CONTRIBUTING.md). You may also [report an issue](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/new/choose). Once you've filed an issue, it will follow the [issue lifecycle](_about/ISSUES.md).
+To contribute, please read the [contribution guidelines](_about/CONTRIBUTING.md). You may also [report an issue](https://github.com/hashicorp/terraform-provider-kubernetes/issues/new/choose). Once you've filed an issue, it will follow the [issue lifecycle](_about/ISSUES.md).
 
 Also available are some answers to [Frequently Asked Questions](_about/FAQ.md).
 

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -13,17 +13,17 @@ To learn more about how to create issues and pull requests in this repository, a
 
 ## Building the provider
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-kubernetes`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-kubernetes`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-kubernetes
+$ git clone git@github.com:hashicorp/terraform-provider-kubernetes
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-kubernetes
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-kubernetes
 $ make build
 ```
 

--- a/_about/ISSUES.md
+++ b/_about/ISSUES.md
@@ -5,7 +5,7 @@
 We welcome your feature requests and bug reports. Below you'll find short checklists with guidelines for well-formed
 issues of each type.
 
-### [Bug Reports](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/new/choose)
+### [Bug Reports](https://github.com/hashicorp/terraform-provider-kubernetes/issues/new/choose)
 
  - [ ] __Test against the latest release__: Make sure you test against the latest
    released version. It is possible we already fixed the bug you're experiencing.
@@ -13,7 +13,7 @@ issues of each type.
  - [ ] __Search for possible duplicate reports__: It's helpful to keep bug
    reports consolidated to one thread, so do a quick search on existing bug
    reports to check if anybody else has reported the same thing. You can [scope
-      searches by the label "bug"](https://github.com/terraform-providers/terraform-provider-kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to help narrow things down.
+      searches by the label "bug"](https://github.com/hashicorp/terraform-provider-kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to help narrow things down.
 
  - [ ] __Include steps to reproduce__: Provide steps to reproduce the issue,
    along with your `.tf` files, with secrets removed, so we can try to
@@ -23,12 +23,12 @@ issues of each type.
    create a [gist](https://gist.github.com) of the *entire* generated crash log
    for us to look at. Double check no sensitive items were in the log.
 
-### [Feature Requests](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/new/choose)
+### [Feature Requests](https://github.com/hashicorp/terraform-provider-kubernetes/issues/new/choose)
 
  - [ ] __Search for possible duplicate requests__: It's helpful to keep requests
    consolidated to one thread, so do a quick search on existing requests to
    check if anybody else has reported the same thing. You can [scope searches by
-      the label "enhancement"](https://github.com/terraform-providers/terraform-provider-kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to help narrow things down.
+      the label "enhancement"](https://github.com/hashicorp/terraform-provider-kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to help narrow things down.
 
  - [ ] __Include a use case description__: In addition to describing the
    behavior of the feature you'd like to see added, it's helpful to also lay

--- a/_examples/wordpress-mysql-gce-pv/README.md
+++ b/_examples/wordpress-mysql-gce-pv/README.md
@@ -42,7 +42,7 @@ on how to do so, specifically look at arguments `credentials` and `project`.
 Below is a graph of the all resources we're creating as part of this example
 which also demonstrates how they depend on each other.
 
-<img src="https://raw.githubusercontent.com/terraform-providers/terraform-provider-kubernetes/master/_examples/wordpress-mysql-gce-pv/graph.png">
+<img src="https://raw.githubusercontent.com/hashicorp/terraform-provider-kubernetes/master/_examples/wordpress-mysql-gce-pv/graph.png">
 
 ## How to
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-kubernetes
+module github.com/hashicorp/terraform-provider-kubernetes
 
 require (
 	github.com/Azure/go-autorest/autorest v0.9.2 // indirect

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-kubernetes/kubernetes"
+	"github.com/hashicorp/terraform-provider-kubernetes/kubernetes"
 )
 
 func main() {


### PR DESCRIPTION
As part of the migration to the `hashicorp` github org, replace
all instances of `terraform-providers/terraform-provider-kubernetes`
with `hashicorp/terraform-provider-kubernetes`.

Also ran `go mod tidy; go mod vendor`.
