### PR TITLE
Change kubernetes_all_namespaces.namespaces type to set

### DIFF
--- a/kubernetes/data_source_kubernetes_all_namespaces.go
+++ b/kubernetes/data_source_kubernetes_all_namespaces.go
@@ -14,8 +14,8 @@ func dataSourceKubernetesAllNamespaces() *schema.Resource {
 		Read: dataSourceKubernetesAllNamespacesRead,
 		Schema: map[string]*schema.Schema{
 			"namespaces": {
-				Type:        schema.TypeList,
-				Description: "List of all namespaces in a cluster.",
+				Type:        schema.TypeSet,
+				Description: "A set of all namespaces in a cluster.",
 				Computed:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -39,7 +39,7 @@ func dataSourceKubernetesAllNamespacesRead(d *schema.ResourceData, meta interfac
 	}
 	namespaces := make([]string, len(nsRaw.Items))
 	for i, v := range nsRaw.Items {
-		namespaces[i] = string(v.Name)
+		namespaces[i] = v.Name
 	}
 	log.Printf("[INFO] Received namespaces: %#v", namespaces)
 	err = d.Set("namespaces", namespaces)

--- a/website/docs/d/all_namespaces.html.markdown
+++ b/website/docs/d/all_namespaces.html.markdown
@@ -27,3 +27,7 @@ output "ns-present" {
 }
 
 ```
+
+## Attribute Reference
+
+* `namespaces` - A set of all namespaces in a cluster.


### PR DESCRIPTION
### Description

#701 introduced `kubernetes_all_namespaces` data source with `namespaces` attribute having `list` type. This PR makes this attribute a `set` for  usage in `for_each` expressions without explicit `toset`. Also added missing attribute reference in docs.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

#701 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment