### PR TITLE
Fix failing test for data source kubernetes_service

### DIFF
--- a/kubernetes/data_source_kubernetes_service.go
+++ b/kubernetes/data_source_kubernetes_service.go
@@ -111,6 +111,11 @@ func dataSourceKubernetesService() *schema.Resource {
 							Description: "Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. More info: http://kubernetes.io/docs/user-guide/services#overview",
 							Computed:    true,
 						},
+						"health_check_node_port": {
+							Type:        schema.TypeInt,
+							Description: "Specifies the Healthcheck NodePort for the service. Only effects when type is set to `LoadBalancer` and external_traffic_policy is set to `Local`.",
+							Computed:    true,
+						},
 					},
 				},
 			},

--- a/kubernetes/data_source_kubernetes_service_test.go
+++ b/kubernetes/data_source_kubernetes_service_test.go
@@ -33,6 +33,7 @@ func TestAccKubernetesDataSourceService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.target_port", "80"),
 					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.session_affinity", "None"),
 					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.type", "ClusterIP"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.health_check_node_port", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
### Description

Noticed the test for this data source was broken with the recent addition of the `health_check_node_port` attribute. This PR fixes the test.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment