### PR TITLE
Fix docs api_group requirement in cluster_role_binding and role_binding

### DIFF
--- a/website/docs/r/cluster_role_binding.html.markdown
+++ b/website/docs/r/cluster_role_binding.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of this ClusterRole to bind Subjects to.
 * `kind` - (Required) The type of binding to use. This value must be and defaults to `ClusterRole`
-* `api_group` - (Optional) The API group to drive authorization decisions. This value must be and defaults to `rbac.authorization.k8s.io`
+* `api_group` - (Required) The API group to drive authorization decisions. This value must be and defaults to `rbac.authorization.k8s.io`
 
 ### `subject`
 
@@ -88,7 +88,7 @@ The following arguments are supported:
 * `name` - (Required) The name of this ClusterRole to bind Subjects to.
 * `namespace` - (Optional) Namespace defines the namespace of the ServiceAccount to bind to. This value only applies to kind `ServiceAccount`
 * `kind` - (Required) The type of binding to use. This value must be `ServiceAccount`, `User` or `Group`
-* `api_group` - (Optional) The API group to drive authorization decisions. This value only applies to kind `User` and `Group`. It must be `rbac.authorization.k8s.io`
+* `api_group` - (Required) The API group to drive authorization decisions. This value only applies to kind `User` and `Group`. It must be `rbac.authorization.k8s.io`
 
 ## Import
 

--- a/website/docs/r/role_binding.html.markdown
+++ b/website/docs/r/role_binding.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of this Role to bind Subjects to.
 * `kind` - (Required) The type of binding to use. This value must be present and defaults to `Role`
-* `api_group` - (Optional) The API group to drive authorization decisions. This value must be and defaults to `rbac.authorization.k8s.io`
+* `api_group` - (Required) The API group to drive authorization decisions. This value must be and defaults to `rbac.authorization.k8s.io`
 
 ### `subject`
 
@@ -89,7 +89,7 @@ The following arguments are supported:
 * `name` - (Required) The name of this Role to bind Subjects to.
 * `namespace` - (Optional) Namespace defines the namespace of the ServiceAccount to bind to. This value only applies to kind `ServiceAccount`
 * `kind` - (Required) The type of binding to use. This value must be `ServiceAccount`, `User` or `Group`
-* `api_group` - (Optional) The API group to drive authorization decisions. This value only applies to kind `User` and `Group`. It must be `rbac.authorization.k8s.io`
+* `api_group` - (Required) The API group to drive authorization decisions. This value only applies to kind `User` and `Group`. It must be `rbac.authorization.k8s.io`
 
 ## Import
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Initiated by #574 , we need to fix the documentation to show that api_group is required.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Correct documentation to show that api_group is required in role_binding and cluster_role_binding
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

* #574

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
