### PR TITLE
Normalize wait defaults across Deployment, DaemonSet, StatefulSet, Service, Ingress, and Job

### DIFF
--- a/kubernetes/resource_kubernetes_daemonset_test.go
+++ b/kubernetes/resource_kubernetes_daemonset_test.go
@@ -71,13 +71,14 @@ func TestAccKubernetesDaemonSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
 					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "spec.0.strategy.0.type", "RollingUpdate"),
 					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "spec.0.strategy.0.rolling_update.0.max_unavailable", "1"),
+					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "wait_for_rollout", "true"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_rollout"},
 			},
 			{
 				Config: testAccKubernetesDaemonSetConfig_modified(name),
@@ -111,6 +112,7 @@ func TestAccKubernetesDaemonSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "spec.0.template.0.spec.0.dns_config.0.option.1.name", "use-vc"),
 					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "spec.0.template.0.spec.0.dns_config.0.option.1.value", ""),
 					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "spec.0.template.0.spec.0.dns_policy", "Default"),
+					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "wait_for_rollout", "true"),
 				),
 			},
 		},

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -3,11 +3,11 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -3,9 +3,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	networking "k8s.io/api/networking/v1beta1"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -123,7 +124,6 @@ func resourceKubernetesIngress() *schema.Resource {
 			"wait_for_load_balancer": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created.",
 			},
 		},

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -3,12 +3,13 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +49,7 @@ func resourceKubernetesJob() *schema.Resource {
 			"wait_for_completion": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 		},
 	}

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -58,7 +58,7 @@ func TestAccKubernetesService_basic(t *testing.T) {
 				ResourceName:            "kubernetes_service.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_load_balancer"},
 			},
 			{
 				Config: testAccKubernetesServiceConfig_modified(name),

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -3,8 +3,9 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,8 +43,8 @@ func resourceKubernetesStatefulSet() *schema.Resource {
 			},
 			"wait_for_rollout": {
 				Type:        schema.TypeBool,
-				Description: "Wait for the rollout of the stateful set to complete. Defaults to false.",
-				Default:     false,
+				Description: "Wait for the rollout of the stateful set to complete. Defaults to true.",
+				Default:     true,
 				Optional:    true,
 			},
 		},

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -1,6 +1,9 @@
 package kubernetes
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -128,11 +131,17 @@ func jobSpecFields() map[string]*schema.Schema {
 			},
 		},
 		"ttl_seconds_after_finished": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			ForceNew:     true,
-			ValidateFunc: validateNonNegativeInteger,
-			Description:  "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: func(value interface{}, key string) ([]string, []error) {
+				v, err := strconv.Atoi(value.(string))
+				if err != nil {
+					return []string{}, []error{fmt.Errorf("%s is not a valid integer", key)}
+				}
+				return validateNonNegativeInteger(v, key)
+			},
+			Description: "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
 		},
 	}
 

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	batchv1 "k8s.io/api/batch/v1"
 )
@@ -49,7 +51,7 @@ func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData, prefix ...string
 	att["template"] = podSpec
 
 	if in.TTLSecondsAfterFinished != nil {
-		att["ttl_seconds_after_finished"] = *in.TTLSecondsAfterFinished
+		att["ttl_seconds_after_finished"] = strconv.Itoa(int(*in.TTLSecondsAfterFinished))
 	}
 
 	return []interface{}{att}, nil
@@ -94,8 +96,12 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 	}
 	obj.Template = *template
 
-	if v, ok := in["ttl_seconds_after_finished"].(int); ok && v >= 0 {
-		obj.TTLSecondsAfterFinished = ptrToInt32(int32(v))
+	if v, ok := in["ttl_seconds_after_finished"].(string); ok && v != "" {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return obj, err
+		}
+		obj.TTLSecondsAfterFinished = ptrToInt32(int32(i))
 	}
 
 	return obj, nil

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -79,6 +79,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard daemonset's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec defines the specification of the desired behavior of the daemonset. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
+* `wait_for_rollout` - (Optional) Wait for the deployment to successfully roll out. Defaults to `true`.
 
 ## Nested Blocks
 

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard ingress's metadata. For more info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
 * `spec` - (Required) Spec defines the behavior of a ingress. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-* `wait_for_load_balancer` - (Optional) Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created.
+* `wait_for_load_balancer` - (Optional) Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created. Defaults to `false`.
 
 ## Nested Blocks
 

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard resource's metadata. For more info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 * `spec` - (Required) Specification of the desired behavior of a job. For more info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
 * `wait_for_completion` - 
-(Optional) If `true` blocks job `create` or `update` until the status of the job has a `Complete` or `Failed` condition.
+(Optional) If `true` blocks job `create` or `update` until the status of the job has a `Complete` or `Failed` condition. Defaults to `true`.
 
 ## Nested Blocks
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard service's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec defines the behavior of a service. [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
+* `wait_for_load_balancer` - (Optional) Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created. Defaults to `true`.
 
 ## Nested Blocks
 

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -213,7 +213,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard Kubernetes object metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec defines the specification of the desired behavior of the stateful set. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
-* `wait_for_rollout` - (Optional) Wait for the StatefulSet to finish rolling out. Defaults to `false`.
+* `wait_for_rollout` - (Optional) Wait for the StatefulSet to finish rolling out. Defaults to `true`.
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

