### PR TITLE
fix resource_kubernetes_pod_security_policy host_ports

### DIFF
--- a/kubernetes/resource_kubernetes_pod_security_policy_test.go
+++ b/kubernetes/resource_kubernetes_pod_security_policy_test.go
@@ -278,6 +278,11 @@ resource "kubernetes_pod_security_policy" "test" {
 		max = 65535
 	  }
     }
+
+    host_ports {
+      min = 0
+      max = 65535
+    }
     
     read_only_root_filesystem = true
   }

--- a/kubernetes/structure_pod_security_policy_spec.go
+++ b/kubernetes/structure_pod_security_policy_spec.go
@@ -149,8 +149,8 @@ func flattenHostPortRangeSlice(in []v1beta1.HostPortRange) []interface{} {
 
 	for k, v := range in {
 		result[k] = map[string]interface{}{
-			"min": v.Min,
-			"max": v.Max,
+			"min": int(v.Min),
+			"max": int(v.Max),
 		}
 	}
 
@@ -383,8 +383,8 @@ func expandHostPortRangeSlice(in []interface{}) []v1beta1.HostPortRange {
 	for k, v := range in {
 		if m, ok := v.(map[string]interface{}); ok {
 			result[k] = v1beta1.HostPortRange{
-				Min: m["min"].(int32),
-				Max: m["max"].(int32),
+				Min: int32(m["min"].(int)),
+				Max: int32(m["max"].(int)),
 			}
 		}
 	}


### PR DESCRIPTION
### Description

Fix terraform crash when creating the kubernetes_pod_security_policy resource with host_ports attribute.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Test log: https://gist.github.com/Filirom1/1ed5ab68a115c96b423990c270ae614c

### References

Fix https://github.com/hashicorp/terraform-provider-kubernetes/issues/931 

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment