### PR TITLE
r/storage_class - add support for `allowed_topologies` + some validations

### DIFF
--- a/kubernetes/data_source_kubernetes_storage_class.go
+++ b/kubernetes/data_source_kubernetes_storage_class.go
@@ -36,6 +36,36 @@ func dataSourceKubernetesStorageClass() *schema.Resource {
 				Set:         schema.HashString,
 				Computed:    true,
 			},
+			"allowed_topologies": {
+				Type:        schema.TypeList,
+				Description: "Restrict the node topologies where volumes can be dynamically provisioned.",
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"match_label_expressions": {
+							Type:        schema.TypeList,
+							Description: "A list of topology selector requirements by labels.",
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Description: "The label key that the selector applies to.",
+										Optional:    true,
+									},
+									"values": {
+										Type:        schema.TypeSet,
+										Description: "An array of string values. One value must match the label to be selected.",
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/kubernetes/data_source_kubernetes_storage_class_test.go
+++ b/kubernetes/data_source_kubernetes_storage_class_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccKubernetesDataSourceStorageClass_basic(t *testing.T) {
+	dataSourceName := "data.kubernetes_storage_class.test"
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
@@ -18,25 +19,26 @@ func TestAccKubernetesDataSourceStorageClass_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesDataSourceStorageClassConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("data.kubernetes_storage_class.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_storage_class.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_storage_class.test", "metadata.0.self_link"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_storage_class.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.labels.TestLabelTwo", "two"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "metadata.0.labels.TestLabelThree", "three"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "reclaim_policy", "Delete"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "storage_provisioner", "kubernetes.io/gce-pd"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "allow_volume_expansion", "true"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "mount_options.#", "2"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "mount_options.2356372769", "foo"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "mount_options.1996459178", "bar"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "parameters.%", "1"),
-					resource.TestCheckResourceAttr("data.kubernetes_storage_class.test", "parameters.type", "pd-ssd"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.annotations.TestAnnotationTwo", "two"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr(dataSourceName, "reclaim_policy", "Delete"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_provisioner", "kubernetes.io/gce-pd"),
+					resource.TestCheckResourceAttr(dataSourceName, "allow_volume_expansion", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "mount_options.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "mount_options.2356372769", "foo"),
+					resource.TestCheckResourceAttr(dataSourceName, "mount_options.1996459178", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.type", "pd-ssd"),
+					resource.TestCheckResourceAttr(dataSourceName, "allowed_topologies.%", "0"),
 				),
 			},
 		},

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -79,6 +79,7 @@ func resourceKubernetesStorageClass() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Restrict the node topologies where volumes can be dynamically provisioned.",
 				Optional:    true,
+				ForceNew:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -46,7 +46,6 @@ func resourceKubernetesStorageClass() *schema.Resource {
 				Optional:    true,
 				Default:     "Delete",
 				ValidateFunc: validation.StringInSlice([]string{
-					"Recycle",
 					"Delete",
 					"Retain",
 				}, false),
@@ -226,7 +225,7 @@ func resourceKubernetesStorageClassDelete(d *schema.ResourceData, meta interface
 	}
 
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		_, err := conn.StorageV1().StorageClasses().Get(d.Id(), metav1.GetOptions{})
+		_, err := conn.StorageV1().StorageClasses().Get(ctx, d.Id(), metav1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 				return nil

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -352,7 +352,6 @@ resource "kubernetes_storage_class" "test" {
   reclaim_policy         = "Delete"
   volume_binding_mode    = "Immediate"
   allow_volume_expansion = true
-
   mount_options			 = ["foo", "bar"]
 
   parameters = {

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -119,7 +119,6 @@ func TestAccKubernetesStorageClass_basic(t *testing.T) {
 
 func TestAccKubernetesStorageClass_generatedName(t *testing.T) {
 	var conf api.StorageClass
-	resourceName := "kubernetes_storage_class.test"
 	prefix := "tf-acc-test-gen-"
 	resourceName := "kubernetes_storage_class.test"
 

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -168,10 +168,6 @@ func TestAccKubernetesStorageClass_allowedTopologies(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesStorageClassConfig_allowedToplogies(name),
-				SkipFunc: func() (bool, error) {
-					isInGke, err := isRunningInGke()
-					return !isInGke, err
-				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStorageClassExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "allowed_topologies.#", "1"),
@@ -181,10 +177,6 @@ func TestAccKubernetesStorageClass_allowedTopologies(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc: func() (bool, error) {
-					isInGke, err := isRunningInGke()
-					return !isInGke, err
-				},
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/website/docs/d/storage_class.html.markdown
+++ b/website/docs/d/storage_class.html.markdown
@@ -56,3 +56,4 @@ The following attributes are exported:
 * `volume_binding_mode` - Indicates when volume binding and dynamic provisioning should occur.
 * `allow_volume_expansion` - Indicates whether the storage class allow volume expand.
 * `mount_options` - Persistent Volumes that are dynamically created by a storage class will have the mount options specified.
+* `allowed_topologies` - Restrict the node topologies where volumes can be dynamically provisioned.

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -41,7 +41,6 @@ The following arguments are supported:
 * `mount_options` - (Optional) Persistent Volumes that are dynamically created by a storage class will have the mount options specified.
 * `allowed_topologies` - (Optional) Restrict the node topologies where volumes can be dynamically provisioned. see [allowed_topologies](#allowed_topologies)
 
-
 ## Nested Blocks
 
 ### `metadata`

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -39,6 +39,8 @@ The following arguments are supported:
 * `volume_binding_mode` - (Optional) Indicates when volume binding and dynamic provisioning should occur.
 * `allow_volume_expansion` - (Optional) Indicates whether the storage class allow volume expand, default true.
 * `mount_options` - (Optional) Persistent Volumes that are dynamically created by a storage class will have the mount options specified.
+* `allowed_topologies` - (Optional) Restrict the node topologies where volumes can be dynamically provisioned. see [allowed_topologies](#allowed_topologies)
+
 
 ## Nested Blocks
 
@@ -56,6 +58,19 @@ The following arguments are supported:
 ~> By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 
 * `name` - (Optional) Name of the storage class, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+### `allowed_topologies`
+
+#### Arguments
+
+* `match_label_expressions` - (Optional) A list of topology selector requirements by labels. see [match_label_expressions](#match_label_expressions)
+
+### `match_label_expressions`
+
+#### Arguments
+
+* `key` - (Optional) The label key that the selector applies to.
+* `values` - (Optional) An array of string values. One value must match the label to be selected.
 
 #### Attributes
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

```
--- PASS: TestAccKubernetesStorageClass_basic (23.41s)
--- PASS: TestAccKubernetesStorageClass_importBasic (6.34s)
--- PASS: TestAccKubernetesStorageClass_generatedName (6.52s)
--- PASS: TestAccKubernetesStorageClass_importGeneratedName (5.46s)
--- PASS: TestAccKubernetesStorageClass_allowedTopologies (4.11s)
--- PASS: TestAccKubernetesDataSourceStorageClass_basic (2.91s)
```

### References
Closes #391, #891
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment