### PR TITLE
Script for cleaning up orphaned ELBs after test run

### DIFF
--- a/kubernetes/test-infra/eks/output.tf
+++ b/kubernetes/test-infra/eks/output.tf
@@ -2,3 +2,6 @@ output "kubeconfig_path" {
   value = abspath("${local.kubeconfig_path}/${local.kubeconfig_name}")
 }
 
+output "cluster_name" {
+  value = module.vpc.cluster_name
+}

--- a/kubernetes/test-infra/eks/scripts/delete_orphan_elbs.sh
+++ b/kubernetes/test-infra/eks/scripts/delete_orphan_elbs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash +e
+
+ORPHAN_ELBS=$(aws elb describe-tags \
+    --load-balancer-names $(aws elb describe-load-balancers | jq -r '.LoadBalancerDescriptions[] | .LoadBalancerName') | \
+    jq -r ".TagDescriptions[] | select(.Tags[] | .Key == \"kubernetes.io/cluster/$(terraform output cluster_name)\") | .LoadBalancerName")
+
+for ELB in $ORPHAN_ELBS; do
+    aws elb delete-load-balancer --load-balancer-name $ELB
+done


### PR DESCRIPTION
### Description

This adds a bash script to find and delete ELBs that are hanging around from the test cluster after the tests have run.