### PR TITLE
Fix empty_dir forced replacement

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -352,7 +352,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Computed:    true,
 			Description: "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes",
 			Deprecated:  deprecatedMessage,
-			Elem:        volumeSchema(),
+			Elem:        volumeSchema(isUpdatable),
 		},
 	}
 
@@ -373,7 +373,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 	return s
 }
 
-func volumeSchema() *schema.Resource {
+func volumeSchema(isUpdatable bool) *schema.Resource {
 	v := commonVolumeSources()
 
 	v["config_map"] = &schema.Schema{
@@ -551,14 +551,16 @@ func volumeSchema() *schema.Resource {
 					Description:  `What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir`,
 					Optional:     true,
 					Default:      "",
+					ForceNew:     !isUpdatable,
 					ValidateFunc: validateAttributeValueIsIn([]string{"", "Memory"}),
 				},
 				"size_limit": {
-					Type:        schema.TypeString,
-					Description: `Total amount of local storage required for this EmptyDir volume.`,
-					Optional:    true,
-					ForceNew:    true,
-					Default:     "0",
+					Type:             schema.TypeString,
+					Description:      `Total amount of local storage required for this EmptyDir volume.`,
+					Optional:         true,
+					ForceNew:         !isUpdatable,
+					ValidateFunc:     validateResourceQuantity,
+					DiffSuppressFunc: suppressEquivalentResourceQuantity,
 				},
 			},
 		},

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -940,7 +940,7 @@ func expandEmptyDirVolumeSource(l []interface{}) (*v1.EmptyDirVolumeSource, erro
 		Medium: v1.StorageMedium(in["medium"].(string)),
 	}
 
-	if v, ok := in["size_limit"].(string); ok {
+	if v, ok := in["size_limit"].(string); ok && v != "" {
 		s, err := resource.ParseQuantity(v)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse size_limit: %w", err)


### PR DESCRIPTION
### Description

Fixes #984 

There was a few issues with this code that are fixed in this PR:

1. The resource quantity was not being validated
2. Diff for `size_limit` was not being suppressed if resource quantities between the API and state were equivalent.
3. ForceNew should only be set if the resource is not updatable, i.e it's in a Pod not a Deployment, Daemonset, Statefulset
4. `size_limit` should default to empty, and the provider should just not send it rather than set it to `"0"`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "./kubernetes" -v -count=1 -run empty_dir_volume -timeout 120m
=== RUN   TestAccKubernetesDeployment_with_empty_dir_volume
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (20.28s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (20.32s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume_with_sizeLimit
--- PASS: TestAccKubernetesPod_with_empty_dir_volume_with_sizeLimit (19.10s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_empty_dir_volume
--- PASS: TestAccKubernetesReplicationController_deprecated_with_empty_dir_volume (9.58s)
=== RUN   TestAccKubernetesReplicationController_with_empty_dir_volume
--- PASS: TestAccKubernetesReplicationController_with_empty_dir_volume (9.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	82.107s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix spurious forced replacement when using empty_dir
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
