### PR TITLE
add support for setting the persistent volume claimRef

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -114,6 +114,28 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 								"Retain",
 							}, false),
 						},
+						"claim_ref": {
+							Type:        schema.TypeList,
+							Description: "A reference to the persistent volume claim details for statically managed PVs. More Info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#binding",
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"namespace": {
+										Type:        schema.TypeString,
+										Description: "The namespace of the PersistentVolumeClaim",
+										Elem:        schema.TypeString,
+										Required:    true,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of the PersistentVolumeClaim",
+										Elem:        schema.TypeString,
+										Required:    true,
+									},
+								},
+							},
+						},
 						"persistent_volume_source": {
 							Type:        schema.TypeList,
 							Description: "The specification of a persistent volume.",

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -716,6 +716,11 @@ resource "kubernetes_persistent_volume" "test" {
       }
     }
   }
+  lifecycle {
+    ignore_changes = [
+      spec[0].claim_ref,
+    ]
+  }
 }
 resource "kubernetes_persistent_volume_claim" "test" {
   wait_until_bound = true

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -879,6 +879,50 @@ func TestAccKubernetesPersistentVolume_regression(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPersistentVolume_hostPath_claimRef(t *testing.T) {
+	var conf api.PersistentVolume
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+	claimNamespace := "default"
+	claimName := "expected-claim-name"
+
+	const resourceName = "kubernetes_persistent_volume.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
+		Steps: []resource.TestStep{
+			// create a volume without a claimRef
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_hostPath_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.claim_ref.#", "0"),
+				),
+			},
+			// set the claimRef and assert it's present
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_hostPath_claimRef(name, claimNamespace, claimName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.claim_ref.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.claim_ref.0.namespace", claimNamespace),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.claim_ref.0.name", claimName),
+				),
+			},
+			// unset the claimRef and assert it's absent
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_hostPath_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.claim_ref.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesPersistentVolumeForceNew(old, new *api.PersistentVolume, wantNew bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if wantNew {
@@ -1716,6 +1760,52 @@ func testAccKubernetesPersistentVolumeConfig_hostPath_mountOptions(name string) 
     }
   }
 }`, name)
+}
+
+func testAccKubernetesPersistentVolumeConfig_hostPath_basic(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_persistent_volume" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    capacity = {
+      storage = "1Gi"
+    }
+    access_modes = ["ReadWriteMany"]
+    mount_options = ["foo"]
+
+    persistent_volume_source {
+      host_path {
+        path = "/mnt/local-volume"
+      }
+    }
+  }
+}`, name)
+}
+
+func testAccKubernetesPersistentVolumeConfig_hostPath_claimRef(name string, claimNamespace string, claimName string) string {
+	return fmt.Sprintf(`resource "kubernetes_persistent_volume" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    capacity = {
+      storage = "1Gi"
+    }
+    access_modes = ["ReadWriteMany"]
+    mount_options = ["foo"]
+	claim_ref {
+       name = "%s"
+       namespace = "%s"
+    }
+
+    persistent_volume_source {
+      host_path {
+        path = "/mnt/local-volume"
+      }
+    }
+  }
+}`, name, claimName, claimNamespace)
 }
 
 func testAccKubernetesPersistentVolume_regression(provider, name, path, typ string) string {

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -888,10 +888,10 @@ func TestAccKubernetesPersistentVolume_hostPath_claimRef(t *testing.T) {
 
 	const resourceName = "kubernetes_persistent_volume.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesPersistentVolumeDestroy,
 		Steps: []resource.TestStep{
 			// create a volume without a claimRef
 			{
@@ -1794,7 +1794,7 @@ func testAccKubernetesPersistentVolumeConfig_hostPath_claimRef(name string, clai
     }
     access_modes = ["ReadWriteMany"]
     mount_options = ["foo"]
-	claim_ref {
+    claim_ref {
        name = "%s"
        namespace = "%s"
     }

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -1028,3 +1028,14 @@ func expandContainerResourceRequirements(l []interface{}) (*v1.ResourceRequireme
 
 	return obj, nil
 }
+
+func flattenObjectRef(in *v1.ObjectReference) []interface{} {
+	att := make(map[string]interface{})
+	if in.Name != "" {
+		att["name"] = in.Name
+	}
+	if in.Namespace != "" {
+		att["namespace"] = in.Namespace
+	}
+	return []interface{}{att}
+}

--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -212,3 +212,35 @@ func TestExpandConfigMapKeyRef(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenObjectRef(t *testing.T) {
+	cases := []struct {
+		Input          *v1.ObjectReference
+		ExpectedOutput []interface{}
+	}{
+		{
+			&v1.ObjectReference{
+				Name:      "demo",
+				Namespace: "default",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":      "demo",
+					"namespace": "default",
+				},
+			},
+		},
+		{
+			&v1.ObjectReference{},
+			[]interface{}{map[string]interface{}{}},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenObjectRef(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

This adds support for setting claimRef namespace and claimRef name for kubernetes persistent volume.

Fixes #1004

I have added an acceptance test that proves the claimRef can be updated and removed.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccKubernetesPersistentVolume"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/Users/dan/dev/github/dvulpe/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesPersistentVolume -timeout 120m
=== RUN   TestAccKubernetesPersistentVolumeClaim_basic
--- PASS: TestAccKubernetesPersistentVolumeClaim_basic (3.12s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch
    provider_test.go:207: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch (0.00s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate
    provider_test.go:207: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate (0.00s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass
    provider_test.go:207: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass (0.00s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_expansion
--- PASS: TestAccKubernetesPersistentVolumeClaim_expansion (46.61s)
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_basic
    provider_test.go:207: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
--- SKIP: TestAccKubernetesPersistentVolume_googleCloud_basic (0.00s)
=== RUN   TestAccKubernetesPersistentVolume_aws_basic
    provider_test.go:214: The environment variables AWS_DEFAULT_REGION, AWS_ZONE, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set to run AWS tests - skipping
--- SKIP: TestAccKubernetesPersistentVolume_aws_basic (0.00s)
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_volumeSource
    provider_test.go:207: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
--- SKIP: TestAccKubernetesPersistentVolume_googleCloud_volumeSource (0.00s)
=== RUN   TestAccKubernetesPersistentVolume_hostPath_volumeSource
--- PASS: TestAccKubernetesPersistentVolume_hostPath_volumeSource (3.50s)
=== RUN   TestAccKubernetesPersistentVolume_local_volumeSource
--- PASS: TestAccKubernetesPersistentVolume_local_volumeSource (3.03s)
=== RUN   TestAccKubernetesPersistentVolume_cephFsSecretRef
--- PASS: TestAccKubernetesPersistentVolume_cephFsSecretRef (1.53s)
=== RUN   TestAccKubernetesPersistentVolume_storageClass
    provider_test.go:207: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
--- SKIP: TestAccKubernetesPersistentVolume_storageClass (0.00s)
=== RUN   TestAccKubernetesPersistentVolume_hostPath_nodeAffinity
--- PASS: TestAccKubernetesPersistentVolume_hostPath_nodeAffinity (5.10s)
=== RUN   TestAccKubernetesPersistentVolume_hostPath_mountOptions
--- PASS: TestAccKubernetesPersistentVolume_hostPath_mountOptions (1.71s)
=== RUN   TestAccKubernetesPersistentVolume_csi_basic
--- PASS: TestAccKubernetesPersistentVolume_csi_basic (3.14s)
=== RUN   TestAccKubernetesPersistentVolume_csi_secrets
--- PASS: TestAccKubernetesPersistentVolume_csi_secrets (1.74s)
=== RUN   TestAccKubernetesPersistentVolume_volumeMode
--- PASS: TestAccKubernetesPersistentVolume_volumeMode (1.51s)
=== RUN   TestAccKubernetesPersistentVolume_hostPath_claimRef
--- PASS: TestAccKubernetesPersistentVolume_hostPath_claimRef (3.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	77.293s```
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):

```release-note
Adds support for updating `kubernetes_persistent_volume` `claimRef` property 
```

### References

Fixes #1004

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
