### PR TITLE
Add divisor to resource_field_ref

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -416,7 +416,7 @@ func waitForDeploymentReplicasFunc(ctx context.Context, conn *kubernetes.Clients
 			return resource.NonRetryableError(err)
 		}
 
-		var specReplicas int32 = 1 // default, acording to API docs
+		var specReplicas int32 = 1 // default, according to API docs
 		if dply.Spec.Replicas != nil {
 			specReplicas = *dply.Spec.Replicas
 		}
@@ -434,6 +434,10 @@ func waitForDeploymentReplicasFunc(ctx context.Context, conn *kubernetes.Clients
 
 			if dply.Status.Replicas > dply.Status.UpdatedReplicas {
 				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d old replicas are pending termination...", dply.Status.Replicas-dply.Status.UpdatedReplicas))
+			}
+
+			if dply.Status.Replicas > dply.Status.ReadyReplicas {
+				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d replicas wanted; %d replicas Ready", dply.Status.Replicas, dply.Status.ReadyReplicas))
 			}
 
 			if dply.Status.AvailableReplicas < dply.Status.UpdatedReplicas {

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -435,24 +435,15 @@ func TestAccKubernetesDeployment_with_container_security_context_run_as_group(t 
 					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.security_context.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.security_context.0.capabilities.#", "0"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.security_context.0.privileged", "true"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.security_context.0.se_linux_options.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.security_context.0.se_linux_options.0.level", "s0:c123,c456"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.allow_privilege_escalation", "true"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.add.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.add.0", "NET_BIND_SERVICE"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.drop.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.drop.0", "all"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.privileged", "true"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.read_only_root_filesystem", "true"),
+					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.privileged", "false"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.run_as_group", "200"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.run_as_non_root", "true"),
+					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.run_as_non_root", "false"),
 					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.run_as_user", "201"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.se_linux_options.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.1.security_context.0.se_linux_options.0.level", "s0:c123,c789"),
 				),
 			},
 		},
@@ -1875,27 +1866,12 @@ func testAccKubernetesDeploymentConfigWithContainerSecurityContextRunAsGroup(dep
         }
 
         container {
-          image = "gcr.io/google_containers/liveness"
-          name  = "containername2"
-          args  = ["/server"]
-
+          name  = "container2"
+          image = "busybox"
+          command = ["sh", "-c", "echo The app is running! && sleep 3600"]
           security_context {
-            allow_privilege_escalation = true
-
-            capabilities {
-              drop = ["all"]
-              add  = ["NET_BIND_SERVICE"]
-            }
-
-            privileged                = true
-            read_only_root_filesystem = true
-            run_as_group              = 200
-            run_as_non_root           = true
-            run_as_user               = 201
-
-            se_linux_options {
-              level = "s0:c123,c789"
-            }
+            run_as_group = 200
+            run_as_user  = 201
           }
         }
       }

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -274,6 +274,13 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Type:     schema.TypeString,
 												Optional: true,
 											},
+											"divisor": {
+												Type:             schema.TypeString,
+												Optional:         true,
+												Default:          "1",
+												ValidateFunc:     validateResourceQuantity,
+												DiffSuppressFunc: suppressEquivalentResourceQuantity,
+											},
 											"resource": {
 												Type:        schema.TypeString,
 												Required:    true,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -547,9 +547,12 @@ func volumeSchema(isUpdatable bool) *schema.Resource {
 											Type:     schema.TypeString,
 											Required: true,
 										},
-										"quantity": {
-											Type:     schema.TypeString,
-											Optional: true,
+										"divisor": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Default:          "1",
+											ValidateFunc:     validateResourceQuantity,
+											DiffSuppressFunc: suppressEquivalentResourceQuantity,
 										},
 										"resource": {
 											Type:        schema.TypeString,

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -1,7 +1,8 @@
 package kubernetes
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -204,6 +205,9 @@ func flattenResourceFieldSelector(in *v1.ResourceFieldSelector) []interface{} {
 	}
 	if in.Resource != "" {
 		att["resource"] = in.Resource
+	}
+	if in.Divisor.String() != "" {
+		att["divisor"] = in.Divisor.String()
 	}
 	return []interface{}{att}
 }
@@ -860,6 +864,13 @@ func expandResourceFieldRef(r []interface{}) (*v1.ResourceFieldSelector, error) 
 	}
 	if v, ok := in["resource"].(string); ok {
 		obj.Resource = v
+	}
+	if v, ok := in["divisor"].(string); ok {
+		q, err := resource.ParseQuantity(v)
+		if err != nil {
+			return obj, err
+		}
+		obj.Divisor = q
 	}
 	return obj, nil
 }


### PR DESCRIPTION

### Description

This PR adds a field that was missing from our implementation of `resourceFieldRef` in the `Container` spec.
This is a cherry-pick of work done by Joshua Hoblitt in https://github.com/hashicorp/terraform-provider-kubernetes/pull/538

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
=== RUN   TestAccKubernetesDeployment_basic
--- PASS: TestAccKubernetesDeployment_basic (28.53s)
=== RUN   TestAccKubernetesDeployment_regression
--- PASS: TestAccKubernetesDeployment_regression (85.69s)
=== RUN   TestAccKubernetesDeployment_with_resource_field_selector
--- PASS: TestAccKubernetesDeployment_with_resource_field_selector (16.01s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):


```release-note
* Add divisor to resource_field_ref.
* Update Deployment `wait_for` to wait for Ready pods.
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/pull/538

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
