### PR TITLE
Fix service test leaking ELBs

### DIFF
--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -281,9 +281,11 @@ func TestAccKubernetesService_loadBalancer_annotations_aws(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesServiceExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.service.beta.kubernetes.io/aws-load-balancer-type", "nlb"),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout", "100"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.service.beta.kubernetes.io/aws-load-balancer-backend-protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.service.beta.kubernetes.io/aws-load-balancer-ssl-ports", "*"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "spec.0.cluster_ip"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.external_ips.#", "2"),
@@ -785,8 +787,10 @@ func testAccKubernetesServiceConfig_loadBalancer_annotations_aws_modified(name s
   metadata {
     name = "%[1]s"
     annotations = {
-      "service.beta.kubernetes.io/aws-load-balancer-type"                    = "nlb"
-      "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout" = "100"
+      "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"                  = "http"
+      "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"           = "60"
+	  "service.beta.kubernetes.io/aws-load-balancer-ssl-ports"                         = "*"
+	  "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
     }
   }
 


### PR DESCRIPTION
### Description

I think this was the culprit - probably because it was using the annotations to change the type of the ELB from classic to nlb. I was able to reproduce the leak running locally, and with these changes it doesn't happen anymore.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -parallel=16 -run TestAccKubernetesService_loadBalancer -timeout 120m
=== RUN   TestAccKubernetesService_loadBalancer
--- PASS: TestAccKubernetesService_loadBalancer (9.95s)
=== RUN   TestAccKubernetesService_loadBalancer_healthcheck
--- PASS: TestAccKubernetesService_loadBalancer_healthcheck (13.04s)
=== RUN   TestAccKubernetesService_loadBalancer_annotations_aws
--- PASS: TestAccKubernetesService_loadBalancer_annotations_aws (7.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	35.407s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
