### PR TITLE
Typhoon configuration to allow selection of K8s version

### DIFF
--- a/kubernetes/test-infra/typhoon-aws/README.md
+++ b/kubernetes/test-infra/typhoon-aws/README.md
@@ -18,15 +18,15 @@ Example:
 ```export TF_VAR_base_domain=k8s.myself.com```
 ## Versions
 
-You can set the desired version of Kubernetes by editing the `main.tf` configuration file and replacing the version in the source URL of the `typhoon-acc` module.
-
+You can set the desired version of Kubernetes via the `kubernetes_version` Terraform variable. If unset it defaults to 
+version 1.18.
 Example:
 ```
-
-module "typhoon-acc" {
-  source = "git::https://github.com/poseidon/typhoon//aws/fedora-coreos/kubernetes?ref=v1.18.0" # set the desired Kubernetes version here
-...
+export TF_VAR_kubernetes_version=1.18
 ```
+
+This configuration is only compatible with Terraform 0.13 and up due to the use of the count-on-module feature which is not available in earlier versions.
+
 ## Worker node count and instance type
 
 You can control the amount of worker nodes in the cluster as well as their machine type, using the following variables:

--- a/kubernetes/test-infra/typhoon-aws/main.tf
+++ b/kubernetes/test-infra/typhoon-aws/main.tf
@@ -26,28 +26,3 @@ resource "null_resource" "ssh-key" {
 data "aws_route53_zone" "typhoon-acc" {
   name = var.base_domain
 }
-
-module "typhoon-acc" {
-  source = "git::https://github.com/poseidon/typhoon//aws/fedora-coreos/kubernetes?ref=v1.18.0" # set the desired Kubernetes version here
-
-  cluster_name = var.cluster_name
-  dns_zone     = var.base_domain
-  dns_zone_id  = data.aws_route53_zone.typhoon-acc.zone_id
-
-  # node configuration
-  ssh_authorized_key = tls_private_key.typhoon-acc.public_key_openssh
-
-  worker_count = var.worker_count
-  controller_count = var.controller_count
-  worker_type  = var.controller_type
-  controller_type = var.worker_type
-}
-
-resource "local_file" "typhoon-acc" {
-  content  = module.typhoon-acc.kubeconfig-admin
-  filename = "kubeconfig"
-}
-
-output "kubeconfig_path" {
-  value = "${path.cwd}/${local_file.typhoon-acc.filename}"
-}

--- a/kubernetes/test-infra/typhoon-aws/module_1_18.tf
+++ b/kubernetes/test-infra/typhoon-aws/module_1_18.tf
@@ -1,0 +1,32 @@
+locals {
+    # This local gets a value of 1 when the 'kubernetes_version' input variable requests a 1.18.x version, otherwise it is 0.
+    # It's used to enable the module and resources specific to 1.18.x as a workaround for not being able 
+    # to interpolate variables in the 'source' attribute of a module block.
+    #
+    enabled_1_18 = length(regexall("v?1.18.?[0-9]{0,2}", var.kubernetes_version))
+}
+
+# This module builds a 1.19.x Typhoon cluster. It is mutually exlusive to the 1.18.x module.
+#
+module "typhoon-acc-1_18" {
+  count = local.enabled_1_18
+  source = "git::https://github.com/poseidon/typhoon//aws/fedora-coreos/kubernetes?ref=v1.18.8"
+
+  cluster_name = var.cluster_name
+  dns_zone     = var.base_domain
+  dns_zone_id  = data.aws_route53_zone.typhoon-acc.zone_id
+
+  # node configuration
+  ssh_authorized_key = tls_private_key.typhoon-acc.public_key_openssh
+
+  worker_count = var.worker_count
+  controller_count = var.controller_count
+  worker_type  = var.controller_type
+  controller_type = var.worker_type
+}
+
+resource "local_file" "typhoon-acc_1_18" {
+  count = local.enabled_1_18
+  content  = module.typhoon-acc-1_18[0].kubeconfig-admin
+  filename = "kubeconfig"
+}

--- a/kubernetes/test-infra/typhoon-aws/module_1_19.tf
+++ b/kubernetes/test-infra/typhoon-aws/module_1_19.tf
@@ -1,0 +1,32 @@
+locals {
+    # This local gets a value of 1 when the 'kubernetes_version' input variable requests a 1.19.x version, otherwise it is 0.
+    # It's used to enable the module and resources specific to 1.19.x as a workaround for not being able 
+    # to interpolate variables in the 'source' attribute of a module block.
+    #
+    enabled_1_19 = length(regexall("v?1.19.?[0-9]{0,2}", var.kubernetes_version))
+}
+
+# This module builds a 1.19.x Typhoon cluster. It is mutually exlusive to the 1.18.x module.
+#
+module "typhoon-acc-1_19" {
+  count = local.enabled_1_19
+  source = "git::https://github.com/poseidon/typhoon//aws/fedora-coreos/kubernetes?ref=v1.19.0"
+
+  cluster_name = var.cluster_name
+  dns_zone     = var.base_domain
+  dns_zone_id  = data.aws_route53_zone.typhoon-acc.zone_id
+
+  # node configuration
+  ssh_authorized_key = tls_private_key.typhoon-acc.public_key_openssh
+
+  worker_count = var.worker_count
+  controller_count = var.controller_count
+  worker_type  = var.controller_type
+  controller_type = var.worker_type
+}
+
+resource "local_file" "typhoon-acc-1_19" {
+  count = local.enabled_1_19
+  content  = module.typhoon-acc-1_19[0].kubeconfig-admin
+  filename = "kubeconfig"
+}

--- a/kubernetes/test-infra/typhoon-aws/variables.tf
+++ b/kubernetes/test-infra/typhoon-aws/variables.tf
@@ -6,6 +6,11 @@ variable "cluster_name" {
   type = string
 }
 
+variable "kubernetes_version" {
+    type = string
+    default = "1.18.8"
+}
+
 variable "controller_count" {
   default = 1
 }

--- a/kubernetes/test-infra/typhoon-aws/versions.tf
+++ b/kubernetes/test-infra/typhoon-aws/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This updates the Typhoon configuration to allow for selecting the Kubernetes version (either 1.18.x or 1.19.x) to be deployed via the `kubernetes_version` input variable.

Some odd syntax and approximations were necessary due to the way Typhoon ties its releases to a specific Kubernetes version and also that Terraform doesn't allow variables to be interpolated in the `source` attribute of a module.

Also upgrades the configuration to be compatible with Terraform 0.13.x.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Typhoon-based test infra upgraded to TF 0.13 and allows Kubernetes version selection.
```

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
