### PR TITLE
Extend isInternalKey to resolve #445 for cloud.google.com/neg-status and others

### DIFF
--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -162,6 +162,14 @@ func isInternalKey(annotationKey string) bool {
 		return true
 	}
 
+        if err == nil && strings.HasSuffix(u.Hostname(), "cloud.google.com") {
+                return true
+        }
+
+        if err == nil && strings.HasSuffix(u.Hostname(), "keel.sh") {
+                return true
+        }
+
 	// Specific to DaemonSet annotations, generated & controlled by the server.
 	if strings.Contains(annotationKey, "deprecated.daemonset.template.generation") {
 		return true


### PR DESCRIPTION
### Description
This adds cloud.google.com and keel.sh to the isInternalKey list, by default ignoring them unless specifically declared in your HCL labels or annotations.

Justification:
* lifecycle ignore_changes requires setting the value for a particular metadata annotation in Terraform HCL prior to ignore_changes working. You can set this value to anything, or an empty string, so long as an external operator does not remove it. If an external operator does remove this annotation, Terraform will persistently re-add the annotation because of the way lifecycle ignore_changes is evaluated.

* Google, on July 17th 2020, made a fundamental change to the behavior of Services on cluster versions 1.17.6-gke.7+ that makes Network Endpoint Groups and the resulting annotations mandatory. cloud.google.com/neg will always be set to {ingress:true} in services deployed to these clusters. Furthermore, IF a NEG is not in use, such as a service of type ClusterIP with no ingress, or if the neg is set to ingress:false, the operator will persistently remove the cloud.google.com/neg-status annotation. This makes it impossible to lifecycle ignore_changes neg-status: Terraform will add it, as a requisite to ignore it, and the google operator will remove it. This results in a plan that always suggests updates.

It IS possible to remove the cloud.google.com/neg if it is not in use, but this results in a separate difficult situation: Two terraform runs are required to make the state match the cluster. The first to create the service, the second to remove the unnecessary NEG annotation. Since google is intending to make this the default configuration for all service deployments, this will ultimately become a problem for all GKE users utilizing this provider.

* Finally, we like many others use a wrapper module around the kubernetes_service resource to simplify the use of the resource. It's presently not possible to programmatically turn on or off any value in lifecycle { ignore_changes = [] }. This is a low level terraform problem revolving around evaluation order. No variables or substitution of any kind can be done in ignore_changes. This means there's no way to toggle this functionality on or off if you are using a NEG or not, and if you are not using a NEG, setting neg-status to "" to cover those cases when you are using a NEG results in the same loop above: GKE just removes the annotation, making terraform try to re-apply it endlessly.

Here's an example of the GKE behavior:
```
$ kubectl get service/prometheus-collector -o yaml | head -5
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2020-07-23T01:26:56Z"
  labels:
$ kubectl patch service prometheus-collector -p '{"metadata": { "annotations": {"cloud.google.com/testing": "test"} }}'
service/prometheus-collector patched
$ kubectl get service/prometheus-collector -o yaml | head -7
apiVersion: v1
kind: Service
metadata:
  annotations:
    cloud.google.com/testing: test
  creationTimestamp: "2020-07-23T01:26:56Z"
  labels:
$ kubectl patch service prometheus-collector -p '{"metadata": { "annotations": {"cloud.google.com/neg-status": ""} }}'
service/prometheus-collector patched
$ kubectl get service/prometheus-collector -o yaml | head -8
apiVersion: v1
kind: Service
metadata:
  annotations:
    cloud.google.com/testing: test
  creationTimestamp: "2020-07-23T01:26:56Z"
  labels:
    app: prometheus-collector

```

It would be ideal if the provider was configurable to make isInternalKey reference a list of annotation suffixes to ignore, but that does not presently appear possible without a lot of hack and slash around the client code, beyond my capability.

Also open to any other solutions to this problem. keel.sh is in this list because it uses annotations in a similar way, though it does not suffer from this one-begets-another dependency cycle issue that Google has put upon us. Ultimately, it is my personal opinion that annotations are a low risk item that is safe to ignore by default unless you have specifically defined them in your HCL. However, that may be a bridge too far for some people. I do forsee that in the near future, as CRDs and Operators become universal to every cluster, that this list would only grow and these edge cases become more difficult to manage around. Some better functionality here would be appreciated. Again, beyond my capabilities.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

https://cloud.google.com/kubernetes-engine/docs/release-notes#july_17_2020

https://github.com/hashicorp/terraform-provider-kubernetes/issues/445#issue-443975800

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment