### PR TITLE
Modify provider to support multiple paths in `KUBECONFIG`.

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -54,6 +54,21 @@ func TestProvider_configure(t *testing.T) {
 	}
 }
 
+func TestProvider_configure_multiple_kubeconfig(t *testing.T) {
+	resetEnv := unsetEnv(t)
+	defer resetEnv()
+
+	os.Setenv("KUBECONFIG", "test-fixtures/kube-config.yaml:test-fixtures/kube-config-dummy.yaml")
+	os.Setenv("KUBE_CTX", "dummy")
+
+	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
+	p := Provider()
+	err := p.Configure(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func unsetEnv(t *testing.T) func() {
 	e := getEnv()
 

--- a/kubernetes/test-fixtures/kube-config-dummy.yaml
+++ b/kubernetes/test-fixtures/kube-config-dummy.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: ZHVtbXk=
+    server: https://127.0.0.1
+  name: default
+
+contexts:
+- context:
+    cluster: default
+    user: dummy
+  name: dummy
+
+users:
+- name: dummy
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: dummy


### PR DESCRIPTION
### Description
Support multiple paths in `KUBECONFIG`. There have been a couple of [other](https://github.com/hashicorp/terraform-provider-kubernetes/issues/647
) [issues](https://github.com/hashicorp/terraform-provider-helm/issues/98
) and a [previous PR](https://github.com/hashicorp/terraform-provider-kubernetes/pull/511) opened for this support.
### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)
With the caveat that the test only `WARN`s instead of `FAIL`s due to https://github.com/hashicorp/terraform-provider-kubernetes/blob/eb1f0d56787045f4012818c2d9d42e9d053807b0/kubernetes/provider.go#L371

Modifying this to return the error results in:
```
$ go test -v -run TestProvider_configure_multiple_kubeconfig
=== RUN   TestProvider_configure_multiple_kubeconfig
2020/08/12 03:43:52 [DEBUG] Trying to load configuration from file
2020/08/12 03:43:52 [DEBUG] Configuration file is: test-fixtures/kube-config.yaml:test-fixtures/kube-config-dummy.yaml
2020/08/12 03:43:52 [DEBUG] Using custom current context: "dummy"
2020/08/12 03:43:52 [DEBUG] Using overidden context: api.Context{LocationOfOrigin:"", Cluster:"", AuthInfo:"", Namespace:"", Extensions:map[string]runtime.Object(nil)}
2020/08/12 03:43:52 [WARN] Invalid provider configuration was supplied. Provider operations likely to fail: stat test-fixtures/kube-config.yaml:test-fixtures/kube-config-dummy.yaml: no such file or directory
    provider_test.go:68: stat test-fixtures/kube-config.yaml:test-fixtures/kube-config-dummy.yaml: no such file or directory
--- FAIL: TestProvider_configure_multiple_kubeconfig (0.00s)
FAIL
```
### References
https://github.com/hashicorp/terraform-provider-kubernetes/issues/104
https://github.com/hashicorp/terraform-provider-kubernetes/pull/511
https://github.com/hashicorp/terraform-provider-kubernetes/issues/647
https://github.com/hashicorp/terraform-provider-helm/issues/98
https://github.com/kubernetes/kubernetes/blob/9ad74781c756fa2d9c4b328f594a933774bd5ef6/staging/src/k8s.io/client-go/tools/clientcmd/loader.go#L141-L161
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment