### PR TITLE
Fix HPA causing deployment update on every apply

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -72,7 +72,6 @@ func resourceKubernetesDeployment() *schema.Resource {
 							Description: "The number of desired replicas. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
 							Optional:    true,
 							Computed:    true,
-							Default:     1,
 						},
 						"revision_history_limit": {
 							Type:        schema.TypeInt,

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -71,6 +71,7 @@ func resourceKubernetesDeployment() *schema.Resource {
 							Type:        schema.TypeInt,
 							Description: "The number of desired replicas. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
 							Optional:    true,
+							Computed:    true,
 							Default:     1,
 						},
 						"revision_history_limit": {


### PR DESCRIPTION
An associated horizontal pod autoscaler modifies the replica count. Currently the replicas setting is optional but defaults to 1 rather than accepting the computed value. This causes the deployment to update on every apply back to a size of 1.

This is such a trivial change I don't think it warrants an acceptance test of its own.