### PR TITLE
Fix annotation diffs on affinity tests

### DIFF
--- a/kubernetes/resource_kubernetes_affinity_test.go
+++ b/kubernetes/resource_kubernetes_affinity_test.go
@@ -216,6 +216,9 @@ func TestAccKubernetesPod_with_pod_anti_affinity_with_preferred_during_schedulin
 
 func testAccKubernetesPodConfigWithNodeAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_pod" "test" {
+  lifecycle {
+    ignore_changes = [ metadata[0].annotations ]
+  }
   metadata {
     labels = {
       app = "pod_label"
@@ -252,6 +255,9 @@ func testAccKubernetesPodConfigWithNodeAffinityWithRequiredDuringSchedulingIgnor
 
 func testAccKubernetesPodConfigWithNodeAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_pod" "test" {
+  lifecycle {
+    ignore_changes = [ metadata[0].annotations ]
+  }
   metadata {
     labels = {
       app = "pod_label"
@@ -289,6 +295,9 @@ func testAccKubernetesPodConfigWithNodeAffinityWithPreferredDuringSchedulingIgno
 
 func testAccKubernetesPodConfigWithPodAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_pod" "test" {
+  lifecycle {
+    ignore_changes = [ metadata[0].annotations ]
+  }
   metadata {
     labels = {
       app = "pod_label"
@@ -321,6 +330,9 @@ func testAccKubernetesPodConfigWithPodAffinityWithRequiredDuringSchedulingIgnore
 
 func testAccKubernetesPodConfigWithPodAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_pod" "test" {
+  lifecycle {
+    ignore_changes = [ metadata[0].annotations ]
+  }
   metadata {
     labels = {
       app = "pod_label"
@@ -357,6 +369,9 @@ func testAccKubernetesPodConfigWithPodAffinityWithPreferredDuringSchedulingIgnor
 
 func testAccKubernetesPodConfigWithPodAntiAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_pod" "test" {
+  lifecycle {
+    ignore_changes = [ metadata[0].annotations ]
+  }
   metadata {
     labels = {
       app = "pod_label"
@@ -389,6 +404,9 @@ func testAccKubernetesPodConfigWithPodAntiAffinityWithRequiredDuringSchedulingIg
 
 func testAccKubernetesPodConfigWithPodAntiAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_pod" "test" {
+  lifecycle {
+    ignore_changes = [ metadata[0].annotations ]
+  }
   metadata {
     labels = {
       app = "pod_label"


### PR DESCRIPTION
### Description

Fixes affinity acc test failures:

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-test.run "TestAccKubernetesPod_with_(node|pod)_(anti)?affinity_"'

```
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -test.run "TestAccKubernetesPod_with_(node|pod)_(anti)?affinity_" -timeout 120m
=== RUN   TestAccKubernetesPod_with_node_affinity_with_required_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_node_affinity_with_required_during_scheduling_ignored_during_execution (11.60s)
=== RUN   TestAccKubernetesPod_with_node_affinity_with_preferred_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_node_affinity_with_preferred_during_scheduling_ignored_during_execution (11.57s)
=== RUN   TestAccKubernetesPod_with_pod_affinity_with_required_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_pod_affinity_with_required_during_scheduling_ignored_during_execution (8.33s)
=== RUN   TestAccKubernetesPod_with_pod_affinity_with_preferred_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_pod_affinity_with_preferred_during_scheduling_ignored_during_execution (18.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	50.339s
```
