### PR TITLE
Expose kubeconfig path out of Typhoon test environment.

### DIFF
--- a/kubernetes/test-infra/typhoon-aws/main.tf
+++ b/kubernetes/test-infra/typhoon-aws/main.tf
@@ -1,3 +1,7 @@
+locals {
+  kubeconfig_path = "${path.root}/kubeconfig"
+}
+
 resource "tls_private_key" "typhoon-acc" {
   algorithm = "RSA"
 }
@@ -25,4 +29,8 @@ resource "null_resource" "ssh-key" {
 
 data "aws_route53_zone" "typhoon-acc" {
   name = var.base_domain
+}
+
+output "kubeconfig_path" {
+  value = local.kubeconfig_path
 }

--- a/kubernetes/test-infra/typhoon-aws/module_1_18.tf
+++ b/kubernetes/test-infra/typhoon-aws/module_1_18.tf
@@ -28,5 +28,5 @@ module "typhoon-acc-1_18" {
 resource "local_file" "typhoon-acc_1_18" {
   count = local.enabled_1_18
   content  = module.typhoon-acc-1_18[0].kubeconfig-admin
-  filename = "kubeconfig"
+  filename = local.kubeconfig_path
 }

--- a/kubernetes/test-infra/typhoon-aws/module_1_19.tf
+++ b/kubernetes/test-infra/typhoon-aws/module_1_19.tf
@@ -28,5 +28,5 @@ module "typhoon-acc-1_19" {
 resource "local_file" "typhoon-acc-1_19" {
   count = local.enabled_1_19
   content  = module.typhoon-acc-1_19[0].kubeconfig-admin
-  filename = "kubeconfig"
+  filename = local.kubeconfig_path
 }


### PR DESCRIPTION
### Description

Exposes the path to the generated `kubeconfig` file as a Terraform output. Following steps in the acceptance tests stage expect this.

This change is needed to successfully run tests against the Typhoon stage in CI.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

```
N/A
```

### Release Note
Internal change - not needed.
