### PR TITLE
Fix reported replica count when waiting for Deployment rollout

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -408,6 +408,11 @@ func waitForDeploymentReplicasFunc(conn *kubernetes.Clientset, ns, name string) 
 			return resource.NonRetryableError(err)
 		}
 
+		var specReplicas int32 = 1 // default, acording to API docs
+		if dply.Spec.Replicas != nil {
+			specReplicas = *dply.Spec.Replicas
+		}
+
 		if dply.Generation <= dply.Status.ObservedGeneration {
 			cond := GetDeploymentCondition(dply.Status, appsv1.DeploymentProgressing)
 			if cond != nil && cond.Reason == TimedOutReason {
@@ -415,8 +420,8 @@ func waitForDeploymentReplicasFunc(conn *kubernetes.Clientset, ns, name string) 
 				return resource.NonRetryableError(err)
 			}
 
-			if dply.Status.UpdatedReplicas < *dply.Spec.Replicas {
-				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d out of %d new replicas have been updated...", dply.Status.UpdatedReplicas, *dply.Spec.Replicas))
+			if dply.Status.UpdatedReplicas < specReplicas {
+				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d out of %d new replicas have been updated...", dply.Status.UpdatedReplicas, specReplicas))
 			}
 
 			if dply.Status.Replicas > dply.Status.UpdatedReplicas {

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -416,7 +416,7 @@ func waitForDeploymentReplicasFunc(conn *kubernetes.Clientset, ns, name string) 
 			}
 
 			if dply.Status.UpdatedReplicas < *dply.Spec.Replicas {
-				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d out of %d new replicas have been updated...", dply.Status.UpdatedReplicas, dply.Spec.Replicas))
+				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d out of %d new replicas have been updated...", dply.Status.UpdatedReplicas, *dply.Spec.Replicas))
 			}
 
 			if dply.Status.Replicas > dply.Status.UpdatedReplicas {


### PR DESCRIPTION
### Description

Provider reports incorrect replica count in error message after waiting for rollout times out.
```
Error: Waiting for rollout to finish: 0 out of 824644526080 new replicas have been updated...
```
After this change, the correct replica count will be reported:
```
Error: Waiting for rollout to finish: 0 out of 1 new replicas have been updated...
```

### Acceptance tests
This changes only concerns user-facing output. It cannot be captured in acceptance tests.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Fix replica count reported in error message after timeout while waiting for rollout
```