### PR TITLE
Fix typo in error message

### DIFF
--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -259,7 +259,7 @@ func retryUntilJobIsFinished(ctx context.Context, conn *kubernetes.Clientset, ns
 				case batchv1.JobComplete:
 					return nil
 				case batchv1.JobFailed:
-					return resource.NonRetryableError(fmt.Errorf("job: %s/%s is in failed sate", ns, name))
+					return resource.NonRetryableError(fmt.Errorf("job: %s/%s is in failed state", ns, name))
 				}
 			}
 		}


### PR DESCRIPTION
### Description

When using the provider, we noticed a typo in an error message. This PR fixes that typo.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

I do not believe this change impacts any acceptance tests.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix typo in error message
```

### References

None.

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
