### PR TITLE
Add Azure Managed disk to PV resource

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -338,7 +338,7 @@ func isRunningInEks() (bool, error) {
 	ctx := context.TODO()
 	_, err = conn.CoreV1().ConfigMaps("kube-system").Get(ctx, "aws-auth", metav1.GetOptions{})
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	return true, nil
 }

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -154,7 +154,7 @@ func TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNotRunningInGke(t) },
 		IDRefreshName: "kubernetes_ingress.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesIngressDestroy,

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -63,12 +63,12 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 			keys := diff.GetChangedKeysPrefix("spec.0.persistent_volume_source")
 			for _, key := range keys {
 				log.Printf("[DEBUG] CustomizeDiff GetChangedKeysPrefix key: %v", key)
-					log.Printf("[DEBUG] CustomizeDiff key: %v", key)
-					err := diff.ForceNew(key)
-					if err != nil {
-						return err
-					}
+				log.Printf("[DEBUG] CustomizeDiff key: %v", key)
+				err := diff.ForceNew(key)
+				if err != nil {
+					return err
 				}
+			}
 			return nil
 		},
 

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -227,7 +227,6 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	diskName := fmt.Sprintf("tf-acc-test-disk-%s", randString)
 
-	region := os.Getenv("AWS_DEFAULT_REGION")
 	zone := os.Getenv("AWS_ZONE")
 
 	resource.Test(t, resource.TestCase{
@@ -252,8 +251,6 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 						"TestLabelOne":   "one",
 						"TestLabelTwo":   "two",
 						"TestLabelThree": "three",
-						"failure-domain.beta.kubernetes.io/region": region,
-						"failure-domain.beta.kubernetes.io/zone":   zone,
 					}),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.name", name),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.generation"),
@@ -284,8 +281,6 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 						"TestLabelOne":   "one",
 						"TestLabelTwo":   "two",
 						"TestLabelThree": "three",
-						"failure-domain.beta.kubernetes.io/region": region,
-						"failure-domain.beta.kubernetes.io/zone":   zone,
 					}),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.name", name),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.generation"),

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -1060,7 +1060,7 @@ resource "google_compute_disk" "test" {
 `, name, diskName, zone)
 }
 
-func testAccKubernetesPersistentVolumeConfig_aws_basic(name, diskName, zone string) string {
+func testAccKubernetesPersistentVolumeConfig_aws_basic(name, region, zone string) string {
 	return fmt.Sprintf(`resource "kubernetes_persistent_volume" "test" {
   metadata {
     annotations = {
@@ -1092,15 +1092,19 @@ func testAccKubernetesPersistentVolumeConfig_aws_basic(name, diskName, zone stri
   }
 }
 
+provider "aws" {
+  region = "%s"
+}
+
 resource "aws_ebs_volume" "test" {
   availability_zone = "%s"
   size              = 10
 
   tags = {
-    Name = "%s"
+    Name = %q[1]
   }
 }
-`, name, zone, diskName)
+`, name, region, zone)
 }
 
 func testAccKubernetesPersistentVolumeConfig_aws_modified(name, diskName, zone string) string {

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -175,7 +175,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.#", "1"),
@@ -225,9 +225,9 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 	var conf api.PersistentVolume
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
-	diskName := fmt.Sprintf("tf-acc-test-disk-%s", randString)
 
 	zone := os.Getenv("AWS_ZONE")
+	region := os.Getenv("AWS_DEFAULT_REGION")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); skipIfNotRunningInEks(t) },
@@ -236,7 +236,7 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesPersistentVolumeConfig_aws_basic(name, diskName, zone),
+				Config: testAccKubernetesPersistentVolumeConfig_aws_basic(name, region, zone),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPersistentVolumeExists("kubernetes_persistent_volume.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "metadata.0.annotations.%", "2"),
@@ -258,7 +258,7 @@ func TestAccKubernetesPersistentVolume_aws_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.aws_elastic_block_store.#", "1"),
@@ -329,7 +329,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.#", "1"),
@@ -355,7 +355,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.host_path.#", "1"),
@@ -392,7 +392,7 @@ func TestAccKubernetesPersistentVolume_hostPath_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.host_path.#", "1"),
@@ -414,7 +414,7 @@ func TestAccKubernetesPersistentVolume_hostPath_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.host_path.#", "1"),
@@ -454,7 +454,7 @@ func TestAccKubernetesPersistentVolume_local_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.local.#", "1"),
@@ -475,7 +475,7 @@ func TestAccKubernetesPersistentVolume_local_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.local.#", "1"),
@@ -556,7 +556,7 @@ func TestAccKubernetesPersistentVolume_storageClass(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.storage_class_name", storageClassName),
@@ -576,7 +576,7 @@ func TestAccKubernetesPersistentVolume_storageClass(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "1Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.storage_class_name", secondStorageClassName),
@@ -941,7 +941,7 @@ func testAccKubernetesPersistentVolumeConfig_googleCloud_basic(name, diskName, z
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteOnce"]
@@ -1037,7 +1037,7 @@ func testAccKubernetesPersistentVolumeConfig_googleCloud_volumeSource(name, disk
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteOnce"]
@@ -1079,7 +1079,7 @@ func testAccKubernetesPersistentVolumeConfig_aws_basic(name, region, zone string
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteOnce"]
@@ -1098,7 +1098,7 @@ provider "aws" {
 
 resource "aws_ebs_volume" "test" {
   availability_zone = "%s"
-  size              = 10
+  size              = 1
 
   tags = {
     Name = %q[1]
@@ -1427,7 +1427,7 @@ func testAccKubernetesPersistentVolumeConfig_hostPath_volumeSource(name, path, t
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteOnce"]
@@ -1451,7 +1451,7 @@ func testAccKubernetesPersistentVolumeConfig_hostPath_volumeSource_volumeMode(na
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteOnce"]
@@ -1476,7 +1476,7 @@ func testAccKubernetesPersistentVolumeConfig_local_volumeSource(name, path, host
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteOnce"]
@@ -1537,7 +1537,7 @@ func testAccKubernetesPersistentVolumeConfig_storageClass(name, diskName, storag
 
   spec {
     capacity = {
-      storage = "123Gi"
+      storage = "1Gi"
     }
 
     access_modes = ["ReadWriteMany"]

--- a/kubernetes/schema_volume_source.go
+++ b/kubernetes/schema_volume_source.go
@@ -107,6 +107,12 @@ func commonVolumeSources() map[string]*schema.Schema {
 						Description: "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
 						Optional:    true,
 					},
+					"kind": {
+						Type:        schema.TypeString,
+						Description: "The type for the data disk. Expected values: Shared, Dedicated, Managed. Defaults to Shared",
+						Optional:    true,
+						Computed:    true,
+					},
 					"read_only": {
 						Type:        schema.TypeBool,
 						Description: "Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).",

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -27,6 +27,9 @@ func flattenAzureDiskVolumeSource(in *v1.AzureDiskVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["disk_name"] = in.DiskName
 	att["data_disk_uri"] = in.DataDiskURI
+	if in.Kind != nil {
+		att["kind"] = string(*in.Kind)
+	}
 	att["caching_mode"] = string(*in.CachingMode)
 	if in.FSType != nil {
 		att["fs_type"] = *in.FSType
@@ -542,6 +545,10 @@ func expandAzureDiskVolumeSource(l []interface{}) *v1.AzureDiskVolumeSource {
 	}
 	if v, ok := in["read_only"].(bool); ok {
 		obj.ReadOnly = ptrToBool(v)
+	}
+	if v, ok := in["kind"].(string); ok && in["kind"].(string) != "" {
+		kind := v1.AzureDataDiskKind(v)
+		obj.Kind = &kind
 	}
 	return obj
 }

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = var.region
+}
+
 module "vpc" {
   source = "./vpc"
 }

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -31,6 +31,53 @@ resource "kubernetes_persistent_volume" "example" {
 }
 ```
 
+## Example: Persistent Volume using Azure Managed Disk
+
+```hcl
+resource "kubernetes_persistent_volume" "example" {
+  metadata {
+    name = "example"
+  }
+  spec {
+    capacity = {
+      storage = "1Gi"
+    }
+    access_modes = ["ReadWriteOnce"]
+    persistent_volume_source {
+      azure_disk {
+        caching_mode  = "None"
+        data_disk_uri = azurerm_managed_disk.example.id
+        disk_name     = "example"
+        kind          = "Managed"
+      }
+    }
+  }
+}
+
+provider "azurerm" {
+  version = ">=2.20.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "westus2"
+}
+
+
+resource "azurerm_managed_disk" "example" {
+  name                 = "example"
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+  tags = {
+    environment = azurerm_resource_group.example.name
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -121,10 +168,11 @@ The following arguments are supported:
 #### Arguments
 
 * `caching_mode` - (Required) Host Caching mode: None, Read Only, Read Write.
-* `data_disk_uri` - (Required) The URI the data disk in the blob storage
-* `disk_name` - (Required) The Name of the data disk in the blob storage
+* `data_disk_uri` - (Required) The URI the data disk in the blob storage OR the resource ID of an Azure managed data disk if `kind` is `Managed`.
+* `disk_name` - (Required) The Name of the data disk in the blob storage OR the name of an Azure managed data disk if `kind` is `Managed`.
 * `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 * `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
+* `kind` - (Optional) The type for the data disk. Expected values: `Shared`, `Dedicated`, `Managed`. Defaults to `Shared`.
 
 ### `azure_file`
 


### PR DESCRIPTION
### Description

* Add Azure Managed Disk to `kubernetes_persistent_volume` resource.
* Fix broken tests around volume expansion.
* Add tests for Azure disk types, and test backwards compatibility.
* Add Custom Diff to help users with Azure configuration.
* Add example for Azure Managed Disk in PV resource docs.
* Update EKS test-infra to include region.
* Update cloud provider checks in acceptance tests.
    
This contains a cherry-pick of work done by Pierre Chalamet in PR https://github.com/hashicorp/terraform-provider-kubernetes/pull/837

Solves https://github.com/hashicorp/terraform-provider-kubernetes/issues/202

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
[dakini@dax terraform-provider-kubernetes (azure20200917 $)]$ TF_VAR_location="westus2" TESTARGS="-run '^TestAccKubernetesPersistentVolume_azure_basic'" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/home/dakini/go/src/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -run '^TestAccKubernetesPersistentVolume_azure_basic' -timeout 120m
=== RUN   TestAccKubernetesPersistentVolume_azure_basic
--- PASS: TestAccKubernetesPersistentVolume_azure_basic (139.27s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   139.347s

[dakini@dax terraform-provider-kubernetes (azure20200917 $)]$ TF_VAR_location="westus2" TESTARGS="-run '^TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud'" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/home/dakini/go/src/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -run '^TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud' -timeout 120m
=== RUN   TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud
    provider_test.go:266: The Kubernetes endpoint must come from GKE for this test to run - skipping
--- SKIP: TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud (0.24s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   0.327s

[dakini@dax terraform-provider-kubernetes (azure20200917 $)]$ TF_VAR_location="westus2" TESTARGS="-run '^TestAccKubernetesPersistentVolumeClaim_expansionMinikube'" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/home/dakini/go/src/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -run '^TestAccKubernetesPersistentVolumeClaim_expansionMinikube' -timeout 120m
=== RUN   TestAccKubernetesPersistentVolumeClaim_expansionMinikube
    provider_test.go:286: The Kubernetes endpoint must come from Minikube for this test to run - skipping
--- SKIP: TestAccKubernetesPersistentVolumeClaim_expansionMinikube (0.13s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   0.210s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Improvement: Add Azure Managed Disk to PV resource.
```

### References

- https://github.com/hashicorp/terraform-provider-kubernetes/pull/837
- https://github.com/hashicorp/terraform-provider-kubernetes/issues/202
- https://github.com/hashicorp/terraform-provider-kubernetes/pull/968

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
