### PR TITLE
Fix crash when SizeLimit is empty on EmptyDirVolumeSource

### DIFF
--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -412,8 +412,10 @@ func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 
 func flattenEmptyDirVolumeSource(in *v1.EmptyDirVolumeSource) []interface{} {
 	att := make(map[string]interface{})
-	att["medium"] = in.Medium
-	att["size_limit"] = in.SizeLimit.String()
+	att["medium"] = string(in.Medium)
+	if in.SizeLimit != nil {
+		att["size_limit"] = in.SizeLimit.String()
+	}
 	return []interface{}{att}
 }
 


### PR DESCRIPTION
### Description

When stringifying the `size_limit` in an `empty_dir` volume we were not checking if the quantity was actually set and getting a nil pointer panic. I have added the nil pointer check, and a regression test for this.

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/982

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "./kubernetes" -v -count=1 -run TestFlattenEmptyDirVolumeSource -timeout 120m
=== RUN   TestFlattenEmptyDirVolumeSource
--- PASS: TestFlattenEmptyDirVolumeSource (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	2.441s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix crash when size_limit is not present on empty_dir volume
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
