### PR TITLE
Add wait_for_rollout attribute to kubernetes_deployment

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -8,14 +8,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	api "k8s.io/api/apps/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const deploymentTestResourceName = "kubernetes_deployment.test"
+const (
+	defaultNginxImage          = "nginx:1.19"
+	deploymentTestResourceName = "kubernetes_deployment.test"
+)
 
 func TestAccKubernetesDeployment_basic(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
@@ -28,6 +32,7 @@ func TestAccKubernetesDeployment_basic(t *testing.T) {
 				Config: testAccKubernetesDeploymentConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					testAccCheckKubernetesDeploymentRolledOut(deploymentTestResourceName),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.%", "2"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationTwo", "two"),
@@ -42,11 +47,12 @@ func TestAccKubernetesDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.uid"),
-					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", defaultNginxImage),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.0.type", "RollingUpdate"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.0.rolling_update.0.max_surge", "25%"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.0.rolling_update.0.max_unavailable", "25%"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "wait_for_rollout", "true"),
 				),
 			},
 		},
@@ -54,7 +60,7 @@ func TestAccKubernetesDeployment_basic(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_initContainer(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
@@ -117,7 +123,7 @@ func TestAccKubernetesDeployment_importBasic(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_generatedName(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 	prefix := "tf-acc-test-gen-"
 
 	resource.Test(t, resource.TestCase{
@@ -169,9 +175,9 @@ func TestAccKubernetesDeployment_importGeneratedName(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_security_context(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "redis:5.0.2"
 
 	resource.Test(t, resource.TestCase{
@@ -180,7 +186,7 @@ func TestAccKubernetesDeployment_with_security_context(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithSecurityContext(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithSecurityContext(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.fs_group", "100"),
@@ -195,9 +201,9 @@ func TestAccKubernetesDeployment_with_security_context(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_security_context_run_as_group(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "redis:5.0.2"
 
 	resource.Test(t, resource.TestCase{
@@ -206,7 +212,7 @@ func TestAccKubernetesDeployment_with_security_context_run_as_group(t *testing.T
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithSecurityContextRunAsGroup(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithSecurityContextRunAsGroup(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.fs_group", "100"),
@@ -222,9 +228,9 @@ func TestAccKubernetesDeployment_with_security_context_run_as_group(t *testing.T
 }
 
 func TestAccKubernetesDeployment_with_tolerations(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "redis:5.0.2"
 	tolerationSeconds := 6000
 	operator := "Equal"
@@ -235,7 +241,7 @@ func TestAccKubernetesDeployment_with_tolerations(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithTolerations(rcName, imageName, &tolerationSeconds, operator, nil),
+				Config: testAccKubernetesDeploymentConfigWithTolerations(deploymentName, imageName, &tolerationSeconds, operator, nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.toleration.0.effect", "NoExecute"),
@@ -250,9 +256,9 @@ func TestAccKubernetesDeployment_with_tolerations(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "redis:5.0.2"
 	operator := "Equal"
 	value := "value"
@@ -263,7 +269,7 @@ func TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds(t *te
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithTolerations(rcName, imageName, nil, operator, &value),
+				Config: testAccKubernetesDeploymentConfigWithTolerations(deploymentName, imageName, nil, operator, &value),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.toleration.0.effect", "NoExecute"),
@@ -278,9 +284,9 @@ func TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds(t *te
 }
 
 func TestAccKubernetesDeployment_with_container_liveness_probe_using_exec(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "gcr.io/google_containers/busybox"
 
 	resource.Test(t, resource.TestCase{
@@ -289,7 +295,7 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_exec(t *tes
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.args.#", "3"),
@@ -307,9 +313,9 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_exec(t *tes
 }
 
 func TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "gcr.io/google_containers/liveness"
 
 	resource.Test(t, resource.TestCase{
@@ -318,7 +324,7 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get(t 
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.args.#", "1"),
@@ -337,9 +343,9 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get(t 
 }
 
 func TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "gcr.io/google_containers/liveness"
 
 	resource.Test(t, resource.TestCase{
@@ -348,7 +354,7 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp(t *test
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.args.#", "1"),
@@ -362,9 +368,9 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp(t *test
 }
 
 func TestAccKubernetesDeployment_with_container_lifecycle(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "gcr.io/google_containers/busybox"
 
 	resource.Test(t, resource.TestCase{
@@ -373,7 +379,7 @@ func TestAccKubernetesDeployment_with_container_lifecycle(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithLifeCycle(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithLifeCycle(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.#", "1"),
@@ -393,9 +399,9 @@ func TestAccKubernetesDeployment_with_container_lifecycle(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_container_security_context(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "redis:5.0.2"
 
 	resource.Test(t, resource.TestCase{
@@ -404,7 +410,7 @@ func TestAccKubernetesDeployment_with_container_security_context(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContext(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContext(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.#", "2"),
@@ -433,9 +439,9 @@ func TestAccKubernetesDeployment_with_container_security_context(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_container_security_context_run_as_group(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "redis:5.0.2"
 
 	resource.Test(t, resource.TestCase{
@@ -444,7 +450,7 @@ func TestAccKubernetesDeployment_with_container_security_context_run_as_group(t 
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContextRunAsGroup(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContextRunAsGroup(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.#", "2"),
@@ -473,12 +479,12 @@ func TestAccKubernetesDeployment_with_container_security_context_run_as_group(t 
 	})
 }
 func TestAccKubernetesDeployment_with_volume_mount(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	secretName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
-	imageName := "nginx:1.7.9"
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -486,7 +492,7 @@ func TestAccKubernetesDeployment_with_volume_mount(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
@@ -502,11 +508,10 @@ func TestAccKubernetesDeployment_with_volume_mount(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_resource_requirements(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -514,7 +519,7 @@ func TestAccKubernetesDeployment_with_resource_requirements(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithResourceRequirements(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithResourceRequirements(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
@@ -529,10 +534,10 @@ func TestAccKubernetesDeployment_with_resource_requirements(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_empty_dir_volume(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -540,7 +545,7 @@ func TestAccKubernetesDeployment_with_empty_dir_volume(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithEmptyDirVolumes(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithEmptyDirVolumes(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
@@ -555,9 +560,9 @@ func TestAccKubernetesDeployment_with_empty_dir_volume(t *testing.T) {
 }
 
 func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -565,7 +570,7 @@ func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfig_basic(rcName),
+				Config: testAccKubernetesDeploymentConfig_basic(deploymentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					// Not to be changed
@@ -579,7 +584,7 @@ func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesDeploymentConfig_modified(rcName),
+				Config: testAccKubernetesDeploymentConfig_modified(deploymentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					// Unchanged
@@ -589,7 +594,7 @@ func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
 					// Added
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.Different", "1234"),
 					// Changed
-					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.9"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", defaultNginxImage),
 				),
 			},
 		},
@@ -597,10 +602,10 @@ func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -608,7 +613,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate(t *testi
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(rcName, "RollingUpdate", imageName),
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(deploymentName, "RollingUpdate", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -623,10 +628,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate(t *testi
 }
 
 func TestAccKubernetesDeployment_with_share_process_namespace(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -634,7 +639,7 @@ func TestAccKubernetesDeployment_with_share_process_namespace(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithShareProcessNamespace(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigWithShareProcessNamespace(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.share_process_namespace", "true"),
@@ -644,11 +649,8 @@ func TestAccKubernetesDeployment_with_share_process_namespace(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc(t *testing.T) {
-	var conf api.Deployment
-
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+func TestAccKubernetesDeployment_no_rollout_wait(t *testing.T) {
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -656,7 +658,29 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName, "30%", "40%", imageName),
+				Config: testAccKubernetesDeploymentConfigWithWaitForRolloutFalse(deploymentName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDeploymentRollingOut(deploymentTestResourceName),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "wait_for_rollout", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc(t *testing.T) {
+	var conf appsv1.Deployment
+
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(deploymentName, "30%", "40%", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -671,10 +695,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 }
 
 func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_200perc_max_unavailable_0perc(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -682,7 +706,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName, "200%", "0%", imageName),
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(deploymentName, "200%", "0%", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -697,10 +721,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 }
 
 func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_0_max_unavailable_1(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -708,7 +732,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName, "0", "1", imageName),
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(deploymentName, "0", "1", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -723,10 +747,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 }
 
 func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_0(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -734,7 +758,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName, "1", "0", imageName),
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(deploymentName, "1", "0", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -749,10 +773,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 }
 
 func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -760,7 +784,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName, "1", "2", imageName),
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(deploymentName, "1", "2", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -775,10 +799,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surg
 }
 
 func TestAccKubernetesDeployment_with_deployment_strategy_recreate(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -786,7 +810,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_recreate(t *testing.T)
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(rcName, "Recreate", imageName),
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(deploymentName, "Recreate", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.strategy.#", "1"),
@@ -799,10 +823,10 @@ func TestAccKubernetesDeployment_with_deployment_strategy_recreate(t *testing.T)
 }
 
 func TestAccKubernetesDeployment_with_host_aliases(t *testing.T) {
-	var conf api.Deployment
+	var conf appsv1.Deployment
 
-	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.8"
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -810,7 +834,7 @@ func TestAccKubernetesDeployment_with_host_aliases(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesDeploymentConfigHostAliases(rcName, imageName),
+				Config: testAccKubernetesDeploymentConfigHostAliases(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.#", "2"),
@@ -827,10 +851,10 @@ func TestAccKubernetesDeployment_with_host_aliases(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_config_with_automount_service_account_token(t *testing.T) {
-	var confDeployment api.Deployment
+	var confDeployment appsv1.Deployment
 
 	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	imageName := defaultNginxImage
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -864,7 +888,7 @@ func testAccCheckKubernetesDeploymentDestroy(s *terraform.State) error {
 			return err
 		}
 
-		resp, err := conn.AppsV1().Deployments(namespace).Get(name, meta_v1.GetOptions{})
+		resp, err := conn.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
 				return fmt.Errorf("Deployment still exists: %s", rs.Primary.ID)
@@ -875,29 +899,67 @@ func testAccCheckKubernetesDeploymentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckKubernetesDeploymentExists(n string, obj *api.Deployment) resource.TestCheckFunc {
+func getDeploymentFromResourceName(s *terraform.State, n string) (*appsv1.Deployment, error) {
+	rs, ok := s.RootModule().Resources[n]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s", n)
+	}
+
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return nil, err
+	}
+
+	namespace, name, err := idParts(rs.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := conn.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func testAccCheckKubernetesDeploymentExists(n string, obj *appsv1.Deployment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+		d, err := getDeploymentFromResourceName(s, n)
+		if err != nil {
+			return err
 		}
+		*obj = *d
+		return nil
+	}
+}
 
-		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+func testAccCheckKubernetesDeploymentRollingOut(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		d, err := getDeploymentFromResourceName(s, n)
 		if err != nil {
 			return err
 		}
 
-		namespace, name, err := idParts(rs.Primary.ID)
+		if d.Status.Replicas == d.Status.ReadyReplicas {
+			return fmt.Errorf("deployment has already rolled out")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKubernetesDeploymentRolledOut(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		d, err := getDeploymentFromResourceName(s, n)
 		if err != nil {
 			return err
 		}
 
-		out, err := conn.AppsV1().Deployments(namespace).Get(name, meta_v1.GetOptions{})
-		if err != nil {
-			return err
+		if d.Status.Replicas != d.Status.ReadyReplicas {
+			return fmt.Errorf("deployment is still rolling out")
 		}
 
-		*obj = *out
 		return nil
 	}
 }
@@ -921,7 +983,7 @@ resource "kubernetes_deployment" "test" {
   }
 
   spec {
-    replicas = 100 # This is intentionally high to exercise the waiter
+    replicas = 5
 
     selector {
       match_labels = {
@@ -942,8 +1004,20 @@ resource "kubernetes_deployment" "test" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = %q
           name  = "tf-acc-test"
+
+          port {
+            container_port = 80
+          }
+
+          readiness_probe {
+            initial_delay_seconds = 5
+            http_get {
+              path = "/"
+              port = 80
+            }
+          }
 
           resources {
             requests {
@@ -956,7 +1030,7 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, name)
+`, name, defaultNginxImage)
 }
 
 func testAccKubernetesDeploymentConfig_initContainer(name string) string {
@@ -978,7 +1052,7 @@ resource "kubernetes_deployment" "test" {
   }
 
   spec {
-    replicas = 100 # This is intentionally high to exercise the waiter
+    replicas = 5
 
     selector {
       match_labels = {
@@ -1004,6 +1078,14 @@ resource "kubernetes_deployment" "test" {
 
           port {
             container_port = 80
+          }
+
+          readiness_probe {
+            initial_delay_seconds = 10
+            http_get {
+              path = "/"
+              port = 80
+            }
           }
 
           resources {
@@ -1101,7 +1183,7 @@ resource "kubernetes_deployment" "test" {
 
       spec {
         container {
-          image = "nginx:1.7.9"
+          image = defaultNginxImage
           name  = "tf-acc-test"
         }
       }
@@ -1144,7 +1226,7 @@ resource "kubernetes_deployment" "test" {
 
       spec {
         container {
-          image = "nginx:1.7.9"
+          image = defaultNginxImage
           name  = "tf-acc-test"
         }
       }
@@ -1154,7 +1236,7 @@ resource "kubernetes_deployment" "test" {
 `, prefix)
 }
 
-func testAccKubernetesDeploymentConfigWithSecurityContext(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithSecurityContext(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1195,10 +1277,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithSecurityContextRunAsGroup(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithSecurityContextRunAsGroup(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1240,10 +1322,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithTolerations(rcName, imageName string, tolerationSeconds *int, operator string, value *string) string {
+func testAccKubernetesDeploymentConfigWithTolerations(deploymentName, imageName string, tolerationSeconds *int, operator string, value *string) string {
 	tolerationDuration := ""
 	if tolerationSeconds != nil {
 		tolerationDuration = fmt.Sprintf("toleration_seconds = %d", *tolerationSeconds)
@@ -1294,10 +1376,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, operator, valueString, tolerationDuration, imageName)
+`, deploymentName, operator, valueString, tolerationDuration, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1341,10 +1423,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1394,10 +1476,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1441,10 +1523,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithLifeCycle(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithLifeCycle(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1493,10 +1575,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithContainerSecurityContext(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithContainerSecurityContext(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1563,10 +1645,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithContainerSecurityContextRunAsGroup(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithContainerSecurityContextRunAsGroup(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1634,10 +1716,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
   metadata {
@@ -1694,10 +1776,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, secretName, rcName, imageName)
+`, secretName, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithResourceRequirements(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithResourceRequirements(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1743,10 +1825,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithEmptyDirVolumes(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithEmptyDirVolumes(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1793,10 +1875,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName)
+`, deploymentName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithDeploymentStrategy(rcName, strategy, imageName string) string {
+func testAccKubernetesDeploymentConfigWithDeploymentStrategy(deploymentName, strategy, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1834,10 +1916,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, strategy, imageName)
+`, deploymentName, strategy, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithShareProcessNamespace(rcName, imageName string) string {
+func testAccKubernetesDeploymentConfigWithShareProcessNamespace(deploymentName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1876,10 +1958,10 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName, imageName)
+`, deploymentName, imageName, imageName)
 }
 
-func testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName, maxSurge, maxUnavailable, imageName string) string {
+func testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(deploymentName, maxSurge, maxUnavailable, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
   metadata {
@@ -1922,7 +2004,7 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, maxSurge, maxUnavailable, imageName)
+`, deploymentName, maxSurge, maxUnavailable, imageName)
 }
 
 func testAccKubernetesDeploymentConfigHostAliases(name string, imageName string) string {
@@ -2023,4 +2105,47 @@ resource "kubernetes_deployment" "test" {
   }
 }
 `, deploymentName, imageName)
+}
+
+func testAccKubernetesDeploymentConfigWithWaitForRolloutFalse(deploymentName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_deployment" "test" {
+  metadata {
+    name = %q
+  }
+  spec {
+    replicas = 5
+    selector {
+      match_labels = {
+        "app" = "test"
+      }
+    }
+    template {
+      metadata {
+        name = "test-automount"
+        labels = {
+          "app" = "test"
+        }
+      }
+      spec {
+        container {
+          name  = "nginx"
+          image = %q
+          port {
+            container_port = 80
+          }
+          readiness_probe {
+            initial_delay_seconds = 5
+            http_get {
+              path = "/"
+              port = 80
+            }
+          }
+        }
+      }
+    }
+  }
+  wait_for_rollout = false
+}
+`, deploymentName, defaultNginxImage)
 }

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -116,7 +116,7 @@ func TestAccKubernetesDeployment_importBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_rollout"},
 			},
 		},
 	})
@@ -168,7 +168,7 @@ func TestAccKubernetesDeployment_importGeneratedName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_rollout"},
 			},
 		},
 	})
@@ -580,7 +580,7 @@ func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
 					// To be added
 					resource.TestCheckNoResourceAttr(deploymentTestResourceName, "metadata.0.annotations.Different"),
 					// To be changed
-					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", defaultNginxImage),
 				),
 			},
 			{
@@ -1028,7 +1028,7 @@ resource "kubernetes_deployment" "test" {
         }
       }
     }
-  }
+	}
 }
 `, name, defaultNginxImage)
 }
@@ -1160,7 +1160,7 @@ resource "kubernetes_deployment" "test" {
       TestLabelThree = "three"
     }
 
-    name = "%s"
+    name = %q
   }
 
   spec {
@@ -1183,14 +1183,14 @@ resource "kubernetes_deployment" "test" {
 
       spec {
         container {
-          image = defaultNginxImage
+          image = %q
           name  = "tf-acc-test"
         }
       }
     }
   }
 }
-`, name)
+`, name, defaultNginxImage)
 }
 
 func testAccKubernetesDeploymentConfig_generatedName(prefix string) string {
@@ -1226,14 +1226,14 @@ resource "kubernetes_deployment" "test" {
 
       spec {
         container {
-          image = defaultNginxImage
+          image = %q
           name  = "tf-acc-test"
         }
       }
     }
   }
 }
-`, prefix)
+`, prefix, defaultNginxImage)
 }
 
 func testAccKubernetesDeploymentConfigWithSecurityContext(deploymentName, imageName string) string {

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -81,6 +81,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard deployment's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec defines the specification of the desired behavior of the deployment. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
+* `wait_for_rollout` - (Optional) Wait for the deployment to successfully roll out. Defaults to `true`.
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

This PR exposes a `wait_for_rollout` attribute on the `kubernetes_deployment` resource. The current default behaviour for the resource is to wait for the rollout to complete. This behaviour is preserved, but can now be disabled by using this attribute.

I also tidied up the acceptance tests for this resource a bit, and removed the fixtures that created massive 100 pod deployments that chewed up time on CI runs. I have made these fixtures use a smaller replica count, and used the `initial_delay_seconds` field on the readiness probe to delay the rollout to test the waiter.

Closes #863 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment