### PR TITLE
Add resource for CertificateSigningRequest

### DIFF
--- a/_examples/certificate-signing-request/README.md
+++ b/_examples/certificate-signing-request/README.md
@@ -1,0 +1,29 @@
+# CertificateSigningRequest example
+
+This example creates a CertificateSigningRequest in Kubernetes and uses the resulting certificate in a pod. To run this example, have a Kubernetes cluster available (or create one for testing using [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)). Ensure your [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) exists in the default location, or specify the `KUBECONFIG` environment variable. Then apply the Terraform configs located in this example directory:
+
+```
+cd _examples/certificate-signing-request/
+terraform init
+terraform apply
+```
+
+The resulting resources can be viewed using kubectl.
+
+```
+$ kubectl logs test-pod
+-----BEGIN CERTIFICATE-----
+MIICIjCCAQqgAwIBAgIQAz7g4BfKx1rHJ8zRceMgsTANBgkqhkiG9w0BAQsFADAV
+MRMwEQYDVQQDEwptaW5pa3ViZUNBMB4XDTIwMDcyNTAwMDkyOFoXDTIxMDcyNTAw
+MDkyOFowKjEYMBYGA1UEChMPZXhhbXBsZSBjbHVzdGVyMQ4wDAYDVQQDEwVhZG1p
+bjBOMBAGByqGSM49AgEGBSuBBAAhAzoABGrufaGO4MMBleMKXVmcDEOknmqG/2A2
+HbBISW1Y1bQTv9JF72ZzXclNglwDTpgSjL7HXRCY0JOgoy8wLTAdBgNVHSUEFjAU
+BggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsF
+AAOCAQEACnJMtZMb2abgqZVeWoPSfFNed2QFSm/+7i4T/L0wKFR4I/XLRIvfhh9z
+kLRf7Gok4w4Og3GQnUSOARZGLFmZaqqRXmbQyTbUWW5XHeH5HkdKIPwwdAmgCo6L
+azwfHRkeLMOJaB3WDgAL4y1Mn42FYwlnMAsiuOydKFfV4BQGNEeuP+dFtH2wAgDq
+7uRi3OMvPuHooO3b3oEKWVM9A5yODLNbAhTsBJL8cmFnUXeCqEKvGkNSQDtb9Kw/
+8UGdRuzlwhvD/LKgF57LvGldijQgP/4lFjalnkSkXDwtoscXInwzXgV9dx7a+syn
+HsD/cyWXbvABKXn5fg5rDtGMUgdIWQ==
+-----END CERTIFICATE-----
+```

--- a/_examples/certificate-signing-request/main.tf
+++ b/_examples/certificate-signing-request/main.tf
@@ -1,0 +1,59 @@
+resource "tls_private_key" "example" {
+  algorithm = "ECDSA"
+  rsa_bits = "4096"
+}
+
+resource "tls_cert_request" "example" {
+  key_algorithm   = "ECDSA"
+  private_key_pem = tls_private_key.example.private_key_pem
+
+  subject {
+    common_name  = var.example_user
+    organization = var.example_org
+  }
+}
+
+resource "kubernetes_certificate_signing_request" "example" {
+  metadata {
+    name = "example"
+  }
+  spec {
+    request = tls_cert_request.example.cert_request_pem
+    usages = ["client auth", "server auth"]
+  }
+  auto_approve = true
+}
+
+resource "kubernetes_secret" "example" {
+  metadata {
+    name = "test-secret"
+  }
+  data = {
+    "tls.crt" = kubernetes_certificate_signing_request.example.certificate
+    "tls.key" = tls_private_key.example.private_key_pem
+  }
+  type = "kubernetes.io/tls"
+}
+
+resource "kubernetes_pod" "main" {
+  metadata {
+    name = "test-pod"
+  }
+  spec {
+    container {
+      name = "default"
+      image = "alpine:latest"
+      command = ["cat", "/etc/test/tls.crt"]
+      volume_mount {
+        mount_path = "/etc/test"
+        name = "secretvol"
+      }
+    }
+    volume {
+      name = "secretvol"
+      secret {
+        secret_name = kubernetes_secret.example.metadata[0].name
+      }
+    }
+  }
+}

