### PR TITLE
Feature - Allow empty string for storage class name

### DIFF
--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -79,7 +79,7 @@ func expandPersistentVolumeClaimSpec(l []interface{}) (*v1.PersistentVolumeClaim
 	if v, ok := in["volume_name"].(string); ok {
 		obj.VolumeName = v
 	}
-	if v, ok := in["storage_class_name"].(string); ok && v != "" {
+	if v, ok := in["storage_class_name"].(string); ok {
 		obj.StorageClassName = ptrToString(v)
 	}
 	return obj, nil


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Current implementation doesn't allow empty strings for storage_class_names when it should've been allowed

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

```
➜  kubernetes git:(feature/allow-empty-string-for-storage-class-name) go test
2020/07/20 10:56:33 [DEBUG] Trying to load configuration from file
2020/07/20 10:56:33 [DEBUG] Configuration file is: test-fixtures/kube-config.yaml
2020/07/20 10:56:33 [DEBUG] Using custom current context: "gcp"
2020/07/20 10:56:33 [DEBUG] Using overidden context: api.Context{LocationOfOrigin:"", Cluster:"", AuthInfo:"", Namespace:"", Extensions:map[string]runtime.Object(nil)}
2020/07/20 10:56:33 [INFO] Successfully initialized config
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	1.546s
```

### References
- https://github.com/hashicorp/terraform-provider-kubernetes/issues/872

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment