### PR TITLE
Fix crash when deferencing nil pointer in v1beta1.IngressRule

### DIFF
--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -10,29 +10,34 @@ import (
 
 func flattenIngressRule(in []v1beta1.IngressRule) []interface{} {
 	att := make([]interface{}, len(in), len(in))
-	for i, n := range in {
-		// rulePrefix := fmt.Sprintf("rule.%d.")
+	for i, r := range in {
 		m := make(map[string]interface{})
 
-		m["host"] = n.Host
-
-		httpAtt := make(map[string]interface{})
-		pathAtts := make([]interface{}, len(n.HTTP.Paths), len(n.HTTP.Paths))
-		for i, p := range n.HTTP.Paths {
-			path := map[string]interface{}{
-				"path":    p.Path,
-				"backend": flattenIngressBackend(&p.Backend),
-			}
-			pathAtts[i] = path
-		}
-		httpAtt["path"] = pathAtts
-		m["http"] = []interface{}{
-			httpAtt,
-		}
-
+		m["host"] = r.Host
+		m["http"] = flattenIngressRuleHttp(r.HTTP)
 		att[i] = m
 	}
 	return att
+}
+
+func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
+	if in == nil {
+		return []interface{}{}
+	}
+	pathAtts := make([]interface{}, len(in.Paths), len(in.Paths))
+	for i, p := range in.Paths {
+		path := map[string]interface{}{
+			"path":    p.Path,
+			"backend": flattenIngressBackend(&p.Backend),
+		}
+		pathAtts[i] = path
+	}
+
+	httpAtt := map[string]interface{}{
+		"path": pathAtts,
+	}
+
+	return []interface{}{httpAtt}
 }
 
 func flattenIngressBackend(in *v1beta1.IngressBackend) []interface{} {

--- a/kubernetes/structure_ingress_spec_test.go
+++ b/kubernetes/structure_ingress_spec_test.go
@@ -1,0 +1,78 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Test Flatteners
+func TestFlattenIngressRule(t *testing.T) {
+	r := v1beta1.HTTPIngressRuleValue{
+		Paths: []v1beta1.HTTPIngressPath{
+			{
+				Path: "/foo/bar",
+				Backend: v1beta1.IngressBackend{
+					ServiceName: "foo",
+					ServicePort: intstr.FromInt(1234),
+				},
+			},
+		},
+	}
+
+	in := []v1beta1.IngressRule{
+		{
+			Host: "the-app-name.staging.live.domain-replaced.tld",
+			IngressRuleValue: v1beta1.IngressRuleValue{
+				HTTP: (*v1beta1.HTTPIngressRuleValue)(nil),
+			},
+		},
+		{
+			Host: "",
+			IngressRuleValue: v1beta1.IngressRuleValue{
+				HTTP: (*v1beta1.HTTPIngressRuleValue)(&r),
+			},
+		},
+	}
+	out := []interface{}{
+		map[string]interface{}{
+			"host": "the-app-name.staging.live.domain-replaced.tld",
+			"http": []interface{}{},
+		},
+		map[string]interface{}{
+			"host": "",
+			"http": []interface{}{
+				map[string]interface{}{
+					"path": []interface{}{
+						map[string]interface{}{
+							"path": "/foo/bar",
+							"backend": []interface{}{
+								map[string]interface{}{
+									"service_name": "foo",
+									"service_port": "1234",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	flatRules := flattenIngressRule(in)
+
+	if len(flatRules) < len(out) {
+		t.Error("Failed to flatten ingress rules")
+	}
+
+	for i, v := range flatRules {
+		control := v.(map[string]interface{})
+		sample := out[i]
+
+		if !reflect.DeepEqual(control, sample) {
+			t.Errorf("Unexpected result:\n\tWant:%s\n\tGot:%s\n", control, sample)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/966

In `v1beta1.IngressRule` the `HTTP` attribute is a pointer type and this implies it potentially can be `nil`.
Before this change, the `flattenIngressRule` function was assuming this will never be the case.
Issue #966 demonstrates that `HTTP` can actually be null (see attached debug log). 

This change address the potential for `nil` values.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment