### PR TITLE
new data source kubernetes_all_pods

### DIFF
--- a/kubernetes/data_source_kubernetes_all_pods.go
+++ b/kubernetes/data_source_kubernetes_all_pods.go
@@ -1,0 +1,59 @@
+package kubernetes
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesAllPods() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesAllPodsRead,
+		Schema: map[string]*schema.Schema{
+			"pods": {
+				Type:        schema.TypeList,
+				Description: "List of all pods in a cluster.",
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesAllPodsRead(d *schema.ResourceData, meta interface{}) error {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Listing pods")
+	nsRaw, err := conn.CoreV1().Pods().List(metav1.ListOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	pods := make([]string, len(nsRaw.Items))
+	for i, v := range nsRaw.Items {
+		pods[i] = string(v.Name)
+	}
+	log.Printf("[INFO] Received pods: %#v", pods)
+	err = d.Set("pods", pods)
+	if err != nil {
+		return err
+	}
+	idsum := sha256.New()
+	for _, v := range pods {
+		_, err := idsum.Write([]byte(v))
+		if err != nil {
+			return err
+		}
+	}
+	id := fmt.Sprintf("%x", idsum.Sum(nil))
+	d.SetId(id)
+	return nil
+}

--- a/kubernetes/data_source_kubernetes_all_pods.go
+++ b/kubernetes/data_source_kubernetes_all_pods.go
@@ -13,9 +13,9 @@ func dataSourceKubernetesAllPods() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceKubernetesAllPodsRead,
 		Schema: map[string]*schema.Schema{
-			"context": {
+			"namespace": {
 				Type:        schema.TypeString,
-				Description: "Context",
+				Description: "Namespace",
 				Optional:    true,
 				Default:     "default",
 			},
@@ -38,7 +38,7 @@ func dataSourceKubernetesAllPodsRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[INFO] Listing pods")
-	nsRaw, err := conn.CoreV1().Pods(d.Get("context").(string)).List(metav1.ListOptions{})
+	nsRaw, err := conn.CoreV1().Pods(d.Get("namespace").(string)).List(metav1.ListOptions{})
 	if err != nil {
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return err

--- a/kubernetes/data_source_kubernetes_all_pods.go
+++ b/kubernetes/data_source_kubernetes_all_pods.go
@@ -13,6 +13,12 @@ func dataSourceKubernetesAllPods() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceKubernetesAllPodsRead,
 		Schema: map[string]*schema.Schema{
+			"context": {
+				Type:        schema.TypeString,
+				Description: "Context",
+				Optional:    true,
+				Default:     "default",
+			},
 			"pods": {
 				Type:        schema.TypeList,
 				Description: "List of all pods in a cluster.",
@@ -32,7 +38,7 @@ func dataSourceKubernetesAllPodsRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[INFO] Listing pods")
-	nsRaw, err := conn.CoreV1().Pods().List(metav1.ListOptions{})
+	nsRaw, err := conn.CoreV1().Pods(d.Get("context").(string)).List(metav1.ListOptions{})
 	if err != nil {
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return err

--- a/kubernetes/data_source_kubernetes_all_pods_test.go
+++ b/kubernetes/data_source_kubernetes_all_pods_test.go
@@ -1,0 +1,33 @@
+package kubernetes
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccKubernetesDataSourceAllPods_basic(t *testing.T) {
+	rxPosNum := regexp.MustCompile("^[1-9][0-9]*$")
+	nsName := regexp.MustCompile("^[a-zA-Z][-\\w]*$")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceAllPodsConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("data.kubernetes_all_pods.test", "pods.#", rxPosNum),
+					resource.TestCheckResourceAttrSet("data.kubernetes_all_pods.test", "pods.0"),
+					resource.TestMatchResourceAttr("data.kubernetes_all_pods.test", "pods.0", nsName),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceAllPodsConfig_basic() string {
+	return `
+data "kubernetes_all_pods" "test" {}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -138,6 +138,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"kubernetes_all_namespaces":          dataSourceKubernetesAllNamespaces(),
+			"kubernetes_all_pods":                dataSourceKubernetesAllPods(),
 			"kubernetes_config_map":              dataSourceKubernetesConfigMap(),
 			"kubernetes_ingress":                 dataSourceKubernetesIngress(),
 			"kubernetes_namespace":               dataSourceKubernetesNamespace(),

--- a/website/docs/d/all_pods.html.markdown
+++ b/website/docs/d/all_pods.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_all_pods"
+description: |-
+  Lists all pods within a namespace.
+---
+
+# kubernetes_all_pods
+
+This data source provides a mechanism for listing the names of all available pods in a Kubernetes namespace.
+It can be used to check for existence of a specific pod or to apply another resource to all or a subset of existing pods in a namespace.
+
+## Example Usage
+
+```hcl
+data "kubernetes_all_pods" "allpods" {
+  namespace = "default"
+}
+
+output "all-pods" {
+  value = data.kubernetes_all_pods.allpods.pods
+}
+
+output "pod-present" {
+  value = contains(data.kubernetes_all_pods.allpods.pods, "my-pod")
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) Namespace to list. Defaults to "default" 
+


### PR DESCRIPTION
### Description

New data source `kubernetes_all_nodes`

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='=run=TestAccKubernetesDataSourceAllPods_.*' TEST=./kubernetes                                                                                                            
==> Checking that code complies with gofmt requirements...                                                                                                                                                                                                                            
TF_ACC=1 go test ./kubernetes -v =run=TestAccKubernetesDataSourceAllPods_.* -timeout 120m                                                                                                                                                                                             
=== RUN   TestAccKubernetesDataSourceAllNamespaces_basic                                                                                                                                                                                                                              
--- PASS: TestAccKubernetesDataSourceAllNamespaces_basic (0.33s)                                                                                                                                                                                                                      
=== RUN   TestAccKubernetesDataSourceAllPods_basic
--- PASS: TestAccKubernetesDataSourceAllPods_basic (0.33s)
=== RUN   TestAccKubernetesDataSourceConfigMap_basic
--- PASS: TestAccKubernetesDataSourceConfigMap_basic (0.37s)

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New data source:  kubernetes_all_pods
```

### References

Resolves: #1007 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
