### PR TITLE
Allow in-place update of PVC's storage request

### DIFF
--- a/kubernetes/schema_persistent_volume_claim.go
+++ b/kubernetes/schema_persistent_volume_claim.go
@@ -12,7 +12,6 @@ func persistentVolumeClaimFields() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims",
 			Required:    true,
-			ForceNew:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: persistentVolumeClaimSpecFields(),
@@ -42,7 +41,6 @@ func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "A list of the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources",
 			Required:    true,
-			ForceNew:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -52,11 +50,11 @@ func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
 						Optional:    true,
 						ForceNew:    true,
 					},
+					// This is the only field the API will allow modifying in-place, so ForceNew is not used.
 					"requests": {
 						Type:        schema.TypeMap,
 						Description: "Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
 						Optional:    true,
-						ForceNew:    true,
 					},
 				},
 			},

--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -39,7 +39,7 @@ func flattenResourceRequirements(in v1.ResourceRequirements) []interface{} {
 
 // Expanders
 
-func expandPersistenVolumeClaim(p map[string]interface{}) (*corev1.PersistentVolumeClaim, error) {
+func expandPersistentVolumeClaim(p map[string]interface{}) (*corev1.PersistentVolumeClaim, error) {
 	pvc := &corev1.PersistentVolumeClaim{}
 	if len(p) == 0 {
 		return pvc, nil

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -60,7 +60,7 @@ func expandStatefulSetSpec(s []interface{}) (*v1.StatefulSetSpec, error) {
 			return obj, nil
 		}
 		for _, pvc := range v {
-			p, err := expandPersistenVolumeClaim(pvc.(map[string]interface{}))
+			p, err := expandPersistentVolumeClaim(pvc.(map[string]interface{}))
 			if err != nil {
 				return obj, err
 			}


### PR DESCRIPTION
### Description

The Kubernetes API allows in-place updates of a PVC's `spec.resources.requests.storage` field.
This commit updates the PVC resource to allow the same.

A PVC's storage request may increase in-place, but the API does not allow it to decrease in place.
Therefore, the provider will recreate the PVC in the case that `requests.storage` decreases.
This will shield the user from this specific Kubernetes API error:

```
spec.resources.requests.storage: field can not be less than previous value
```

...And it provides an additional convenience by handling the delete/re-create automatically.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/602

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment