### PR TITLE
add ingressClassName as field in Ingress manifest

### DIFF
--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -39,6 +39,11 @@ func resourceKubernetesIngress() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"ingress_class_name": {
+							Type:        schema.TypeString,
+							Description: docIngressSpec["ingressClassName"],
+							Optional:    true,
+						},
 						"backend": backendSpecFields(defaultBackendDescription),
 						// FIXME: this field is inconsistent with the k8s API 'rules'
 						"rule": {

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -32,6 +32,7 @@ func TestAccKubernetesIngress_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_ingress.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_ingress.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.ingress_class_name", "ingress-class"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service_name", "app1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service_port", "443"),
@@ -54,6 +55,7 @@ func TestAccKubernetesIngress_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_ingress.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_ingress.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.ingress_class_name", "other-ingress-class"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service_name", "svc"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service_port", "8443"),
@@ -234,6 +236,7 @@ func testAccKubernetesIngressConfig_basic(name string) string {
     name = "%s"
   }
   spec {
+	ingress_class_name = "ingress-class"
     backend {
       service_name = "app1"
       service_port = 443
@@ -260,6 +263,7 @@ func testAccKubernetesIngressConfig_modified(name string) string {
     name = "%s"
   }
   spec {
+	ingress_class_name = "other-ingress-class"
     backend {
       service_name = "svc"
       service_port = 8443

--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -55,6 +55,10 @@ func flattenIngressBackend(in *v1beta1.IngressBackend) []interface{} {
 func flattenIngressSpec(in v1beta1.IngressSpec) []interface{} {
 	att := make(map[string]interface{})
 
+	if in.IngressClassName != nil {
+		att["ingress_class_name"] = in.IngressClassName
+	}
+
 	if in.Backend != nil {
 		att["backend"] = flattenIngressBackend(in.Backend)
 	}
@@ -133,6 +137,10 @@ func expandIngressSpec(l []interface{}) v1beta1.IngressSpec {
 	}
 	in := l[0].(map[string]interface{})
 	obj := v1beta1.IngressSpec{}
+
+	if v, ok := in["ingress_class_name"].(string); ok && len(v) > 0 {
+		obj.IngressClassName = &v
+	}
 
 	if v, ok := in["backend"].([]interface{}); ok && len(v) > 0 {
 		obj.Backend = expandIngressBackend(v)


### PR DESCRIPTION
Signed-off-by: Christian Niehoff <mail@christian-niehoff.com>

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccKubernetesIngress_basic'
==> Checking that code complies with gofmt requirements...
rm -rf /home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform /home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform.lock.hcl || true
mkdir /home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform
mkdir -p /tmp/.terraform.d/localhost/test/kubernetes/9.9.9/linux_amd64 || true
go clean -cache
go build -o /tmp/.terraform.d/localhost/test/kubernetes/9.9.9/linux_amd64/terraform-provider-kubernetes_9.9.9_linux_amd64
cd /home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers && TF_CLI_CONFIG_FILE=/home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraformrc TF_PLUGIN_CACHE_DIR=/home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform terraform init -upgrade

Initializing the backend...

Initializing provider plugins...
- Finding localhost/test/kubernetes versions matching "9.9.9"...
- Installing localhost/test/kubernetes v9.9.9...
- Installed localhost/test/kubernetes v9.9.9 (unauthenticated)

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
TF_CLI_CONFIG_FILE=/home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraformrc TF_PLUGIN_CACHE_DIR=/home/chris/git-repos/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform TF_ACC=1 go test "/home/chris/git-repos/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesIngress_basic -timeout 120m
=== RUN   TestAccKubernetesIngress_basic
--- PASS: TestAccKubernetesIngress_basic (4.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	4.686s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):


```release-note
Add `ingressClassName` field.
```

### References

Resolves #1056 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
