### PR TITLE
Credentials changes for v2.0.0

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -279,7 +279,7 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	} else if v := os.Getenv("KUBE_CONFIG_PATHS"); v != "" {
 		// NOTE we have to do this here because the schema
 		// does not yet allow you to set a default for a TypeList
-		configPaths = strings.Split(v, ":")
+		configPaths = filepath.SplitList(v)
 	}
 
 	if len(configPaths) > 0 {

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -77,10 +77,11 @@ func Provider() *schema.Provider {
 				Description: "A list of paths to kube config files. Can be set with KUBE_CONFIG_PATHS environment variable.",
 			},
 			"config_path": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("KUBE_CONFIG_PATH", ""),
-				Description: "Path to the kube config file. Can be set with KUBE_CONFIG_PATH.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("KUBE_CONFIG_PATH", ""),
+				Description:   "Path to the kube config file. Can be set with KUBE_CONFIG_PATH.",
+				ConflictsWith: []string{"config_paths"},
 			},
 			"config_context": {
 				Type:        schema.TypeString,

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -233,9 +233,18 @@ func (k kubeClientsets) AggregatorClientset() (*aggregator.Clientset, error) {
 	return k.aggregatorClientset, nil
 }
 
+var apiTokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+
 func inCluster() bool {
 	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
-	return host != "" && port != ""
+	if host == "" || port == "" {
+		return false
+	}
+
+	if _, err := os.Stat(apiTokenMountPath); err != nil {
+		return false
+	}
+	return true
 }
 
 var authDocumentationURL = "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication"

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -73,7 +73,7 @@ func TestProvider_configure(t *testing.T) {
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 
-	os.Setenv("KUBE_CONFIG_PATHS", "test-fixtures/kube-config.yaml")
+	os.Setenv("KUBE_CONFIG_PATH", "test-fixtures/kube-config.yaml")
 	os.Setenv("KUBE_CTX", "gcp")
 
 	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
@@ -87,79 +87,33 @@ func TestProvider_configure(t *testing.T) {
 func unsetEnv(t *testing.T) func() {
 	e := getEnv()
 
-	if err := os.Unsetenv("KUBE_CONFIG_PATHS"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CONFIG_PATHS: %s", err)
+	envVars := map[string]string{
+		"KUBE_CONFIG_PATH": e.ConfigPath,
+		"KUBE_CONFIG_PATHS": strings.Join(e.ConfigPaths, ":"),
+		"KUBE_CTX": e.Ctx,
+		"KUBE_CTX_AUTH_INFO": e.CtxAuthInfo,
+		"KUBE_CTX_CLUSTER": e.CtxCluster,
+		"KUBE_HOST": e.Host,
+		"KUBE_USER": e.User,
+		"KUBE_PASSWORD": e.Password,
+		"KUBE_CLIENT_CERT_DATA": e.ClientCertData,
+		"KUBE_CLIENT_KEY_DATA": e.ClientKeyData,
+		"KUBE_CLUSTER_CA_CERT_DATA": e.ClusterCACertData,
+		"KUBE_INSECURE": e.Insecure,
+		"KUBE_TOKEN": e.Token,
 	}
-	if err := os.Unsetenv("KUBE_CTX"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CTX: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_CTX_AUTH_INFO"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CTX_AUTH_INFO: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_CTX_CLUSTER"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CTX_CLUSTER: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_HOST"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_HOST: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_USER"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_USER: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_PASSWORD"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_PASSWORD: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_CLIENT_CERT_DATA"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CLIENT_CERT_DATA: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_CLIENT_KEY_DATA"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CLIENT_KEY_DATA: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_CLUSTER_CA_CERT_DATA"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_CLUSTER_CA_CERT_DATA: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_INSECURE"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_INSECURE: %s", err)
-	}
-	if err := os.Unsetenv("KUBE_TOKEN"); err != nil {
-		t.Fatalf("Error unsetting env var KUBE_TOKEN: %s", err)
+
+	for k, _ := range envVars {
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatalf("Error unsetting env var %s: %s", k, err)
+		}	
 	}
 
 	return func() {
-		if err := os.Setenv("KUBE_CONFIG_PATHS", strings.Join(e.ConfigPaths, ":")); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CONFIG_PATHS: %s", err)
-		}
-		if err := os.Setenv("KUBE_CTX", e.Ctx); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CTX: %s", err)
-		}
-		if err := os.Setenv("KUBE_CTX_AUTH_INFO", e.CtxAuthInfo); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CTX_AUTH_INFO: %s", err)
-		}
-		if err := os.Setenv("KUBE_CTX_CLUSTER", e.CtxCluster); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CTX_CLUSTER: %s", err)
-		}
-		if err := os.Setenv("KUBE_HOST", e.Host); err != nil {
-			t.Fatalf("Error resetting env var KUBE_HOST: %s", err)
-		}
-		if err := os.Setenv("KUBE_USER", e.User); err != nil {
-			t.Fatalf("Error resetting env var KUBE_USER: %s", err)
-		}
-		if err := os.Setenv("KUBE_PASSWORD", e.Password); err != nil {
-			t.Fatalf("Error resetting env var KUBE_PASSWORD: %s", err)
-		}
-		if err := os.Setenv("KUBE_CLIENT_CERT_DATA", e.ClientCertData); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CLIENT_CERT_DATA: %s", err)
-		}
-		if err := os.Setenv("KUBE_CLIENT_KEY_DATA", e.ClientKeyData); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CLIENT_KEY_DATA: %s", err)
-		}
-		if err := os.Setenv("KUBE_CLUSTER_CA_CERT_DATA", e.ClusterCACertData); err != nil {
-			t.Fatalf("Error resetting env var KUBE_CLUSTER_CA_CERT_DATA: %s", err)
-		}
-		if err := os.Setenv("KUBE_INSECURE", e.Insecure); err != nil {
-			t.Fatalf("Error resetting env var KUBE_INSECURE: %s", err)
-		}
-		if err := os.Setenv("KUBE_TOKEN", e.Token); err != nil {
-			t.Fatalf("Error resetting env var KUBE_TOKEN: %s", err)
+		for k, v := range envVars {
+			if err := os.Setenv(k, v); err != nil {
+				t.Fatalf("Error resetting env var %s: %s", k, err)
+			}	
 		}
 	}
 }
