### PR TITLE
Update job documentation

### DIFF
--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -129,7 +129,7 @@ Please see the [Pod resource](pod.html#spec-1) for reference.
 The following [Timeout](/docs/configuration/resources.html#operation-timeouts) configuration options are available for the `kubernetes_job` resource when used with `wait_for_completion = true`:
 
 * `create` - (Default `1 minute`) Used for creating a new job and waiting for a successful job completion.
-* `update - (Default `1 minute`) Used for updating an existing job and waiting for a successful job completion.
+* `update` - (Default `1 minute`) Used for updating an existing job and waiting for a successful job completion.
 
 Note: 
 


### PR DESCRIPTION
### Description

This is just an update to the documentation, I noticed that in the job section, the `update` property was misformatted, as a backtick was missing.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? N/A
- [ ] Have you run the acceptance tests on this branch? N/A

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix job documentation.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