--- a/_examples/certificate-signing-request/variables.tf
+++ b/_examples/certificate-signing-request/variables.tf
@@ -1,0 +1,7 @@
+variable example_user {
+        default = "admin"
+}
+
+variable example_org {
+        default = "example cluster"
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -151,6 +151,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"kubernetes_api_service":                      resourceKubernetesAPIService(),
+			"kubernetes_certificate_signing_request":      resourceKubernetesCertificateSigningRequest(),
 			"kubernetes_cluster_role":                     resourceKubernetesClusterRole(),
 			"kubernetes_cluster_role_binding":             resourceKubernetesClusterRoleBinding(),
 			"kubernetes_config_map":                       resourceKubernetesConfigMap(),

--- a/kubernetes/resource_kubernetes_certificate_signing_request.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request.go
@@ -1,0 +1,200 @@
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"log"
+	"reflect"
+	"time"
+)
+
+func resourceKubernetesCertificateSigningRequest() *schema.Resource {
+	apiDoc := v1beta1.CertificateSigningRequest{}.SwaggerDoc()
+	apiDocSpec := v1beta1.CertificateSigningRequestSpec{}.SwaggerDoc()
+	apiDocStatus := v1beta1.CertificateSigningRequestStatus{}.SwaggerDoc()
+
+	return &schema.Resource{
+		Create: resourceKubernetesCertificateSigningRequestCreate,
+		Read:   resourceKubernetesCertificateSigningRequestRead,
+		Delete: resourceKubernetesCertificateSigningRequestDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"auto_approve": {
+				Type:        schema.TypeBool,
+				Description: "Automatically approve the CertificateSigningRequest",
+				Optional:    true,
+				ForceNew:    true,
+				Default:     true,
+			},
+			"certificate": {
+				Type:        schema.TypeString,
+				Description: apiDocStatus["certificate"],
+				Computed:    true,
+			},
+			"metadata": metadataSchemaForceNew(metadataSchema("certificate signing request", true)),
+			"spec": {
+				ForceNew:    true,
+				Type:        schema.TypeList,
+				Description: apiDoc[""],
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"request": {
+							Type:        schema.TypeString,
+							Description: apiDocSpec["request"],
+							Required:    true,
+							ForceNew:    true,
+						},
+						"signer_name": {
+							Type: schema.TypeString,
+							// no swagger doc available for signerName
+							Description: "Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`." +
+								"If empty, it will be defaulted: 1. If it's a kubelet client certificate, it is assigned `kubernetes.io/kube-apiserver-client-kubelet`." +
+								"2. If it's a kubelet serving certificate, it is assigned `kubernetes.io/kubelet-serving`." +
+								"3. Otherwise, it is assigned `kubernetes.io/legacy-unknown`. Distribution of trust for signers happens out of band." +
+								"You can select on this field using `spec.signerName`.",
+							Optional: true,
+							ForceNew: true,
+						},
+						"usages": {
+							Type:        schema.TypeSet,
+							Description: apiDocSpec["usages"],
+							Set:         schema.HashString,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceKubernetesCertificateSigningRequestCreate(d *schema.ResourceData, meta interface{}) error {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec, err := expandCertificateSigningRequestSpec(d.Get("spec").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	csr := v1beta1.CertificateSigningRequest{
+		ObjectMeta: metadata,
+		Spec:       *spec,
+	}
+	log.Printf("[INFO] Creating new certificate signing request: %#v", csr)
+	newCSR, createErr := conn.CertificatesV1beta1().CertificateSigningRequests().Create(&csr)
+	if createErr != nil {
+		return fmt.Errorf("Failed to create certificate signing request: %s", err)
+	}
+
+	// Get the name, since it might have been randomly generated during create.
+	csrName := newCSR.ObjectMeta.Name
+
+	// Delete the remote CSR resource when this function exits, or when errors are encountered.
+	defer conn.CertificatesV1beta1().CertificateSigningRequests().Delete(csrName, &metav1.DeleteOptions{})
+
+	if d.Get("auto_approve").(bool) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			pendingCSR, getErr := conn.CertificatesV1beta1().CertificateSigningRequests().Get(csrName, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			approval := v1beta1.CertificateSigningRequestCondition{
+				Type:    "Approved",
+				Reason:  "TerraformAutoApprove",
+				Message: "This CSR was approved by Terraform auto_approve.",
+			}
+			pendingCSR.Status.Certificate = []byte{}
+			pendingCSR.Status.Conditions = append(pendingCSR.Status.Conditions, approval)
+			_, updateErr := conn.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(pendingCSR)
+			return updateErr
+		})
+		if retryErr != nil {
+			panic(fmt.Errorf("CSR auto-approve update failed: %v", retryErr))
+		}
+		fmt.Println("CSR auto-approve update succeeded")
+	}
+
+	log.Printf("[DEBUG] Waiting for certificate to be issued")
+	stateConf := &resource.StateChangeConf{
+		Target:  []string{"Issued"},
+		Pending: []string{"", "Approved"},
+		Timeout: d.Timeout(schema.TimeoutCreate),
+		Refresh: func() (interface{}, string, error) {
+			out, refreshErr := conn.CertificatesV1beta1().CertificateSigningRequests().Get(csrName, metav1.GetOptions{})
+			if refreshErr != nil {
+				log.Printf("[ERROR] Received error: %v", refreshErr)
+				return out, "Error", refreshErr
+			}
+			var csrStatus string
+			emptyStatus := v1beta1.CertificateSigningRequestStatus{}
+			emptyCSR := v1beta1.CertificateSigningRequest{}
+
+			// If the CSR is empty, check again later.
+			if reflect.DeepEqual(emptyCSR, out) {
+				return out, csrStatus, nil
+			}
+
+			// If the status is empty, check again later.
+			if reflect.DeepEqual(emptyStatus, out.Status) {
+				return out, csrStatus, nil
+			}
+
+			// Check to see if a certificate has been issued, and update status accordingly,
+			// since 'Issued' is not a state ever populated in the Status Conditions.
+			for _, condition := range out.Status.Conditions {
+				log.Printf("[DEBUG] Found Status.Condition.Type: %v", condition.Type)
+				if string(condition.Type) == "Approved" {
+					if string(out.Status.Certificate) != "" {
+						log.Printf("[DEBUG] Found non-empty Certificate field in Status")
+						csrStatus = "Issued"
+					}
+				}
+			}
+			log.Printf("[DEBUG] CertificateSigningRequest %s status received: %#v", csrName, csrStatus)
+			return out, csrStatus, nil
+		},
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Certificate issued for request: %s", csrName)
+
+	issued, err := conn.CertificatesV1beta1().CertificateSigningRequests().Get(csrName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(csrName)
+	d.Set("certificate", string(issued.Status.Certificate))
+
+	return resourceKubernetesCertificateSigningRequestRead(d, meta)
+}
+
+// resourceKubernetesCertificateSigningRequestRead does not return any data, because Read functions exist to
+// sync the local state with the remote state. Since this data is local-only, there is nothing to read.
+func resourceKubernetesCertificateSigningRequestRead(_ *schema.ResourceData, _ interface{}) error {
+	return nil
+}
+
+func resourceKubernetesCertificateSigningRequestDelete(d *schema.ResourceData, _ interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/kubernetes/resource_kubernetes_certificate_signing_request_test.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_test.go
@@ -1,0 +1,133 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAccKubernetesCertificateSigningRequest_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	usages := []string{"client auth"}
+	signerName := "kubernetes.io/legacy-unknown"
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_certificate_signing_request.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesCertificateSigningRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCertificateSigningRequestConfig_basic(name, signerName, usages, true),
+				Check:  testAccCheckKubernetesCertificateSigningRequestValid,
+			},
+		},
+	})
+}
+
+func TestAccKubernetesCertificateSigningRequest_generateName(t *testing.T) {
+	generateName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_certificate_signing_request.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesCertificateSigningRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCertificateSigningRequestConfig_generateName(generateName),
+				Check:  testAccCheckKubernetesCertificateSigningRequestValid,
+			},
+		},
+	})
+}
+
+// testAccCheckKubernetesCertificateSigningRequestValid checks to see that the locally-stored certificate
+// contains a valid PEM preamble. It also checks that the CSR resource has been deleted from Kubernetes, since
+// the CSR is only supposed to exist momentarily as the certificate is generated. (CSR resources are ephemeral
+// in Kubernetes and therefore are only used temporarily).
+func testAccCheckKubernetesCertificateSigningRequestValid(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "kubernetes_certificate_signing_request" {
+			if !strings.HasPrefix(rs.Primary.Attributes["certificate"], "-----BEGIN CERTIFICATE----") {
+				return fmt.Errorf("certificate is missing cert PEM preamble from resource: %s", rs.Primary.ID)
+			}
+		}
+	}
+	return testAccCheckKubernetesCertificateSigningRequestRemoteResourceDeleted(s)
+}
+
+func testAccCheckKubernetesCertificateSigningRequestRemoteResourceDeleted(s *terraform.State) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kubernetes_certificate_signing_request" {
+			continue
+		}
+
+		out, err := conn.CertificatesV1beta1().CertificateSigningRequests().Get(rs.Primary.ID, metav1.GetOptions{})
+		if err == nil {
+			if out.Name == rs.Primary.ID {
+				return fmt.Errorf("CertificateSigningRequest still exists in Kubernetes: %s", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckKubernetesCertificateSigningRequestDestroy(s *terraform.State) error {
+	return testAccCheckKubernetesCertificateSigningRequestRemoteResourceDeleted(s)
+}
+
+func testAccKubernetesCertificateSigningRequestConfig_basic(name, signerName string, usages []string, autoApprove bool) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_certificate_signing_request" "test" {
+  metadata {
+    name = "%s"
+  }
+  auto_approve = %t
+  spec {
+    request = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
+YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
+ImigHcF787djpF2QDbz3oQ3QsM/I7ftdjB/HHlG2a5YpqjzT0KAAMAoGCCqGSM49
+BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
+DpNPvh30e0Js8/DYn2YUfu/pQU19
+-----END CERTIFICATE REQUEST-----
+EOT
+    signer_name = "%s"
+    usages = %q
+  }
+}
+`, name, autoApprove, signerName, usages)
+}
+
+func testAccKubernetesCertificateSigningRequestConfig_generateName(generateName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_certificate_signing_request" "test" {
+  metadata {
+    generate_name = "%s"
+  }
+  auto_approve = true
+  spec {
+    request = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
+YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
+ImigHcF787djpF2QDbz3oQ3QsM/I7ftdjB/HHlG2a5YpqjzT0KAAMAoGCCqGSM49
+BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
+DpNPvh30e0Js8/DYn2YUfu/pQU19
+-----END CERTIFICATE REQUEST-----
+EOT
+    signer_name = "kubernetes.io/legacy-unknown"
+    usages = ["client auth"]
+  }
+}
+`, generateName)
+}

