### PR TITLE
add projected volumes in pod_spec

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -533,6 +533,58 @@ func TestAccKubernetesPod_with_cfg_map_volume_mount(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPod_with_projected_volume(t *testing.T) {
+	var conf api.Pod
+
+	cfgMapName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	cfgMap2Name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	secretName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	satPath := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "busybox:1.30.1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExpectNonEmptyPlan: true,
+				Config:             testAccKubernetesPodProjectedVolume(cfgMapName, cfgMap2Name, secretName, satPath, podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName),
+
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.name", "projected-vol"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.default_mode", "0777"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.#", "5"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.0.secret.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.0.secret.0.name", secretName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.1.config_map.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.1.config_map.0.name", cfgMapName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.2.config_map.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.2.config_map.0.name", cfgMap2Name),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.0.path", "labels"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.0.field_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.0.field_ref.0.field_path", "metadata.labels"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.path", "cpu_limit"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.0.container_name", "containername"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.0.resource", "limits.cpu"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.4.service_account_token.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.4.service_account_token.0.path", satPath),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.4.service_account_token.0.expiration_seconds", "600"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.4.service_account_token.0.audience", "sat_audience"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesPod_with_resource_requirements(t *testing.T) {
 	var conf api.Pod
 
@@ -1388,6 +1440,132 @@ resource "kubernetes_pod" "test" {
   }
 }
 `, secretName, podName, imageName)
+}
+
+func testAccKubernetesPodProjectedVolume(cfgMapName, cfgMap2Name, secretName, satPath, podName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_config_map" "test" {
+    metadata {
+      name = "%s"
+    }
+
+    binary_data = {
+      raw = "${base64encode("Raw data should come back as is in the pod")}"
+    }
+
+    data = {
+      one = "first"
+    }
+}
+
+resource "kubernetes_config_map" "test2" {
+    metadata {
+      name = "%s"
+    }
+
+    binary_data = {
+      raw = "${base64encode("Raw data should come back as is in the pod")}"
+    }
+
+    data = {
+      one = "first"
+    }
+}
+
+resource "kubernetes_secret" "test" {
+    metadata {
+      name = "%s"
+    }
+
+    data = {
+      one = "first"
+    }
+}
+
+resource "kubernetes_pod" "test" {
+  metadata {
+    labels = {
+      app = "pod_label"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    restart_policy = "Never"
+
+    container {
+      image = "%s"
+      name  = "containername"
+
+      args = ["/bin/sh", "-xc", "ls -l /tmp/my-projected-volume ; cat /tmp/my-projected-volume/raw.txt ; sleep 10"]
+
+      lifecycle {
+        post_start {
+          exec {
+            command = ["/bin/sh", "-xc", "grep 'Raw data should come back as is in the pod' /tmp/my-projected-volume/raw.txt"]
+          }
+        }
+      }
+
+      volume_mount {
+        mount_path = "/tmp/my-projected-volume"
+        name       = "projected-vol"
+      }
+    }
+
+    volume {
+      name = "projected-vol"
+      projected {
+        default_mode = "0777"
+        sources {
+          config_map {
+            name = "${kubernetes_config_map.test.metadata.0.name}"
+            items {
+              key  = "raw"
+              path = "raw.txt"
+            }
+          }
+		  config_map {
+            name = "${kubernetes_config_map.test2.metadata.0.name}"
+            items {
+              key  = "raw"
+              path = "raw-again.txt"
+            }
+          }
+          secret {
+            name = "${kubernetes_secret.test.metadata.0.name}"
+            items {
+              key  = "one"
+              path = "secret.txt"
+            }
+          }
+          downward_api {
+            items {
+              path = "labels"
+              field_ref {
+                field_path = "metadata.labels"
+              }
+            }
+            items {
+              path = "cpu_limit"
+              resource_field_ref {
+                container_name = "containername"
+                resource = "limits.cpu"
+              }
+            }
+          }
+          service_account_token {
+            path = %q
+            expiration_seconds = 600
+            audience = "sat_audience"
+          }
+        }
+      }
+    }
+  }
+}
+`, cfgMapName, cfgMap2Name, secretName, podName, imageName, satPath)
 }
 
 func testAccKubernetesPodConfigWithResourceRequirements(podName, imageName string) string {

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -718,7 +718,7 @@ func volumeSchema() *schema.Resource {
 										},
 										"items": {
 											Type:        schema.TypeList,
-											Description: `If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.`,
+											Description: "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.",
 											Optional:    true,
 											Elem: &schema.Resource{
 												Schema: map[string]*schema.Schema{
@@ -730,14 +730,14 @@ func volumeSchema() *schema.Resource {
 													"mode": {
 														Type:         schema.TypeString,
 														Optional:     true,
-														Description:  `Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.`,
+														Description:  "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 														ValidateFunc: validateModeBits,
 													},
 													"path": {
 														Type:         schema.TypeString,
 														Optional:     true,
 														ValidateFunc: validateAttributeValueDoesNotContain(".."),
-														Description:  `The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.`,
+														Description:  "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
 													},
 												},
 											},
@@ -755,11 +755,12 @@ func volumeSchema() *schema.Resource {
 								Type:        schema.TypeList,
 								Description: "DownwardAPI represents downward API about the pod that should populate this volume",
 								Optional:    true,
+								MaxItems:    1,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"items": {
 											Type:        schema.TypeList,
-											Description: `If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.`,
+											Description: "Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
 											Optional:    true,
 											Elem: &schema.Resource{
 												Schema: map[string]*schema.Schema{
@@ -767,14 +768,14 @@ func volumeSchema() *schema.Resource {
 														Type:        schema.TypeList,
 														Optional:    true,
 														MaxItems:    1,
-														Description: "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+														Description: "Selects a field of the pod: only annotations, labels, name and namespace are supported.",
 														Elem: &schema.Resource{
 															Schema: map[string]*schema.Schema{
 																"api_version": {
 																	Type:        schema.TypeString,
 																	Optional:    true,
 																	Default:     "v1",
-																	Description: `Version of the schema the FieldPath is written in terms of, defaults to "v1".`,
+																	Description: "Version of the schema the FieldPath is written in terms of, defaults to 'v1'.",
 																},
 																"field_path": {
 																	Type:        schema.TypeString,
@@ -787,14 +788,14 @@ func volumeSchema() *schema.Resource {
 													"mode": {
 														Type:         schema.TypeString,
 														Optional:     true,
-														Description:  `Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.`,
+														Description:  "Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 														ValidateFunc: validateModeBits,
 													},
 													"path": {
 														Type:         schema.TypeString,
 														Required:     true,
 														ValidateFunc: validateAttributeValueDoesNotContain(".."),
-														Description:  `Path is the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'`,
+														Description:  "Path is the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
 													},
 													"resource_field_ref": {
 														Type:        schema.TypeList,
@@ -827,8 +828,9 @@ func volumeSchema() *schema.Resource {
 							},
 							"service_account_token": &schema.Schema{
 								Type:        schema.TypeList,
-								Description: "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+								Description: "A projected service account token volume",
 								Optional:    true,
+								MaxItems:    1,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"audience": {
@@ -841,7 +843,7 @@ func volumeSchema() *schema.Resource {
 											Optional:     true,
 											Default:      3600,
 											Description:  "ExpirationSeconds is the expected duration of validity of the service account token. It defaults to 1 hour and must be at least 10 minutes (600 seconds).",
-											ValidateFunc: validateServiceAccountTokenExpirationSeconds(600),
+											ValidateFunc: validateIntGreaterThan(600),
 										},
 										"path": {
 											Type:        schema.TypeString,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -637,6 +637,226 @@ func volumeSchema() *schema.Resource {
 		Description: "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
 		Optional:    true,
 	}
+
+	v["projected"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "Projected represents a single volume that projects several volume sources into the same directory. More info: https://kubernetes.io/docs/concepts/storage/volumes/#projected",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"default_mode": {
+					Type:         schema.TypeString,
+					Description:  "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					Optional:     true,
+					Default:      "0644",
+					ValidateFunc: validateModeBits,
+				},
+				"sources": {
+					Type:        schema.TypeList,
+					Description: "Source of the volume to project in the directory.",
+					Required:    true,
+					MinItems:    1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							// identical to SecretVolumeSource but without the default mode and uses a local object reference as name instead of a secret name.
+							"secret": &schema.Schema{
+								Type:        schema.TypeList,
+								Description: "Secret represents a secret that should populate this volume. More info: http://kubernetes.io/docs/user-guide/volumes#secrets",
+								Optional:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"name": {
+											Type:        schema.TypeString,
+											Description: "Name of the secret in the pod's namespace to use. More info: http://kubernetes.io/docs/user-guide/volumes#secrets",
+											Optional:    true,
+										},
+										"items": {
+											Type:        schema.TypeList,
+											Description: "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+											Optional:    true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"key": {
+														Type:        schema.TypeString,
+														Optional:    true,
+														Description: "The key to project.",
+													},
+													"mode": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														Description:  "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+														ValidateFunc: validateModeBits,
+													},
+													"path": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validateAttributeValueDoesNotContain(".."),
+														Description:  "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+													},
+												},
+											},
+										},
+										"optional": {
+											Type:        schema.TypeBool,
+											Description: "Optional: Specify whether the Secret or it's keys must be defined.",
+											Optional:    true,
+										},
+									},
+								},
+							},
+							// identical to ConfigMapVolumeSource but without the default mode and uses a local object reference as name instead of a secret name.
+							"config_map": &schema.Schema{
+								Type:        schema.TypeList,
+								Description: "ConfigMap represents a configMap that should populate this volume",
+								Optional:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"name": {
+											Type:        schema.TypeString,
+											Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+											Optional:    true,
+										},
+										"items": {
+											Type:        schema.TypeList,
+											Description: `If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.`,
+											Optional:    true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"key": {
+														Type:        schema.TypeString,
+														Optional:    true,
+														Description: "The key to project.",
+													},
+													"mode": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														Description:  `Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.`,
+														ValidateFunc: validateModeBits,
+													},
+													"path": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validateAttributeValueDoesNotContain(".."),
+														Description:  `The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.`,
+													},
+												},
+											},
+										},
+										"optional": {
+											Type:        schema.TypeBool,
+											Description: "Optional: Specify whether the ConfigMap or it's keys must be defined.",
+											Optional:    true,
+										},
+									},
+								},
+							},
+							// identical to DownwardAPIVolumeSource but without the default mode.
+							"downward_api": &schema.Schema{
+								Type:        schema.TypeList,
+								Description: "DownwardAPI represents downward API about the pod that should populate this volume",
+								Optional:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"items": {
+											Type:        schema.TypeList,
+											Description: `If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.`,
+											Optional:    true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"field_ref": {
+														Type:        schema.TypeList,
+														Optional:    true,
+														MaxItems:    1,
+														Description: "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"api_version": {
+																	Type:        schema.TypeString,
+																	Optional:    true,
+																	Default:     "v1",
+																	Description: `Version of the schema the FieldPath is written in terms of, defaults to "v1".`,
+																},
+																"field_path": {
+																	Type:        schema.TypeString,
+																	Optional:    true,
+																	Description: "Path of the field to select in the specified API version",
+																},
+															},
+														},
+													},
+													"mode": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														Description:  `Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.`,
+														ValidateFunc: validateModeBits,
+													},
+													"path": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validateAttributeValueDoesNotContain(".."),
+														Description:  `Path is the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'`,
+													},
+													"resource_field_ref": {
+														Type:        schema.TypeList,
+														Optional:    true,
+														MaxItems:    1,
+														Description: "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"container_name": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																"quantity": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"resource": {
+																	Type:        schema.TypeString,
+																	Required:    true,
+																	Description: "Resource to select",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"service_account_token": &schema.Schema{
+								Type:        schema.TypeList,
+								Description: "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+								Optional:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"audience": {
+											Type:        schema.TypeString,
+											Description: "Audience is the intended audience of the token",
+											Optional:    true,
+										},
+										"expiration_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      3600,
+											Description:  "ExpirationSeconds is the expected duration of validity of the service account token. It defaults to 1 hour and must be at least 10 minutes (600 seconds).",
+											ValidateFunc: validateServiceAccountTokenExpirationSeconds(600),
+										},
+										"path": {
+											Type:        schema.TypeString,
+											Description: "Path specifies a relative path to the mount point of the projected volume.",
+											Required:    true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	return &schema.Resource{
 		Schema: v,
 	}

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -264,6 +264,9 @@ func flattenVolumes(volumes []v1.Volume) ([]interface{}, error) {
 		if v.Secret != nil {
 			obj["secret"] = flattenSecretVolumeSource(v.Secret)
 		}
+		if v.Projected != nil {
+			obj["projected"] = flattenProjectedVolumeSource(v.Projected)
+		}
 		if v.GCEPersistentDisk != nil {
 			obj["gce_persistent_disk"] = flattenGCEPersistentDiskVolumeSource(v.GCEPersistentDisk)
 		}
@@ -435,6 +438,103 @@ func flattenSecretVolumeSource(in *v1.SecretVolumeSource) []interface{} {
 	}
 	if in.Optional != nil {
 		att["optional"] = *in.Optional
+	}
+	return []interface{}{att}
+}
+
+func flattenProjectedVolumeSource(in *v1.ProjectedVolumeSource) []interface{} {
+	att := make(map[string]interface{})
+	if in.DefaultMode != nil {
+		att["default_mode"] = "0" + strconv.FormatInt(int64(*in.DefaultMode), 8)
+	}
+	if len(in.Sources) > 0 {
+		sources := make([]interface{}, 0, len(in.Sources))
+		for _, src := range in.Sources {
+			s := make(map[string]interface{})
+			if src.Secret != nil {
+				s["secret"] = flattenSecretProjection(src.Secret)
+			}
+			if src.ConfigMap != nil {
+				s["config_map"] = flattenConfigMapProjection(src.ConfigMap)
+			}
+			if src.DownwardAPI != nil {
+				s["downward_api"] = flattenDownwardAPIProjection(src.DownwardAPI)
+			}
+			if src.ServiceAccountToken != nil {
+				s["service_account_token"] = flattenServiceAccountTokenProjection(src.ServiceAccountToken)
+			}
+			sources = append(sources, s)
+		}
+		att["sources"] = sources
+	}
+	return []interface{}{att}
+}
+
+func flattenSecretProjection(in *v1.SecretProjection) []interface{} {
+	att := make(map[string]interface{})
+	if in.Name != "" {
+		att["name"] = in.Name
+	}
+	if len(in.Items) > 0 {
+		items := make([]interface{}, len(in.Items))
+		for i, v := range in.Items {
+			m := map[string]interface{}{}
+			m["key"] = v.Key
+			if v.Mode != nil {
+				m["mode"] = "0" + strconv.FormatInt(int64(*v.Mode), 8)
+			}
+			m["path"] = v.Path
+			items[i] = m
+		}
+		att["items"] = items
+	}
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
+	}
+	return []interface{}{att}
+}
+
+func flattenConfigMapProjection(in *v1.ConfigMapProjection) []interface{} {
+	att := make(map[string]interface{})
+	att["name"] = in.Name
+	if len(in.Items) > 0 {
+		items := make([]interface{}, len(in.Items))
+		for i, v := range in.Items {
+			m := map[string]interface{}{}
+			if v.Key != "" {
+				m["key"] = v.Key
+			}
+			if v.Mode != nil {
+				m["mode"] = "0" + strconv.FormatInt(int64(*v.Mode), 8)
+			}
+			if v.Path != "" {
+				m["path"] = v.Path
+			}
+			items[i] = m
+		}
+		att["items"] = items
+	}
+	return []interface{}{att}
+}
+
+func flattenDownwardAPIProjection(in *v1.DownwardAPIProjection) []interface{} {
+	att := make(map[string]interface{})
+	if len(in.Items) > 0 {
+		att["items"] = flattenDownwardAPIVolumeFile(in.Items)
+	}
+	return []interface{}{att}
+}
+
+func flattenServiceAccountTokenProjection(in *v1.ServiceAccountTokenProjection) []interface{} {
+	att := make(map[string]interface{})
+	if in.Audience != "" {
+		att["audience"] = in.Audience
+	}
+	if in.ExpirationSeconds != nil {
+		att["expiration_seconds"] = in.ExpirationSeconds
+	}
+	if in.Path != "" {
+		att["path"] = in.Path
 	}
 	return []interface{}{att}
 }
@@ -727,8 +827,8 @@ func expandDownwardAPIVolumeFile(in []interface{}) ([]v1.DownwardAPIVolumeFile, 
 	dapivf := make([]v1.DownwardAPIVolumeFile, len(in))
 	for i, c := range in {
 		p := c.(map[string]interface{})
-		if v, ok := p["mode"].(string); ok {
-			m, err := strconv.ParseInt(v, 8, 32)
+		if mode, ok := p["mode"].(string); ok && len(mode) > 0 {
+			m, err := strconv.ParseInt(mode, 8, 32)
 			if err != nil {
 				return dapivf, fmt.Errorf("DownwardAPI volume file: failed to parse 'mode' value: %s", err)
 			}
@@ -879,6 +979,174 @@ func expandSecretVolumeSource(l []interface{}) (*v1.SecretVolumeSource, error) {
 	return obj, nil
 }
 
+func expandProjectedVolumeSource(l []interface{}) (*v1.ProjectedVolumeSource, error) {
+	obj := &v1.ProjectedVolumeSource{}
+	if len(l) == 0 || l[0] == nil {
+		return obj, nil
+	}
+	in := l[0].(map[string]interface{})
+
+	if mode, ok := in["default_mode"].(string); ok && len(mode) > 0 {
+		v, err := strconv.ParseInt(mode, 8, 32)
+		if err != nil {
+			return obj, fmt.Errorf("Projected volume: failed to parse 'default_mode' value: %s", err)
+		}
+		obj.DefaultMode = ptrToInt32(int32(v))
+	}
+	if v, ok := in["sources"].([]interface{}); ok && len(v) > 0 {
+		srcs, err := expandProjectedSources(v)
+		if err != nil {
+			return obj, fmt.Errorf("Projected volume: failed to parse 'sources' value: %s", err)
+		}
+
+		obj.Sources = srcs
+	} else if v, ok := in["sources"]; ok {
+		return obj, fmt.Errorf("projected sources of unexpected type: %T, %#v", v, v)
+	}
+
+	return obj, nil
+}
+
+func expandProjectedSources(sources []interface{}) ([]v1.VolumeProjection, error) {
+	if len(sources) == 0 {
+		return []v1.VolumeProjection{}, nil
+	}
+	srcs := make([]v1.VolumeProjection, 0, len(sources))
+	for _, src := range sources {
+		in := src.(map[string]interface{})
+		if v, ok := in["secret"].([]interface{}); ok {
+			srcs = append(srcs, expandProjectedSecrets(v)...)
+		}
+		if v, ok := in["config_map"].([]interface{}); ok {
+			srcs = append(srcs, expandProjectedConfigMaps(v)...)
+		}
+		if v, ok := in["downward_api"].([]interface{}); ok {
+			values, err := expandProjectedDownwardAPIs(v)
+			if err != nil {
+				return nil, err
+			}
+			srcs = append(srcs, values...)
+		}
+		if v, ok := in["service_account_token"].([]interface{}); ok {
+			values, err := expandProjectedServiceAccountTokens(v)
+			if err != nil {
+				return nil, err
+			}
+			srcs = append(srcs, values...)
+		}
+	}
+
+	return srcs, nil
+}
+
+func expandProjectedSecrets(secrets []interface{}) []v1.VolumeProjection {
+	out := make([]v1.VolumeProjection, 0, len(secrets))
+	for _, in := range secrets {
+		if v, ok := in.(map[string]interface{}); ok {
+			out = append(out, v1.VolumeProjection{Secret: expandProjectedSecret(v)})
+		}
+	}
+	return out
+}
+
+func expandProjectedSecret(secret map[string]interface{}) *v1.SecretProjection {
+	s := &v1.SecretProjection{}
+	if value, ok := secret["name"].(string); ok {
+		s.Name = value
+	}
+	if values, ok := secret["items"].([]interface{}); ok {
+		s.Items = expandKeyPath(values)
+	}
+	if value, ok := secret["optional"].(bool); ok {
+		s.Optional = ptrToBool(value)
+	}
+	return s
+}
+
+func expandProjectedConfigMaps(configMaps []interface{}) []v1.VolumeProjection {
+	out := make([]v1.VolumeProjection, 0, len(configMaps))
+	for _, in := range configMaps {
+		if v, ok := in.(map[string]interface{}); ok {
+			var vol v1.VolumeProjection
+			vol.ConfigMap = expandProjectedConfigMap(v)
+			out = append(out, vol)
+		}
+	}
+	return out
+}
+
+func expandProjectedConfigMap(configMap map[string]interface{}) *v1.ConfigMapProjection {
+	s := &v1.ConfigMapProjection{}
+	if value, ok := configMap["name"].(string); ok {
+		s.Name = value
+	}
+	if values, ok := configMap["items"].([]interface{}); ok {
+		s.Items = expandKeyPath(values)
+	}
+	if value, ok := configMap["optional"].(bool); ok {
+		s.Optional = ptrToBool(value)
+	}
+	return s
+}
+
+func expandProjectedDownwardAPIs(downwardAPIs []interface{}) ([]v1.VolumeProjection, error) {
+	out := make([]v1.VolumeProjection, 0, len(downwardAPIs))
+	for i, in := range downwardAPIs {
+		if v, ok := in.(map[string]interface{}); ok {
+			downwardAPI, err := expandProjectedDownwardAPI(v)
+			if err != nil {
+				return nil, fmt.Errorf("expanding downward API #%d: %v", i+1, err)
+			}
+			out = append(out, v1.VolumeProjection{
+				DownwardAPI: downwardAPI,
+			})
+		}
+	}
+	return out, nil
+}
+
+func expandProjectedDownwardAPI(downwardAPI map[string]interface{}) (*v1.DownwardAPIProjection, error) {
+	s := &v1.DownwardAPIProjection{}
+	if values, ok := downwardAPI["items"].([]interface{}); ok {
+		v, err := expandDownwardAPIVolumeFile(values)
+		if err != nil {
+			return nil, err
+		}
+		s.Items = v
+	}
+	return s, nil
+}
+
+func expandProjectedServiceAccountTokens(sats []interface{}) ([]v1.VolumeProjection, error) {
+	out := make([]v1.VolumeProjection, 0, len(sats))
+	for i, in := range sats {
+		if v, ok := in.(map[string]interface{}); ok {
+			sat, err := expandProjectedServiceAccountToken(v)
+			if err != nil {
+				return nil, fmt.Errorf("expanding service account token #%d: %v", i+1, err)
+			}
+			out = append(out, v1.VolumeProjection{
+				ServiceAccountToken: sat,
+			})
+		}
+	}
+	return out, nil
+}
+
+func expandProjectedServiceAccountToken(sat map[string]interface{}) (*v1.ServiceAccountTokenProjection, error) {
+	s := &v1.ServiceAccountTokenProjection{}
+	if value, ok := sat["audience"].(string); ok {
+		s.Audience = value
+	}
+	if value, ok := sat["expiration_seconds"].(int); ok {
+		s.ExpirationSeconds = ptrToInt64(int64(value))
+	}
+	if value, ok := sat["path"].(string); ok {
+		s.Path = value
+	}
+	return s, nil
+}
+
 func expandTolerations(tolerations []interface{}) ([]*v1.Toleration, error) {
 	if len(tolerations) == 0 {
 		return []*v1.Toleration{}, nil
@@ -954,6 +1222,13 @@ func expandVolumes(volumes []interface{}) ([]v1.Volume, error) {
 				return vl, err
 			}
 			vl[i].Secret = sc
+		}
+		if value, ok := m["projected"].([]interface{}); ok && len(value) > 0 {
+			pj, err := expandProjectedVolumeSource(value)
+			if err != nil {
+				return vl, err
+			}
+			vl[i].Projected = pj
 		}
 		if v, ok := m["gce_persistent_disk"].([]interface{}); ok && len(v) > 0 {
 			vl[i].GCEPersistentDisk = expandGCEPersistentDiskVolumeSource(v)

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -1000,20 +1000,21 @@ func expandProjectedVolumeSource(l []interface{}) (*v1.ProjectedVolumeSource, er
 		}
 
 		obj.Sources = srcs
-	} else if v, ok := in["sources"]; ok {
-		return obj, fmt.Errorf("projected sources of unexpected type: %T, %#v", v, v)
 	}
 
 	return obj, nil
 }
 
 func expandProjectedSources(sources []interface{}) ([]v1.VolumeProjection, error) {
-	if len(sources) == 0 {
+	if len(sources) == 0 || sources[0] == nil {
 		return []v1.VolumeProjection{}, nil
 	}
 	srcs := make([]v1.VolumeProjection, 0, len(sources))
 	for _, src := range sources {
-		in := src.(map[string]interface{})
+		in, ok := src.(map[string]interface{})
+		if !ok {
+			continue
+		}
 		if v, ok := in["secret"].([]interface{}); ok {
 			srcs = append(srcs, expandProjectedSecrets(v)...)
 		}

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -460,23 +460,33 @@ func TestExpandThenFlatten_projected_volume(t *testing.T) {
 		{
 			Input: &v1.ProjectedVolumeSource{
 				Sources: []v1.VolumeProjection{
-					{Secret: &v1.SecretProjection{
-						LocalObjectReference: v1.LocalObjectReference{Name: "secret-1"},
-					}},
-					{ConfigMap: &v1.ConfigMapProjection{
-						LocalObjectReference: v1.LocalObjectReference{Name: "config-1"},
-					}},
-					{ConfigMap: &v1.ConfigMapProjection{
-						LocalObjectReference: v1.LocalObjectReference{Name: "config-2"},
-					}},
-					{DownwardAPI: &v1.DownwardAPIProjection{
-						Items: []v1.DownwardAPIVolumeFile{
-							{Path: "path-1"},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{Name: "secret-1"},
 						},
-					}},
-					{ServiceAccountToken: &v1.ServiceAccountTokenProjection{
-						Audience: "audience-1",
-					}},
+					},
+					{
+						ConfigMap: &v1.ConfigMapProjection{
+							LocalObjectReference: v1.LocalObjectReference{Name: "config-1"},
+						},
+					},
+					{
+						ConfigMap: &v1.ConfigMapProjection{
+							LocalObjectReference: v1.LocalObjectReference{Name: "config-2"},
+						},
+					},
+					{
+						DownwardAPI: &v1.DownwardAPIProjection{
+							Items: []v1.DownwardAPIVolumeFile{
+								{Path: "path-1"},
+							},
+						},
+					},
+					{
+						ServiceAccountToken: &v1.ServiceAccountTokenProjection{
+							Audience: "audience-1",
+						},
+					},
 				},
 			},
 		},

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -450,4 +451,51 @@ func TestExpandConfigMapVolumeSource(t *testing.T) {
 				tc.ExpectedOutput, output)
 		}
 	}
+}
+
+func TestExpandThenFlatten_projected_volume(t *testing.T) {
+	cases := []struct {
+		Input *v1.ProjectedVolumeSource
+	}{
+		{
+			Input: &v1.ProjectedVolumeSource{
+				Sources: []v1.VolumeProjection{
+					{Secret: &v1.SecretProjection{
+						LocalObjectReference: v1.LocalObjectReference{Name: "secret-1"},
+					}},
+					{ConfigMap: &v1.ConfigMapProjection{
+						LocalObjectReference: v1.LocalObjectReference{Name: "config-1"},
+					}},
+					{ConfigMap: &v1.ConfigMapProjection{
+						LocalObjectReference: v1.LocalObjectReference{Name: "config-2"},
+					}},
+					{DownwardAPI: &v1.DownwardAPIProjection{
+						Items: []v1.DownwardAPIVolumeFile{
+							{Path: "path-1"},
+						},
+					}},
+					{ServiceAccountToken: &v1.ServiceAccountTokenProjection{
+						Audience: "audience-1",
+					}},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		in := tc.Input
+		flattenedFirst := flattenProjectedVolumeSource(in)
+		out, err := expandProjectedVolumeSource(flattenedFirst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cmp.Equal(in, out) {
+			t.Fatal(cmp.Diff(in, out))
+		}
+
+		flattenedAgain := flattenProjectedVolumeSource(out)
+		if !cmp.Equal(flattenedFirst, flattenedAgain) {
+			t.Fatal(cmp.Diff(flattenedFirst, flattenedAgain))
+		}
+	}
+
 }

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -189,6 +189,16 @@ func validateTerminationGracePeriodSeconds(value interface{}, key string) (ws []
 	return
 }
 
+func validateServiceAccountTokenExpirationSeconds(minValue int) func(value interface{}, key string) (ws []string, es []error) {
+	return func(value interface{}, key string) (ws []string, es []error) {
+		v := value.(int)
+		if v < minValue {
+			es = append(es, fmt.Errorf("%s must be greater than or equal to %d", key, minValue))
+		}
+		return
+	}
+}
+
 // validateTypeStringNullableInt provides custom error messaging for TypeString ints
 // Some arguments require an int value or unspecified, empty field.
 func validateTypeStringNullableInt(v interface{}, k string) (ws []string, es []error) {

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -189,7 +189,7 @@ func validateTerminationGracePeriodSeconds(value interface{}, key string) (ws []
 	return
 }
 
-func validateServiceAccountTokenExpirationSeconds(minValue int) func(value interface{}, key string) (ws []string, es []error) {
+func validateIntGreaterThan(minValue int) func(value interface{}, key string) (ws []string, es []error) {
 	return func(value interface{}, key string) (ws []string, es []error) {
 		v := value.(int)
 		if v < minValue {

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -762,6 +762,30 @@ The `items` block supports the following:
 * `toleration_seconds` - (Optional) TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
 * `value` - (Optional) Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
 
+### `projected`
+
+#### Arguments
+
+* `default_mode` - (Optional) Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+* `sources` - (Required) List of volume projection sources
+
+### `sources`
+
+#### Arguments
+
+* `config_map` - (Optional) Adapts a ConfigMap into a projected volume. The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+* `downward_api` - (Optional) Represents downward API info for projecting into a projected volume. Note that this is identical to a downward_api volume source without the default mode.
+* `secret` - (Optional) Adapts a secret into a projected volume. The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+* `service_account_token` - (Optional) Represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+
+### `service_account_token`
+
+#### Arguments
+
+* `audience` - (Optional) Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+* `expiration_seconds` - (Optional) The requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+* `path` - (Required) Path is the path relative to the mount point of the file to project the token into.
+
 ### `volume`
 
 #### Arguments
@@ -786,6 +810,7 @@ The `items` block supports the following:
 * `nfs` - (Optional) Represents an NFS mount on the host. Provisioned by an admin. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
 * `persistent_volume_claim` - (Optional) The specification of a persistent volume.
 * `photon_persistent_disk` - (Optional) Represents a PhotonController persistent disk attached and mounted on kubelets host machine
+* `projected` (Optional) Items for all in one resources secrets, configmaps, and downward API.
 * `quobyte` - (Optional) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
 * `rbd` - (Optional) Represents a Rados Block Device mount on the host that shares a pod's lifetime. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md
 * `secret` - (Optional) Secret represents a secret that should populate this volume. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#secrets)

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -769,6 +769,30 @@ The `items` block supports the following:
 * `toleration_seconds` - (Optional) TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
 * `value` - (Optional) Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
 
+### `projected`
+
+#### Arguments
+
+* `default_mode` - (Optional) Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+* `sources` - (Required) List of volume projection sources
+
+### `sources`
+
+#### Arguments
+
+* `config_map` - (Optional) Adapts a ConfigMap into a projected volume. The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+* `downward_api` - (Optional) Represents downward API info for projecting into a projected volume. Note that this is identical to a downward_api volume source without the default mode.
+* `secret` - (Optional) Adapts a secret into a projected volume. The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+* `service_account_token` - (Optional) Represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+
+### `service_account_token`
+
+#### Arguments
+
+* `audience` - (Optional) Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+* `expiration_seconds` - (Optional) The requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+* `path` - (Required) Path is the path relative to the mount point of the file to project the token into.
+
 ### `volume`
 
 #### Arguments
@@ -793,6 +817,7 @@ The `items` block supports the following:
 * `nfs` - (Optional) Represents an NFS mount on the host. Provisioned by an admin. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
 * `persistent_volume_claim` - (Optional) The specification of a persistent volume.
 * `photon_persistent_disk` - (Optional) Represents a PhotonController persistent disk attached and mounted on kubelets host machine
+* `projected` (Optional) Items for all in one resources secrets, configmaps, and downward API.
 * `quobyte` - (Optional) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
 * `rbd` - (Optional) Represents a Rados Block Device mount on the host that shares a pod's lifetime. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md
 * `secret` - (Optional) Secret represents a secret that should populate this volume. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#secrets)

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -822,6 +822,30 @@ The `items` block supports the following:
 * `resource_field_ref` - (Optional) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 * `secret_key_ref` - (Optional) Selects a key of a secret in the pod's namespace.
 
+### `projected`
+
+#### Arguments
+
+* `default_mode` - (Optional) Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+* `sources` - (Required) List of volume projection sources
+
+### `sources`
+
+#### Arguments
+
+* `config_map` - (Optional) Adapts a ConfigMap into a projected volume. The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+* `downward_api` - (Optional) Represents downward API info for projecting into a projected volume. Note that this is identical to a downward_api volume source without the default mode.
+* `secret` - (Optional) Adapts a secret into a projected volume. The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+* `service_account_token` - (Optional) Represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+
+### `service_account_token`
+
+#### Arguments
+
+* `audience` - (Optional) Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+* `expiration_seconds` - (Optional) The requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+* `path` - (Required) Path is the path relative to the mount point of the file to project the token into.
+
 ### `volume`
 
 #### Arguments
@@ -846,6 +870,7 @@ The `items` block supports the following:
 * `nfs` - (Optional) Represents an NFS mount on the host. Provisioned by an admin. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
 * `persistent_volume_claim` - (Optional) The specification of a persistent volume.
 * `photon_persistent_disk` - (Optional) Represents a PhotonController persistent disk attached and mounted on kubelets host machine
+* `projected` (Optional) Items for all in one resources secrets, configmaps, and downward API.
 * `quobyte` - (Optional) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
 * `rbd` - (Optional) Represents a Rados Block Device mount on the host that shares a pod's lifetime. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md
 * `secret` - (Optional) Secret represents a secret that should populate this volume. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#secrets)


### PR DESCRIPTION
### Description

Implement support for projected volumes in pod specs.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)*

```
$ TESTARGS="-test.run TestAccKubernetesPod_with_projected_volume" KUBECONFIG=~/.kube/config  make testacc 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -test.run TestAccKubernetesPod_with_projected_volume -timeout 120m
=== RUN   TestAccKubernetesPod_with_projected_volume
--- PASS: TestAccKubernetesPod_with_projected_volume (28.54s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   30.181s
```

There's a problem with the test if `ExpectNonEmptyPlan: false`, and after spending a few hours looking at it, stepping through the code with a debugger and plenty of logging, I can't figure out what's happening. I'm not sure `ExpectNonEmptyPlan: true` is an acceptable setting, but I don't quite understand what the implication are. [Here's what the test failure looks like when this flag isn't set](https://gist.github.com/aybabtme/b3d0375249ab144c12ec3f823787ef8a#file-gistfile1-txt-L86-L149).

### References

fixes #818

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment