### PR TITLE
bugfix: introduce filter for flattenPodSpec to control tolerations

### DIFF
--- a/kubernetes/data_source_kubernetes_pod.go
+++ b/kubernetes/data_source_kubernetes_pod.go
@@ -63,7 +63,7 @@ func dataSourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	podSpec, err := flattenPodSpec(pod.Spec)
+	podSpec, err := flattenPodSpec(pod.Spec, true)
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -164,7 +164,7 @@ func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	podSpec, err := flattenPodSpec(pod.Spec)
+	podSpec, err := flattenPodSpec(pod.Spec, true)
 	if err != nil {
 		return err
 	}

--- a/kubernetes/structures_daemonset.go
+++ b/kubernetes/structures_daemonset.go
@@ -20,7 +20,7 @@ func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData) ([]in
 		att["selector"] = flattenLabelSelector(in.Selector)
 	}
 
-	podSpec, err := flattenPodSpec(in.Template.Spec)
+	podSpec, err := flattenPodSpec(in.Template.Spec, false)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -29,7 +29,7 @@ func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData) ([]
 
 	att["strategy"] = flattenDeploymentStrategy(in.Strategy)
 
-	podSpec, err := flattenPodSpec(in.Template.Spec)
+	podSpec, err := flattenPodSpec(in.Template.Spec, false)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -13,7 +13,7 @@ import (
 
 // Flatteners
 
-func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
+func flattenPodSpec(in v1.PodSpec, isNative bool) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	if in.ActiveDeadlineSeconds != nil {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
@@ -91,7 +91,7 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 	}
 
 	if len(in.Tolerations) > 0 {
-		att["toleration"] = flattenTolerations(in.Tolerations)
+		att["toleration"] = flattenTolerations(in.Tolerations, isNative)
 	}
 
 	if len(in.Volumes) > 0 {
@@ -209,11 +209,13 @@ func flattenSysctls(sysctls []v1.Sysctl) []interface{} {
 	return att
 }
 
-func flattenTolerations(tolerations []v1.Toleration) []interface{} {
+func flattenTolerations(tolerations []v1.Toleration, isNative bool) []interface{} {
 	att := []interface{}{}
 	for _, v := range tolerations {
-		// The API Server may automatically add several Tolerations to pods, strip these to avoid TF diff.
-		if strings.Contains(v.Key, "node.kubernetes.io/") {
+		// The API Server may automatically add several Tolerations to
+		// pods when it is created natively, not as part of  deployment or daemonset
+		// strip these to avoid TF diff, but keep these for non-native pods to be able to use them explicitly
+		if isNative && strings.Contains(v.Key, "node.kubernetes.io/") {
 			log.Printf("[INFO] ignoring toleration with key: %s", v.Key)
 			continue
 		}

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -20,7 +20,7 @@ func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, d *schema
 	}
 
 	if in.Template != nil {
-		podSpec, err := flattenPodSpec(in.Template.Spec)
+		podSpec, err := flattenPodSpec(in.Template.Spec, false)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -190,7 +190,7 @@ func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData, pr
 		metaPrefix = prefix[0]
 	}
 	template["metadata"] = flattenMetadata(t.ObjectMeta, d, metaPrefix)
-	spec, err := flattenPodSpec(t.Spec)
+	spec, err := flattenPodSpec(t.Spec, false)
 	if err != nil {
 		return []interface{}{template}, err
 	}


### PR DESCRIPTION
### Description

If you start a pod natively, k8s may add tolerations automatically that
you did not define. There is already a filter in the flattenPodSpec that
filters these out, but if you start it as part of a
deployment/replicaset/daemonset, you might want to use similar
tolerations and don't want to get in a perpetual diff (where state
refresh ignores your toleration in deployments just like it would with
native pods).

This is not a silver bullet, but unblocked me at my work and will possibly unblock many others, as these taint tolerations are used by modules in the registry including https://registry.terraform.io/modules/spotinst/ocean-controller/spotinst/0.5.0 which connects spot.io managed workers to EKS.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestFlattenTolerationsNative'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/home/elodani/playground/terraform-provider-kubernetes/kubernetes" -v -run=TestFlattenTolerationsNative -timeout 120m
=== RUN   TestFlattenTolerationsNative
2020/09/19 09:52:25 [INFO] ignoring toleration with key: node.kubernetes.io/not-ready
--- PASS: TestFlattenTolerationsNative (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	0.037s
```
```
$ make testacc TESTARGS='-run=TestFlattenTolerationsNonNative'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/home/elodani/playground/terraform-provider-kubernetes/kubernetes" -v -run=TestFlattenTolerationsNonNative -timeout 120m
=== RUN   TestFlattenTolerationsNonNative
--- PASS: TestFlattenTolerationsNonNative (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	0.043s

```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`node.kubernetes.io/` prefixed tolerations in pod templates of daemonset/replicaset/deployments are no longer filtered out from the state
```

### References
fixes issue: https://github.com/hashicorp/terraform-provider-kubernetes/issues/955
slightly related: https://github.com/hashicorp/terraform-provider-kubernetes/pull/978

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
