### PR TITLE
Add behavior field to horizontal pod autoscaler

### DIFF
--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -48,6 +48,28 @@ func resourceKubernetesHorizontalPodAutoscaler() *schema.Resource {
 							Optional:    true,
 							Default:     1,
 						},
+						"behavior": {
+							Type:        schema.TypeList,
+							Description: "Behavior configures the scaling behavior of the target in both Up and Down directions (scale_up and scale_down fields respectively).",
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scale_up": {
+										Type:        schema.TypeList,
+										Description: "Scaling policy for scaling Up",
+										Optional:    true,
+										Elem:        scalingRulesSpecFields(),
+									},
+									"scale_down": {
+										Type:        schema.TypeList,
+										Description: "Scaling policy for scaling Down",
+										Optional:    true,
+										Elem:        scalingRulesSpecFields(),
+									},
+								},
+							},
+						},
 						"scale_target_ref": {
 							Type:        schema.TypeList,
 							Description: "Reference to scaled resource. e.g. Replication Controller",
@@ -260,5 +282,11 @@ func useV2(d *schema.ResourceData) bool {
 		log.Printf("[INFO] Using autoscaling/v2beta2 because this resource has a metric field")
 		return true
 	}
+
+	if len(d.Get("spec.0.behavior").([]interface{})) > 0 {
+		log.Printf("[INFO] Using autoscaling/v2beta2 because this resource has a behavior field")
+		return true
+	}
+
 	return false
 }

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -38,6 +38,7 @@ func resourceKubernetesHorizontalPodAutoscaler() *schema.Resource {
 						},
 						"metric": {
 							Type:        schema.TypeList,
+							Computed:    true,
 							Optional:    true,
 							Description: "The specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods. Ergo, metrics used must decrease as the pod count is increased, and vice-versa. See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.",
 							Elem:        metricSpecFields(),

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2_test.go
@@ -34,6 +34,27 @@ func TestAccKubernetesHorizontalPodAutoscalerV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_horizontal_pod_autoscaler.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_horizontal_pod_autoscaler.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.0.period_seconds", "120"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.0.type", "Pods"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.0.value", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.1.period_seconds", "310"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.1.type", "Percent"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.1.value", "100"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.select_policy", "Min"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.stabilization_window_seconds", "300"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.0.period_seconds", "180"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.0.type", "Percent"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.0.value", "100"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.1.period_seconds", "600"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.1.type", "Pods"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.1.value", "5"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.select_policy", "Max"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.stabilization_window_seconds", "600"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.max_replicas", "10"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.min_replicas", "1"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.scale_target_ref.#", "1"),
@@ -76,6 +97,20 @@ func TestAccKubernetesHorizontalPodAutoscalerV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "metadata.0.labels.test", "test"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "metadata.0.name", name),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.0.period_seconds", "120"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.0.type", "Pods"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.policy.0.value", "10"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.select_policy", "Max"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_down.0.stabilization_window_seconds", "100"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.select_policy", "Disabled"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.0.period_seconds", "60"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.0.type", "Pods"),
+					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.behavior.0.scale_up.0.policy.0.value", "1"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.max_replicas", "100"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.min_replicas", "50"),
 					resource.TestCheckResourceAttr("kubernetes_horizontal_pod_autoscaler.test", "spec.0.scale_target_ref.#", "1"),
@@ -140,6 +175,42 @@ func testAccKubernetesHorizontalPodAutoscalerV2Config_basic(name string) string 
     scale_target_ref {
       kind = "Deployment"
       name = "TerraformAccTest"
+    }
+
+    behavior {
+      scale_down {
+        stabilization_window_seconds = 300
+        select_policy                = "Min"
+
+        policy {
+          period_seconds = 120
+          type           = "Pods"
+          value          = 1
+        }
+        
+        policy {
+          period_seconds = 310
+          type           = "Percent"
+          value          = 100
+        } 
+      }
+
+      scale_up {
+        stabilization_window_seconds = 600
+        select_policy                = "Max"
+
+        policy {
+          period_seconds = 180
+          type           = "Percent"
+          value          = 100
+        }
+
+        policy {
+          period_seconds = 600
+          type           = "Pods"
+          value          = 5
+        }
+      }
     }
 
     metric {
@@ -227,6 +298,29 @@ func testAccKubernetesHorizontalPodAutoscalerV2Config_modified(name string) stri
     scale_target_ref {
       kind = "Deployment"
       name = "TerraformAccTest"
+    }
+
+    behavior {
+      scale_down {
+        stabilization_window_seconds = 100
+        select_policy                = "Max"
+
+        policy {
+          period_seconds = 120
+          type           = "Pods"
+          value          = 10
+        }
+      }
+
+      scale_up {
+        select_policy = "Disabled"
+
+        policy {
+          period_seconds = 60
+          type           = "Pods"
+          value          = 1
+        }
+      }
     }
 
     metric {

--- a/kubernetes/schema_horizontal_pod_autoscaler.go
+++ b/kubernetes/schema_horizontal_pod_autoscaler.go
@@ -199,3 +199,49 @@ func metricSpecFields() *schema.Resource {
 		},
 	}
 }
+
+func scalingRulesSpecFields() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"policy": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MinItems:    1,
+				Elem:        scalingPolicySpecFields(),
+				Description: "List of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the scaling rule will be discarded as invalid.",
+			},
+			"select_policy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to specify which policy should be used. If not set, the default value Max is used.",
+			},
+			"stabilization_window_seconds": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+			},
+		},
+	}
+}
+
+func scalingPolicySpecFields() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"period_seconds": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Period specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Type is used to specify the scaling policy: Percent or Pods",
+			},
+			"value": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Value contains the amount of change which is permitted by the policy. It must be greater than zero.",
+			},
+		},
+	}
+}

--- a/website/docs/r/horizontal_pod_autoscaler.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler.html.markdown
@@ -94,12 +94,12 @@ resource "kubernetes_horizontal_pod_autoscaler" "example" {
           type           = "Pods"
           value          = 1
         }
-        
+
         policy {
           period_seconds = 310
           type           = "Percent"
           value          = 100
-        } 
+        }
       }
       scale_up {
         stabilization_window_seconds = 600


### PR DESCRIPTION
### Description

Add support for behavior field in horizontal_pod_autoscaler as requested in #1029 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesHorizontalPodAutoscalerV2.*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ".../terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesHorizontalPodAutoscalerV2.* -timeout 120m
=== RUN   TestAccKubernetesHorizontalPodAutoscalerV2_basic
--- PASS: TestAccKubernetesHorizontalPodAutoscalerV2_basic (1.86s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   4.458s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Add `behavior` field to horizontal pod autoscaler
```

### References

- User guide https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
- Reference https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#horizontalpodautoscalerspec-v2beta2-autoscaling
- Add support for metrics field in horizontal_pod_autoscaler https://github.com/hashicorp/terraform-provider-kubernetes/pull/773

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