--- a/kubernetes/schema_metadata.go
+++ b/kubernetes/schema_metadata.go
@@ -79,6 +79,11 @@ func metadataSchema(objectName string, generatableName bool) *schema.Schema {
 	}
 }
 
+func metadataSchemaForceNew(s *schema.Schema) *schema.Schema {
+	s.ForceNew = true
+	return s
+}
+
 func namespacedMetadataSchema(objectName string, generatableName bool) *schema.Schema {
 	return namespacedMetadataSchemaIsTemplate(objectName, generatableName, false)
 }

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -190,10 +190,6 @@ func ptrToString(s string) *string {
 	return &s
 }
 
-func ptrToInt(i int) *int {
-	return &i
-}
-
 func ptrToBool(b bool) *bool {
 	return &b
 }
@@ -218,7 +214,7 @@ func base64EncodeStringMap(m map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	for k, v := range m {
 		value := v.(string)
-		result[k] = (base64.StdEncoding.EncodeToString([]byte(value)))
+		result[k] = base64.StdEncoding.EncodeToString([]byte(value))
 	}
 	return result
 }

--- a/kubernetes/structures_certificate_signing_request.go
+++ b/kubernetes/structures_certificate_signing_request.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"k8s.io/api/certificates/v1beta1"
+)
+
+func expandCertificateSigningRequestSpec(csr []interface{}) (*v1beta1.CertificateSigningRequestSpec, error) {
+	obj := &v1beta1.CertificateSigningRequestSpec{}
+	if len(csr) == 0 || csr[0] == nil {
+		return obj, nil
+	}
+	in := csr[0].(map[string]interface{})
+	obj.Request = []byte(in["request"].(string))
+	if v, ok := in["usages"].(*schema.Set); ok && v.Len() > 0 {
+		obj.Usages = expandCertificateSigningRequestUsages(v.List())
+	}
+	return obj, nil
+}
+
+func expandCertificateSigningRequestUsages(s []interface{}) []v1beta1.KeyUsage {
+	out := make([]v1beta1.KeyUsage, len(s), len(s))
+	for i, v := range s {
+		out[i] = v1beta1.KeyUsage(v.(string))
+	}
+	return out
+}

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -181,25 +181,6 @@ func validatePositiveInteger(value interface{}, key string) (ws []string, es []e
 	return
 }
 