@@ -178,7 +132,10 @@ func getEnv() *currentEnv {
 		Insecure:          os.Getenv("KUBE_INSECURE"),
 		Token:             os.Getenv("KUBE_TOKEN"),
 	}
-	if v := os.Getenv("KUBE_CONFIG_PATHS"); v != "" {
+	if v := os.Getenv("KUBE_CONFIG_PATH"); v != "" {
+		e.ConfigPath = v
+	}
+	if v := os.Getenv("KUBE_CONFIG_PATH"); v != "" {
 		e.ConfigPaths = strings.Split(v, ":")
 	}
 	return e
@@ -188,7 +145,7 @@ func testAccPreCheck(t *testing.T) {
 	ctx := context.TODO()
 	hasFileCfg := (os.Getenv("KUBE_CTX_AUTH_INFO") != "" && os.Getenv("KUBE_CTX_CLUSTER") != "") ||
 		os.Getenv("KUBE_CTX") != "" ||
-		os.Getenv("KUBE_CONFIG_PATHS") != ""
+		os.Getenv("KUBE_CONFIG_PATH") != ""
 	hasUserCredentials := os.Getenv("KUBE_USER") != "" && os.Getenv("KUBE_PASSWORD") != ""
 	hasClientCert := os.Getenv("KUBE_CLIENT_CERT_DATA") != "" && os.Getenv("KUBE_CLIENT_KEY_DATA") != ""
 	hasStaticCfg := (os.Getenv("KUBE_HOST") != "" &&
@@ -424,6 +381,7 @@ func clusterVersionLessThan(vs string) bool {
 }
 
 type currentEnv struct {
+	ConfigPath       string
 	ConfigPaths       []string
 	Ctx               string
 	CtxAuthInfo       string

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -88,32 +89,32 @@ func unsetEnv(t *testing.T) func() {
 	e := getEnv()
 
 	envVars := map[string]string{
-		"KUBE_CONFIG_PATH": e.ConfigPath,
-		"KUBE_CONFIG_PATHS": strings.Join(e.ConfigPaths, ":"),
-		"KUBE_CTX": e.Ctx,
-		"KUBE_CTX_AUTH_INFO": e.CtxAuthInfo,
-		"KUBE_CTX_CLUSTER": e.CtxCluster,
-		"KUBE_HOST": e.Host,
-		"KUBE_USER": e.User,
-		"KUBE_PASSWORD": e.Password,
-		"KUBE_CLIENT_CERT_DATA": e.ClientCertData,
-		"KUBE_CLIENT_KEY_DATA": e.ClientKeyData,
+		"KUBE_CONFIG_PATH":          e.ConfigPath,
+		"KUBE_CONFIG_PATHS":         filepath.Join(e.ConfigPaths...),
+		"KUBE_CTX":                  e.Ctx,
+		"KUBE_CTX_AUTH_INFO":        e.CtxAuthInfo,
+		"KUBE_CTX_CLUSTER":          e.CtxCluster,
+		"KUBE_HOST":                 e.Host,
+		"KUBE_USER":                 e.User,
+		"KUBE_PASSWORD":             e.Password,
+		"KUBE_CLIENT_CERT_DATA":     e.ClientCertData,
+		"KUBE_CLIENT_KEY_DATA":      e.ClientKeyData,
 		"KUBE_CLUSTER_CA_CERT_DATA": e.ClusterCACertData,
-		"KUBE_INSECURE": e.Insecure,
-		"KUBE_TOKEN": e.Token,
+		"KUBE_INSECURE":             e.Insecure,
+		"KUBE_TOKEN":                e.Token,
 	}
 
 	for k, _ := range envVars {
 		if err := os.Unsetenv(k); err != nil {
 			t.Fatalf("Error unsetting env var %s: %s", k, err)
-		}	
+		}
 	}
 
 	return func() {
 		for k, v := range envVars {
 			if err := os.Setenv(k, v); err != nil {
 				t.Fatalf("Error resetting env var %s: %s", k, err)
-			}	
+			}
 		}
 	}
 }
@@ -136,7 +137,7 @@ func getEnv() *currentEnv {
 		e.ConfigPath = v
 	}
 	if v := os.Getenv("KUBE_CONFIG_PATH"); v != "" {
-		e.ConfigPaths = strings.Split(v, ":")
+		e.ConfigPaths = filepath.SplitList(v)
 	}
 	return e
 }
@@ -381,7 +382,7 @@ func clusterVersionLessThan(vs string) bool {
 }
 
 type currentEnv struct {
-	ConfigPath       string
+	ConfigPath        string
 	ConfigPaths       []string
 	Ctx               string
 	CtxAuthInfo       string

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -69,7 +69,7 @@ func TestProvider_impl(t *testing.T) {
 	var _ schema.Provider = *Provider()
 }
 
-func TestProvider_configure(t *testing.T) {
+func TestProvider_configure_path(t *testing.T) {
 	ctx := context.TODO()
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
@@ -85,12 +85,31 @@ func TestProvider_configure(t *testing.T) {
 	}
 }
 
+func TestProvider_configure_paths(t *testing.T) {
+	ctx := context.TODO()
+	resetEnv := unsetEnv(t)
+	defer resetEnv()
+
+	os.Setenv("KUBE_CONFIG_PATHS", strings.Join([]string{
+		"test-fixtures/kube-config.yaml",
+		"test-fixtures/kube-config-secondary.yaml",
+	}, string(os.PathListSeparator)))
+	os.Setenv("KUBE_CTX", "oidc")
+
+	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
+	p := Provider()
+	diags := p.Configure(ctx, rc)
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+}
+
 func unsetEnv(t *testing.T) func() {
 	e := getEnv()
 
 	envVars := map[string]string{
 		"KUBE_CONFIG_PATH":          e.ConfigPath,
-		"KUBE_CONFIG_PATHS":         filepath.Join(e.ConfigPaths...),
+		"KUBE_CONFIG_PATHS":         strings.Join(e.ConfigPaths, string(os.PathListSeparator)),
 		"KUBE_CTX":                  e.Ctx,
 		"KUBE_CTX_AUTH_INFO":        e.CtxAuthInfo,
 		"KUBE_CTX_CLUSTER":          e.CtxCluster,

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -129,7 +129,9 @@ func resourceKubernetesJobUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.Get("wait_for_completion").(bool) {
 		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
 			retryUntilJobIsFinished(ctx, conn, namespace, name))
-		return diag.FromErr(err)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	return resourceKubernetesJobRead(ctx, d, meta)
 }

--- a/kubernetes/test-fixtures/kube-config-secondary.yaml
+++ b/kubernetes/test-fixtures/kube-config-secondary.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: ZHVtbXk=
+    server: https://127.0.0.1
+  name: default
+
+contexts:
+- context:
+    cluster: default
+    user: azure
+  name: azure
+- context:
+    cluster: default
+    user: gcp
+  name: gcp
+- context:
+    cluster: default
+    user: oidc
+  name: oidc
+
+users:
+- name: azure
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: azure
+- name: gcp
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+- name: oidc
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: oidc

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,6 +15,7 @@ Use the navigation to the left to read about the available resources.
 
 ```hcl
 provider "kubernetes" {
+  config_path = "~/.kube/config"
   config_context = "my-context"
 }
 
@@ -131,12 +132,11 @@ The following arguments are supported:
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. Can be sourced from `KUBE_CLIENT_CERT_DATA`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
-* `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG`. Defaults to `~/.kube/config`.
+* `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG`.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
 * `token` - (Optional) Token of your service account.  Can be sourced from `KUBE_TOKEN`.
-* `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disables this behaviour which is desired when statically specifying the configuration or relying on in-cluster config. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
     * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
     * `command` - (Required) Command to execute.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,7 +15,9 @@ Use the navigation to the left to read about the available resources.
 
 ```hcl
 provider "kubernetes" {
-  config_path = "~/.kube/config"
+  config_paths = [
+    "~/.kube/config"
+  ]
   config_context = "my-context"
 }
 
@@ -79,12 +81,6 @@ the provider will try to use the service account token from the `/var/run/secret
 Detection of in-cluster execution is based on the sole availability both of the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables,
 with non empty values.
 
-```hcl
-provider "kubernetes" {
-  load_config_file = "false"
-}
-```
-
 If you have any other static configuration setting specified in a config file or static configuration, in-cluster service account token will not be tried.
 
 ### Statically defined credentials
@@ -93,8 +89,6 @@ Another way is **statically** define TLS certificate credentials:
 
 ```hcl
 provider "kubernetes" {
-  load_config_file = "false"
-
   host = "https://104.196.242.174"
 
   client_certificate     = "${file("~/.kube/client-cert.pem")}"
@@ -107,8 +101,6 @@ or username and password (HTTP Basic Authorization):
 
 ```hcl
 provider "kubernetes" {
-  load_config_file = "false"
-
   host = "https://104.196.242.174"
 
   username = "username"
@@ -132,7 +124,7 @@ The following arguments are supported:
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. Can be sourced from `KUBE_CLIENT_CERT_DATA`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
-* `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG`.
+* `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`, which allows `:` to be used to delimit multiple paths.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -122,7 +122,7 @@ The following arguments are supported:
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. Can be sourced from `KUBE_CLIENT_CERT_DATA`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
-* `config_path` - (Optional) A path to a kube config files. Can be sourced from `KUBE_CONFIG_PATH`.
+* `config_path` - (Optional) A path to a kube config file. Can be sourced from `KUBE_CONFIG_PATH`.
 * `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,9 +15,7 @@ Use the navigation to the left to read about the available resources.
 
 ```hcl
 provider "kubernetes" {
-  config_paths = [
-    "~/.kube/config"
-  ]
+  config_path    = "~/.kube/config"
   config_context = "my-context"
 }
 
@@ -124,6 +122,7 @@ The following arguments are supported:
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. Can be sourced from `KUBE_CLIENT_CERT_DATA`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
+* `config_path` - (Optional) A path to a kube config files. Can be sourced from `KUBE_CONFIG_PATH`.
 * `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`, which allows `:` to be used to delimit multiple paths.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
 * `config_path` - (Optional) A path to a kube config files. Can be sourced from `KUBE_CONFIG_PATH`.
-* `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`, which allows `:` to be used to delimit multiple paths.
+* `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.


### PR DESCRIPTION
### Description

Removes the load_config_file attribute and drops implicit support for `KUBECONFIG`. 

### Acceptance tests
- [ ] ~Have you added an acceptance test for the functionality being added?~
- [ ] Have you run the acceptance tests on this branch?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Remove `load_config_file` attribute from provider block
Remove explicit support for KUBECONFIG
Remove config_path default to ~/.kube/config
Add config_paths attribute to provider block
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