This PR normalizes the default values for `wait_for_rollout`, `wait_for_completion`, and `wait_for_load_balancer`. The default behaviour was inconsistent here, with some being true and some being false – all will now be defaulted to `true`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -run 'TestAccKubernetes(Job|Ingress|DaemonSet|Deployment)' -timeout 120m
=== RUN   TestAccKubernetesDaemonSet_minimal
--- PASS: TestAccKubernetesDaemonSet_minimal (9.97s)
=== RUN   TestAccKubernetesDaemonSet_basic
--- PASS: TestAccKubernetesDaemonSet_basic (17.93s)
=== RUN   TestAccKubernetesDaemonSet_with_template_metadata
--- PASS: TestAccKubernetesDaemonSet_with_template_metadata (16.39s)
=== RUN   TestAccKubernetesDaemonSet_initContainer
--- PASS: TestAccKubernetesDaemonSet_initContainer (8.23s)
=== RUN   TestAccKubernetesDaemonSet_noTopLevelLabels
--- PASS: TestAccKubernetesDaemonSet_noTopLevelLabels (9.60s)
=== RUN   TestAccKubernetesDaemonSet_with_tolerations
--- PASS: TestAccKubernetesDaemonSet_with_tolerations (8.26s)
=== RUN   TestAccKubernetesDaemonSet_with_tolerations_unset_toleration_seconds
--- PASS: TestAccKubernetesDaemonSet_with_tolerations_unset_toleration_seconds (7.51s)
=== RUN   TestAccKubernetesDeployment_basic
--- PASS: TestAccKubernetesDeployment_basic (24.05s)
=== RUN   TestAccKubernetesDeployment_initContainer
--- PASS: TestAccKubernetesDeployment_initContainer (24.18s)
=== RUN   TestAccKubernetesDeployment_generatedName
--- PASS: TestAccKubernetesDeployment_generatedName (10.00s)
=== RUN   TestAccKubernetesDeployment_with_security_context
--- PASS: TestAccKubernetesDeployment_with_security_context (8.78s)
=== RUN   TestAccKubernetesDeployment_with_security_context_run_as_group
--- PASS: TestAccKubernetesDeployment_with_security_context_run_as_group (8.85s)
=== RUN   TestAccKubernetesDeployment_with_security_context_sysctl
--- PASS: TestAccKubernetesDeployment_with_security_context_sysctl (8.55s)
=== RUN   TestAccKubernetesDeployment_with_tolerations
--- PASS: TestAccKubernetesDeployment_with_tolerations (8.62s)
=== RUN   TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds
--- PASS: TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds (9.13s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (9.63s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (8.63s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (10.70s)
=== RUN   TestAccKubernetesDeployment_with_container_lifecycle
--- PASS: TestAccKubernetesDeployment_with_container_lifecycle (8.74s)
=== RUN   TestAccKubernetesDeployment_with_container_security_context
--- PASS: TestAccKubernetesDeployment_with_container_security_context (8.79s)
=== RUN   TestAccKubernetesDeployment_with_container_security_context_run_as_group
--- PASS: TestAccKubernetesDeployment_with_container_security_context_run_as_group (11.45s)
=== RUN   TestAccKubernetesDeployment_with_volume_mount
--- PASS: TestAccKubernetesDeployment_with_volume_mount (8.68s)
=== RUN   TestAccKubernetesDeployment_ForceNew
--- PASS: TestAccKubernetesDeployment_ForceNew (31.28s)
=== RUN   TestAccKubernetesDeployment_with_resource_requirements
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (8.77s)
=== RUN   TestAccKubernetesDeployment_with_empty_dir_volume
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (18.60s)
=== RUN   TestAccKubernetesDeploymentUpdate_basic
--- PASS: TestAccKubernetesDeploymentUpdate_basic (29.43s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate (9.16s)
=== RUN   TestAccKubernetesDeployment_with_share_process_namespace
--- PASS: TestAccKubernetesDeployment_with_share_process_namespace (9.41s)
=== RUN   TestAccKubernetesDeployment_no_rollout_wait
--- PASS: TestAccKubernetesDeployment_no_rollout_wait (7.64s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc (10.95s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_200perc_max_unavailable_0perc
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_200perc_max_unavailable_0perc (8.65s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_0_max_unavailable_1
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_0_max_unavailable_1 (8.62s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_0
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_0 (7.66s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2 (8.64s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_recreate
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_recreate (8.75s)
=== RUN   TestAccKubernetesDeployment_with_host_aliases
--- PASS: TestAccKubernetesDeployment_with_host_aliases (9.74s)
=== RUN   TestAccKubernetesDeployment_regression
--- PASS: TestAccKubernetesDeployment_regression (124.67s)
=== RUN   TestAccKubernetesDeployment_config_with_automount_service_account_token
--- PASS: TestAccKubernetesDeployment_config_with_automount_service_account_token (10.87s)
=== RUN   TestAccKubernetesIngress_basic
--- PASS: TestAccKubernetesIngress_basic (6.88s)
=== RUN   TestAccKubernetesIngress_TLS
--- PASS: TestAccKubernetesIngress_TLS (6.85s)
=== RUN   TestAccKubernetesIngress_InternalKey
--- PASS: TestAccKubernetesIngress_InternalKey (10.18s)
=== RUN   TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud
    TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud: provider_test.go:281: The Kubernetes endpoint must come from GKE for this test to run - skipping
--- SKIP: TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud (0.01s)
=== RUN   TestAccKubernetesJob_wait_for_completion
--- PASS: TestAccKubernetesJob_wait_for_completion (25.18s)
=== RUN   TestAccKubernetesJob_basic
--- PASS: TestAccKubernetesJob_basic (20.77s)
=== RUN   TestAccKubernetesJob_ttl_seconds_after_finished
    TestAccKubernetesJob_ttl_seconds_after_finished: resource_kubernetes_job_test.go:120: TTLAfterFinished is not enabled
--- SKIP: TestAccKubernetesJob_ttl_seconds_after_finished (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	631.115s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Normalize wait defaults across Deployment, DaemonSet, StatefulSet, Service, Ingress, and Job
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