-func validateDNSPolicy(value interface{}, key string) (ws []string, es []error) {
-	v := value.(string)
-	if v != "ClusterFirst" && v != "Default" {
-		es = append(es, fmt.Errorf("%s must be either ClusterFirst or Default", key))
-	}
-	return
-}
-
-func validateRestartPolicy(value interface{}, key string) (ws []string, es []error) {
-	v := value.(string)
-	switch v {
-	case "Always", "OnFailure", "Never":
-		return
-	default:
-		es = append(es, fmt.Errorf("%s must be one of Always, OnFailure or Never ", key))
-	}
-	return
-}
-
 func validateTerminationGracePeriodSeconds(value interface{}, key string) (ws []string, es []error) {
 	v := value.(int)
 	if v < 0 {

--- a/website/docs/r/certificate_signing_request.html.markdown
+++ b/website/docs/r/certificate_signing_request.html.markdown
@@ -1,0 +1,91 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_certificate_signing_request"
+sidebar_current: "docs-kubernetes-resource-certificate-signing-request"
+description: |-
+  Use this resource to generate TLS certificates using Kubernetes.
+---
+
+# kubernetes_certificate_signing_request
+
+Use this resource to generate TLS certificates using Kubernetes.
+
+This is a *logical resource*, so it contributes only to the current Terraform state and does not persist any external managed resources.
+
+This resource enables automation of [X.509](https://www.itu.int/rec/T-REC-X.509) credential provisioning (including TLS/SSL certificates). It does this by creating a CertificateSigningRequest using the Kubernetes API, which generates a certificate from the Certificate Authority (CA) configured in the Kubernetes cluster. The CSR can be approved automatically by Terraform, or it can be approved by a custom controller running in Kubernetes. See [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for all available options pertaining to CertificateSigningRequests.
+
+## Example Usage
+
+```hcl
+resource "kubernetes_certificate_signing_request" "example" {
+  metadata {
+    name = "example"
+  }
+  auto_approve = true
+  spec {
+    usages = ["client auth", "server auth"]
+    request = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
+YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
+ImigHcF787djpF2QDbz3oQ3QsM/I7ftdjB/HHlG2a5YpqjzT0KAAMAoGCCqGSM49
+BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
+DpNPvh30e0Js8/DYn2YUfu/pQU19
+-----END CERTIFICATE REQUEST-----
+EOT
+￼   }
+￼ }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auto_approve` - (Optional) Automatically approve the CertificateSigningRequest. Defaults to 'true'.
+* `metadata` - (Required) Standard certificate signing request's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+* `spec` - (Required) Spec defines the specification of the desired behavior of the deployment. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the certificate signing request that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the certificate signing request. May match selectors of replication controllers and services.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `name` - (Optional) Name of the certificate signing request, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this certificate signing request that can be used by clients to determine when certificate signing request has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
+* `self_link` - A URL representing this certificate signing request.
+* `uid` - The unique in time and space value for this certificate signing request. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+### `spec`
+
+#### Arguments
+
+* `request` - (Required) Base64-encoded PKCS#10 CSR data.
+* `signer_name` - (Optional) Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`. If empty, it will be defaulted: 1. If it's a kubelet client certificate, it is assigned "kubernetes.io/kube-apiserver-client-kubelet". 2. If it's a kubelet serving certificate, it is assigned "kubernetes.io/kubelet-serving". 3. Otherwise, it is assigned "kubernetes.io/legacy-unknown". Distribution of trust for signers happens out of band.
+* `usages` - (Required) Specifies a set of usage contexts the key will be valid for. See https://godoc.org/k8s.io/api/certificates/v1beta1#KeyUsage
+
+## Generating a New Certificate
+
+Since the certificate is a logical resource that lives only in the Terraform state,
+it will persist until it is explicitly destroyed by the user.
+
+In order to force the generation of a new certificate within an existing state, the
+certificate instance can be "tainted":
+
+```
+terraform taint kubernetes_certificate_signing_request.example
+```
+
+A new certificate will then be generated on the next ``terraform apply``.

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -59,6 +59,9 @@
             <li<%= sidebar_current("docs-kubernetes-resource-cluster-role") %>>
               <a href="/docs/providers/kubernetes/r/cluster_role.html">kubernetes_cluster_role</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-certificate-signing-request") %>>
+              <a href="/docs/providers/kubernetes/r/certificate_signing_request.html">kubernetes_certificate_signing_request</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-resource-cluster-role-binding") %>>
               <a href="/docs/providers/kubernetes/r/cluster_role_binding.html">kubernetes_cluster_role_binding</a>
             </li>


### PR DESCRIPTION
### Description

This PR adds the `kubernetes_certificate_signing_request` resource to allow for automatic certificate generation within Kubernetes.

Example usage (I'll add more via examples/docs):

```
resource "kubernetes_certificate_signing_request" "example" {
  metadata {
    name = "example"
  }
  spec {
    request = tls_cert_request.example.cert_request_pem
    usages = ["client auth", "server auth"]
  }
  auto_approve = true # this can be set to false in case the user would prefer a custom controller approve the request
}
```

The resulting certificate is stored in Terraform state, making this resource a "logical resource" rather than persisting any objects in the Kubernetes API. The reason for this is that CSRs within Kubernetes are temporary objects that are [deleted by a garbage-collection controller](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#request-signing-process) usually within one hour. Since the most valuable part of the CertificateSigningRequest is the certificate itself, that is the only API-generated data that is kept persistently in this resource's state.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/447#issuecomment-656199305

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment