### PR TITLE
r/kubernetes_service - add support for `health_check_node_port` + some validations

### DIFF
--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -104,6 +104,10 @@ func resourceKubernetesService() *schema.Resource {
 										Description: "The IP protocol for this port. Supports `TCP` and `UDP`. Default is `TCP`.",
 										Optional:    true,
 										Default:     "TCP",
+										ValidateFunc: validation.StringInSlice([]string{
+											"TCP",
+											"UDP",
+										}, false),
 									},
 									"target_port": {
 										Type:        schema.TypeString,
@@ -130,12 +134,28 @@ func resourceKubernetesService() *schema.Resource {
 							Description: "Used to maintain session affinity. Supports `ClientIP` and `None`. Defaults to `None`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
 							Optional:    true,
 							Default:     "None",
+							ValidateFunc: validation.StringInSlice([]string{
+								"ClientIP",
+								"None",
+							}, false),
 						},
 						"type": {
 							Type:        schema.TypeString,
 							Description: "Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. More info: http://kubernetes.io/docs/user-guide/services#overview",
 							Optional:    true,
 							Default:     "ClusterIP",
+							ValidateFunc: validation.StringInSlice([]string{
+								"ClusterIP",
+								"ExternalName",
+								"NodePort",
+								"LoadBalancer",
+							}, false),
+						},
+						"health_check_node_port": {
+							Type:        schema.TypeInt,
+							Description: "Specifies the Healthcheck NodePort for the service. Only effects when type is set to `LoadBalancer` and external_traffic_policy is set to `Local`.",
+							Optional:    true,
+							Computed:    true,
 						},
 					},
 				},

--- a/kubernetes/structure_service_spec.go
+++ b/kubernetes/structure_service_spec.go
@@ -59,6 +59,9 @@ func flattenServiceSpec(in v1.ServiceSpec) []interface{} {
 	if in.ExternalTrafficPolicy != "" {
 		att["external_traffic_policy"] = string(in.ExternalTrafficPolicy)
 	}
+
+	att["health_check_node_port"] = int(in.HealthCheckNodePort)
+
 	return []interface{}{att}
 }
 
@@ -141,6 +144,10 @@ func expandServiceSpec(l []interface{}) v1.ServiceSpec {
 	if v, ok := in["external_traffic_policy"].(string); ok {
 		obj.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyType(v)
 	}
+	if v, ok := in["health_check_node_port"].(int); ok {
+		obj.HealthCheckNodePort = int32(v)
+	}
+
 	return obj
 }
 
@@ -228,6 +235,12 @@ func patchServiceSpec(keyPrefix, pathPrefix string, d *schema.ResourceData, v *v
 				Path: p,
 			})
 		}
+	}
+	if d.HasChange(keyPrefix + "health_check_node_port") {
+		ops = append(ops, &ReplaceOperation{
+			Path:  pathPrefix + "health_check_node_port",
+			Value: int32(d.Get(keyPrefix + "health_check_node_port").(int)),
+		})
 	}
 	return ops, nil
 }

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -95,6 +95,7 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/la
 * `selector` - (Optional) Route service traffic to pods with label keys and values matching this selector. Only applies to types `ClusterIP`, `NodePort`, and `LoadBalancer`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#overview)
 * `session_affinity` - (Optional) Used to maintain session affinity. Supports `ClientIP` and `None`. Defaults to `None`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
 * `type` - (Optional) Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#overview)
+* `health_check_node_port` - (Optional) Specifies the Healthcheck NodePort for the service. Only effects when type is set to `LoadBalancer` and external_traffic_policy is set to `Local`.
 
 ### `port`
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

```
--- PASS: TestAccKubernetesService_loadBalancer (17.69s)
--- PASS: TestAccKubernetesService_loadBalancer_healthcheck (8.77s)
--- PASS: TestAccKubernetesService_loadBalancer_annotations_aws (11.15s)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment