### PR TITLE
Fix url attribute in admissionregistration client_config.service block

### DIFF
--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_test.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_test.go
@@ -72,10 +72,8 @@ func TestAccKubernetesMutatingWebhookConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.admission_review_versions.0", "v1"),
 					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.admission_review_versions.1", "v1beta1"),
 					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.0.service.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.0.service.0.name", "example-service"),
-					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.0.service.0.namespace", "example-namespace"),
-					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.0.service.0.port", "443"),
+					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.0.service.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.client_config.0.url", "https://test"),
 					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.failure_policy", "Ignore"),
 					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.match_policy", "Exact"),
 					resource.TestCheckResourceAttr("kubernetes_mutating_webhook_configuration.test", "webhook.0.name", name),
@@ -254,12 +252,7 @@ resource "kubernetes_mutating_webhook_configuration" "test" {
 		]
 
 		client_config {
-			service {
-				namespace = "example-namespace"
-				name = "example-service"
-			}
-
-			ca_bundle = "test"
+			url = "https://test"
 		}
 
 		rule {

--- a/kubernetes/schema_webhook_client_config.go
+++ b/kubernetes/schema_webhook_client_config.go
@@ -57,24 +57,24 @@ func webhookClientConfigFields() map[string]*schema.Schema {
 			Description: apiDoc["url"],
 			Optional:    true,
 			ValidateFunc: func(v interface{}, k string) ([]string, []error) {
-				url, err := url.Parse(v.(string))
+				u, err := url.Parse(v.(string))
 				if err != nil {
 					return nil, []error{err}
 				}
 
-				if url.Scheme != "https" {
+				if u.Scheme != "https" {
 					return nil, []error{errors.New("url: scheme must be https")}
 				}
 
-				if url.Host == "" {
+				if u.Host == "" {
 					return nil, []error{errors.New("url: host must be provided")}
 				}
 
-				if url.User != nil {
+				if u.User != nil {
 					return nil, []error{errors.New("url: user info is not permitted")}
 				}
 
-				if url.Fragment != "" || url.RawQuery != "" {
+				if u.Fragment != "" || u.RawQuery != "" {
 					return nil, []error{errors.New("url: fragments and query parameters are not permitted")}
 				}
 

--- a/kubernetes/schema_webhook_client_config.go
+++ b/kubernetes/schema_webhook_client_config.go
@@ -62,23 +62,25 @@ func webhookClientConfigFields() map[string]*schema.Schema {
 					return nil, []error{err}
 				}
 
+				errs := []error{}
+
 				if u.Scheme != "https" {
-					return nil, []error{errors.New("url: scheme must be https")}
+					errs = append(errs, errors.New("url: scheme must be https"))
 				}
 
 				if u.Host == "" {
-					return nil, []error{errors.New("url: host must be provided")}
+					errs = append(errs, errors.New("url: host must be provided"))
 				}
 
 				if u.User != nil {
-					return nil, []error{errors.New("url: user info is not permitted")}
+					errs = append(errs, errors.New("url: user info is not permitted"))
 				}
 
 				if u.Fragment != "" || u.RawQuery != "" {
-					return nil, []error{errors.New("url: fragments and query parameters are not permitted")}
+					errs = append(errs, errors.New("url: fragments and query parameters are not permitted"))
 				}
 
-				return nil, nil
+				return nil, errs
 			},
 		},
 	}

--- a/kubernetes/structures_admissionregistration.go
+++ b/kubernetes/structures_admissionregistration.go
@@ -80,7 +80,7 @@ func expandWebhookClientConfig(l []interface{}) admissionregistrationv1.WebhookC
 		obj.CABundle = []byte(v)
 	}
 
-	if v, ok := in["service"].([]interface{}); ok {
+	if v, ok := in["service"].([]interface{}); ok && len(v) > 0 {
 		obj.Service = expandServiceReference(v)
 	}
 


### PR DESCRIPTION
### Description

Fixes #882 

The problem here was that we weren't checking list length before expanding the service block. I have update the acceptance test to capture this case. I also noticed that the API does some validation on the URL, so I have added that to the schema too.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment