### PR TITLE
Add volume_binding_mode resource docs

### DIFF
--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 	Read more about [available parameters](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters).
 * `storage_provisioner` - (Required) Indicates the type of the provisioner
 * `reclaim_policy` - (Optional) Indicates the reclaim policy to use.  If no reclaimPolicy is specified when a StorageClass object is created, it will default to Delete.
-* `volume_binding_mode` - Indicates when volume binding and dynamic provisioning should occur.
+* `volume_binding_mode` - (Optional) Indicates when volume binding and dynamic provisioning should occur.
 * `allow_volume_expansion` - (Optional) Indicates whether the storage class allow volume expand, default true.
 * `mount_options` - (Optional) Persistent Volumes that are dynamically created by a storage class will have the mount options specified.
 

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 	Read more about [available parameters](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters).
 * `storage_provisioner` - (Required) Indicates the type of the provisioner
 * `reclaim_policy` - (Optional) Indicates the reclaim policy to use.  If no reclaimPolicy is specified when a StorageClass object is created, it will default to Delete.
+* `volume_binding_mode` - Indicates when volume binding and dynamic provisioning should occur.
 * `allow_volume_expansion` - (Optional) Indicates whether the storage class allow volume expand, default true.
 * `mount_options` - (Optional) Persistent Volumes that are dynamically created by a storage class will have the mount options specified.
 


### PR DESCRIPTION
Looks like this was added to the data source docs here but the resource got omitted: https://github.com/hashicorp/terraform-provider-kubernetes/pull/266

### Description

Add missing attribute to the storage_class resource docs

### References
https://github.com/hashicorp/terraform-provider-kubernetes/pull/266

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment