### PR TITLE
support topologySpreadConstraint in pod spec schema

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -2159,7 +2159,7 @@ resource "kubernetes_config_map" "test_from" {
 resource "kubernetes_pod" "test" {
   metadata {
     labels = {
-	  app = "pod_label"
+      app = "pod_label"
     }
 
     name = "%s"

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -2159,7 +2159,7 @@ resource "kubernetes_config_map" "test_from" {
 resource "kubernetes_pod" "test" {
   metadata {
     labels = {
-      "app.kubernetes.io/instance" = "terraform-example"
+	  app = "pod_label"
     }
 
     name = "%s"

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -972,9 +972,9 @@ func TestAccKubernetesPod_topologySpreadConstraint(t *testing.T) {
 	imageName := "nginx:1.7.9"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesPodDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesPodTopologySpreadConstraintConfig(podName, imageName),
@@ -983,7 +983,7 @@ func TestAccKubernetesPod_topologySpreadConstraint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.max_skew", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.topology_key", "failure-domain.beta.kubernetes.io/zone"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.when_unsatisfiable", "DoNotSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.when_unsatisfiable", "ScheduleAnyway"),
 				),
 			},
 			{
@@ -2408,9 +2408,6 @@ func testAccKubernetesPodTopologySpreadConstraintConfig(podName, imageName strin
 	return fmt.Sprintf(`
 resource "kubernetes_pod" "test" {
   metadata {
-    labels = {
-      "app.kubernetes.io/instance" = "terraform-example"
-    }
     name = "%s"
   }
   spec {
@@ -2420,8 +2417,8 @@ resource "kubernetes_pod" "test" {
     }
     topology_spread_constraint {
       max_skew           = 1
-      topology_key       = "kubernetes.io/hostname"
-      when_unsatisfiable = "DoNotSchedule"
+      topology_key       = "failure-domain.beta.kubernetes.io/zone"
+      when_unsatisfiable = "ScheduleAnyway"
       label_selector {
         match_labels = {
           "app.kubernetes.io/instance" = "terraform-example"

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -2159,7 +2159,7 @@ resource "kubernetes_config_map" "test_from" {
 resource "kubernetes_pod" "test" {
   metadata {
     labels = {
-      app = "pod_label"
+      "app.kubernetes.io/instance" = "terraform-example"
     }
 
     name = "%s"

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -79,6 +79,7 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.1.secret_ref.0.optional", "false"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.1.prefix", "FROM_S_"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName1),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.topology_spread_constraint.#", "0"),
 				),
 			},
 			{

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -385,6 +385,42 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 				},
 			},
 		},
+		"topology_spread_constraint": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"max_skew": {
+						Type:         schema.TypeInt,
+						Description:  "describes the degree to which pods may be unevenly distributed.",
+						Optional:     true,
+						Default:      1,
+						ValidateFunc: validation.IntNotInSlice([]int{0}),
+					},
+					"topology_key": {
+						Type:        schema.TypeString,
+						Description: "the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.",
+						Optional:    true,
+					},
+					"when_unsatisfiable": {
+						Type:         schema.TypeString,
+						Description:  "indicates how to deal with a pod if it doesn't satisfy the spread constraint.",
+						Default:      "DoNotSchedule",
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"DoNotSchedule", "ScheduleAnyway"}, false),
+					},
+					"label_selector": {
+						Type:        schema.TypeList,
+						Description: "A label query over a set of resources, in this case pods.",
+						Optional:    true,
+						Elem: &schema.Resource{
+							Schema: labelSelectorFields(true),
+						},
+					},
+				},
+			},
+		},
 		"volume": {
 			Type:        schema.TypeList,
 			Optional:    true,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -396,7 +396,7 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 						Description:  "describes the degree to which pods may be unevenly distributed.",
 						Optional:     true,
 						Default:      1,
-						ValidateFunc: validation.IntNotInSlice([]int{0}),
+						ValidateFunc: validation.IntAtLeast(1),
 					},
 					"topology_key": {
 						Type:        schema.TypeString,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -113,7 +113,9 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["toleration"] = flattenTolerations(in.Tolerations)
 	}
 
+	log.Printf("haha3")
 	if len(in.TopologySpreadConstraints) > 0 {
+		log.Printf("haha4")
 		att["topology_spread_constraint"] = flattenTopologySpreadConstraints(in.TopologySpreadConstraints)
 	}
 
@@ -279,9 +281,9 @@ func flattenTolerations(tolerations []v1.Toleration) []interface{} {
 	return att
 }
 
-func flattenTopologySpreadConstraints(tolerations []v1.TopologySpreadConstraint) []interface{} {
+func flattenTopologySpreadConstraints(tsc []v1.TopologySpreadConstraint) []interface{} {
 	att := []interface{}{}
-	for _, v := range tolerations {
+	for _, v := range tsc {
 		obj := map[string]interface{}{}
 
 		if v.TopologyKey != "" {
@@ -773,7 +775,9 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 		obj.Volumes = cs
 	}
 
+	log.Printf("haha1")
 	if v, ok := in["topology_spread_constraint"].([]interface{}); ok && len(v) > 0 {
+		log.Printf("haha2")
 		ts, err := expandTopologySpreadConstraints(v)
 		if err != nil {
 			return obj, err

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -113,6 +113,10 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["toleration"] = flattenTolerations(in.Tolerations)
 	}
 
+	if len(in.TopologySpreadConstraints) > 0 {
+		att["topology_spread_constraint"] = flattenTopologySpreadConstraints(in.TopologySpreadConstraints)
+	}
+
 	if len(in.Volumes) > 0 {
 		for i, volume := range in.Volumes {
 			// To avoid perpetual diff, remove the service account token volume from PodSpec.
@@ -269,6 +273,28 @@ func flattenTolerations(tolerations []v1.Toleration) []interface{} {
 		}
 		if v.Value != "" {
 			obj["value"] = v.Value
+		}
+		att = append(att, obj)
+	}
+	return att
+}
+
+func flattenTopologySpreadConstraints(tolerations []v1.TopologySpreadConstraint) []interface{} {
+	att := []interface{}{}
+	for _, v := range tolerations {
+		obj := map[string]interface{}{}
+
+		if v.TopologyKey != "" {
+			obj["topology_key"] = v.TopologyKey
+		}
+		if v.MaxSkew != 0 {
+			obj["max_skew"] = v.MaxSkew
+		}
+		if v.WhenUnsatisfiable != "" {
+			obj["when_unsatisfiable"] = string(v.WhenUnsatisfiable)
+		}
+		if v.LabelSelector != nil {
+			obj["label_selector"] = flattenLabelSelector(v.LabelSelector)
 		}
 		att = append(att, obj)
 	}
@@ -746,6 +772,17 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 		}
 		obj.Volumes = cs
 	}
+
+	if v, ok := in["topology_spread_constraint"].([]interface{}); ok && len(v) > 0 {
+		ts, err := expandTopologySpreadConstraints(v)
+		if err != nil {
+			return obj, err
+		}
+		for _, t := range ts {
+			obj.TopologySpreadConstraints = append(obj.TopologySpreadConstraints, *t)
+		}
+	}
+
 	return obj, nil
 }
 
@@ -1263,6 +1300,35 @@ func expandTolerations(tolerations []interface{}) ([]*v1.Toleration, error) {
 		if value, ok := m["value"]; ok {
 			ts[i].Value = value.(string)
 		}
+	}
+	return ts, nil
+}
+
+func expandTopologySpreadConstraints(tsc []interface{}) ([]*v1.TopologySpreadConstraint, error) {
+	if len(tsc) == 0 {
+		return []*v1.TopologySpreadConstraint{}, nil
+	}
+	ts := make([]*v1.TopologySpreadConstraint, len(tsc))
+	for i, t := range tsc {
+		m := t.(map[string]interface{})
+		ts[i] = &v1.TopologySpreadConstraint{}
+
+		if value, ok := m["topology_key"].(string); ok {
+			ts[i].TopologyKey = value
+		}
+
+		if v, ok := m["label_selector"].([]interface{}); ok && len(v) > 0 {
+			ts[i].LabelSelector = expandLabelSelector(v)
+		}
+
+		if value, ok := m["when_unsatisfiable"].(string); ok {
+			ts[i].WhenUnsatisfiable = v1.UnsatisfiableConstraintAction(value)
+		}
+
+		if value, ok := m["max_skew"].(int); ok {
+			ts[i].MaxSkew = int32(value)
+		}
+
 	}
 	return ts, nil
 }

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -113,9 +113,7 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["toleration"] = flattenTolerations(in.Tolerations)
 	}
 
-	log.Printf("haha3")
 	if len(in.TopologySpreadConstraints) > 0 {
-		log.Printf("haha4")
 		att["topology_spread_constraint"] = flattenTopologySpreadConstraints(in.TopologySpreadConstraints)
 	}
 
@@ -775,9 +773,7 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 		obj.Volumes = cs
 	}
 
-	log.Printf("haha1")
 	if v, ok := in["topology_spread_constraint"].([]interface{}); ok && len(v) > 0 {
-		log.Printf("haha2")
 		ts, err := expandTopologySpreadConstraints(v)
 		if err != nil {
 			return obj, err

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -808,7 +808,7 @@ The `items` block supports the following:
 
 #### Arguments
 
-* `max_skew` - (Optional) Describes the degree to which pods may be unevenly distributed.
+* `max_skew` - (Optional) Describes the degree to which pods may be unevenly distributed. Default value is `1`.
 * `topology_key` - (Optional) The key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 * `when_unsatisfiable` - (Optional) Indicates how to deal with a pod if it doesn't satisfy the spread constraint. Valid values are `DoNotSchedule` and `ScheduleAnyway`. Default value is `DoNotSchedule`.
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -221,7 +221,7 @@ The following arguments are supported:
 * `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `toleration` - (Optional) Optional pod node tolerations. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-* `topology_spread_constraint` - (Optional) describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+* `topology_spread_constraint` - (Optional) Describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes)
 * `readiness_gate` - (Optional) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True". [More info](https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready++.md)
 
@@ -812,6 +812,7 @@ The `items` block supports the following:
 * `topology_key` - (Optional) The key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 * `when_unsatisfiable` - (Optional) Indicates how to deal with a pod if it doesn't satisfy the spread constraint. Valid values are `DoNotSchedule` and `ScheduleAnyway`. Default value is `DoNotSchedule`.
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
+
 ### `value_from`
 
 #### Arguments

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -221,6 +221,7 @@ The following arguments are supported:
 * `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `toleration` - (Optional) Optional pod node tolerations. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+* `topology_spread_constraint` - (Optional) describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes)
 * `readiness_gate` - (Optional) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True". [More info](https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready++.md)
 
@@ -803,6 +804,14 @@ The `items` block supports the following:
 * `toleration_seconds` - (Optional) TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
 * `value` - (Optional) Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
 
+### `topology_spread_constraint`
+
+#### Arguments
+
+* `max_skew` - (Optional) Describes the degree to which pods may be unevenly distributed.
+* `topology_key` - (Optional) The key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
+* `when_unsatisfiable` - (Optional) Indicates how to deal with a pod if it doesn't satisfy the spread constraint. Valid values are `DoNotSchedule` and `ScheduleAnyway`. Default value is `DoNotSchedule`.
+* `label_selector` - (Optional) A label query over a set of resources, in this case pods.
 ### `value_from`
 
 #### Arguments


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccKubernetesPod_basic (31.93s)
--- PASS: TestAccKubernetesPod_topologySpreadConstraint (25.00s)
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for TopologySpreadConstraint
...
```

### References
Closes #994

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
