### PR TITLE
Allow succeeded target for pods

### DIFF
--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -78,7 +78,7 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(buildId(out.ObjectMeta))
 
 	stateConf := &resource.StateChangeConf{
-		Target:  []string{"Running"},
+		Target:  []string{"Running", "Succeeded"},
 		Pending: []string{"Pending"},
 		Timeout: d.Timeout(schema.TimeoutCreate),
 		Refresh: func() (interface{}, string, error) {

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -86,8 +86,8 @@ func TestAccKubernetesPod_initContainer_updateForcesNew(t *testing.T) {
 	var conf2 api.Pod
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
-	image1 := "busybox:1.27"
-	image2 := "busybox:1.28"
+	image1 := "alpine:3.11"
+	image2 := "alpine:3.12"
 	resourceName := "kubernetes_pod.test"
 
 	resource.Test(t, resource.TestCase{

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -86,8 +86,8 @@ func TestAccKubernetesPod_initContainer_updateForcesNew(t *testing.T) {
 	var conf2 api.Pod
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
-	image1 := "alpine:3.11"
-	image2 := "alpine:3.12"
+	image1 := "busybox:1.27"
+	image2 := "busybox:1.28"
 	resourceName := "kubernetes_pod.test"
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
### Description

Adds `Succeeded` to the list of target states for `kubernetes_pod` resources. Fixes #599 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccKubernetesPod"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "/Users/.../Workspace/garbetjie/terraform-provider-kubernetes/kubernetes" -v -run=KubernetesPod -timeout 120m
=== RUN   TestAccKubernetesPod_with_node_affinity_with_required_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_node_affinity_with_required_during_scheduling_ignored_during_execution (7.07s)
=== RUN   TestAccKubernetesPod_with_node_affinity_with_preferred_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_node_affinity_with_preferred_during_scheduling_ignored_during_execution (20.34s)
=== RUN   TestAccKubernetesPod_with_pod_affinity_with_required_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_pod_affinity_with_required_during_scheduling_ignored_during_execution (18.72s)
=== RUN   TestAccKubernetesPod_with_pod_affinity_with_preferred_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_pod_affinity_with_preferred_during_scheduling_ignored_during_execution (6.73s)
=== RUN   TestAccKubernetesPod_with_pod_anti_affinity_with_required_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_pod_anti_affinity_with_required_during_scheduling_ignored_during_execution (5.92s)
=== RUN   TestAccKubernetesPod_with_pod_anti_affinity_with_preferred_during_scheduling_ignored_during_execution
--- PASS: TestAccKubernetesPod_with_pod_anti_affinity_with_preferred_during_scheduling_ignored_during_execution (8.43s)
=== RUN   TestAccKubernetesPodDisruptionBudget_basic
--- PASS: TestAccKubernetesPodDisruptionBudget_basic (1.48s)
=== RUN   TestAccKubernetesPodSecurityPolicy_basic
--- PASS: TestAccKubernetesPodSecurityPolicy_basic (2.01s)
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (12.69s)
=== RUN   TestAccKubernetesPod_initContainer_updateForcesNew
    testing.go:684: Step 0 error: errors during apply:

        Error: timeout while waiting for state to become 'Running, Succeeded' (last state: 'Pending', timeout: 5m0s)
           * tf-acc-test-122506545661952870 (Pod): DNSConfigForming: Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 10.0.2.3 1.1.1.1 8.8.8.8
           * tf-acc-test-122506545661952870 (Pod): BackOff: Back-off restarting failed container

          on /var/folders/x9/pkvn9rfj3xxddwzc1yl5krpjn6tbfn/T/tf-test764799878/main.tf line 1:
          (source code not available)


--- FAIL: TestAccKubernetesPod_initContainer_updateForcesNew (308.78s)
=== RUN   TestAccKubernetesPod_updateArgsForceNew
--- PASS: TestAccKubernetesPod_updateArgsForceNew (87.30s)
=== RUN   TestAccKubernetesPod_updateEnvForceNew
--- PASS: TestAccKubernetesPod_updateEnvForceNew (21.08s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (10.73s)
=== RUN   TestAccKubernetesPod_with_pod_security_context_run_as_group
--- PASS: TestAccKubernetesPod_with_pod_security_context_run_as_group (10.71s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (43.98s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (11.54s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (12.32s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (23.73s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (7.05s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (12.38s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (19.04s)
=== RUN   TestAccKubernetesPod_with_projected_volume
    testing.go:684: Step 0 error: Expected a non-empty plan, but got an empty plan!
--- FAIL: TestAccKubernetesPod_with_projected_volume (50.52s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (18.70s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (8.66s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume_with_sizeLimit
--- PASS: TestAccKubernetesPod_with_empty_dir_volume_with_sizeLimit (12.48s)
=== RUN   TestAccKubernetesPod_with_secret_vol_items
--- PASS: TestAccKubernetesPod_with_secret_vol_items (20.40s)
=== RUN   TestAccKubernetesPod_gke_with_nodeSelector
    provider_test.go:252: The Kubernetes endpoint must come from GKE for this test to run - skipping
--- SKIP: TestAccKubernetesPod_gke_with_nodeSelector (0.01s)
=== RUN   TestAccKubernetesPod_config_with_automount_service_account_token
--- PASS: TestAccKubernetesPod_config_with_automount_service_account_token (8.89s)
=== RUN   TestAccKubernetesPod_config_container_working_dir
--- PASS: TestAccKubernetesPod_config_container_working_dir (18.01s)
=== RUN   TestAccKubernetesPod_config_container_startup_probe
    testing.go:684: Step 0 error: Check failed: 4 errors occurred:
        	* Check 3/6 error: kubernetes_pod.test: Attribute 'spec.0.container.0.startup_probe.0.http_get.0.path' not found
        	* Check 4/6 error: kubernetes_pod.test: Attribute 'spec.0.container.0.startup_probe.0.http_get.0.port' not found
        	* Check 5/6 error: kubernetes_pod.test: Attribute 'spec.0.container.0.startup_probe.0.initial_delay_seconds' not found
        	* Check 6/6 error: kubernetes_pod.test: Attribute 'spec.0.container.0.startup_probe.0.timeout_seconds' not found


--- FAIL: TestAccKubernetesPod_config_container_startup_probe (10.19s)
=== RUN   TestAccKubernetesPod_termination_message_policy_default
--- PASS: TestAccKubernetesPod_termination_message_policy_default (6.73s)
=== RUN   TestAccKubernetesPod_termination_message_policy_override_as_file
--- PASS: TestAccKubernetesPod_termination_message_policy_override_as_file (18.74s)
=== RUN   TestAccKubernetesPod_termination_message_policy_override_as_fallback_to_logs_on_err
--- PASS: TestAccKubernetesPod_termination_message_policy_override_as_fallback_to_logs_on_err (20.67s)
=== RUN   TestAccKubernetesPod_enableServiceLinks
--- PASS: TestAccKubernetesPod_enableServiceLinks (6.31s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	855.112s
FAIL
make: *** [testacc] Error 1
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `Succeeded` to target states for `kubernetes_pod` (#599)
```

### References

#599 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
