### PR TITLE
fix assertion in TestAccKubernetesPersistentVolume_hostPath_nodeAffinity

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -643,7 +643,7 @@ func TestAccKubernetesPersistentVolume_hostPath_nodeAffinity(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.node_affinity.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.node_affinity.0.required.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.node_affinity.0.required.0.node_selector_term.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", fmt.Sprintf("%s.match_expressions.#", keyName), "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", fmt.Sprintf("%s.#", keyName), "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", fmt.Sprintf("%s.0.key", keyName), "selectorLabelTest"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", fmt.Sprintf("%s.0.operator", keyName), "In"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", fmt.Sprintf("%s.0.values.#", keyName), "1"),


### PR DESCRIPTION
### Description

When working on resolving merge conflicts in #1020 I realised `TestAccKubernetesPersistentVolume_hostPath_nodeAffinity` fails with the following error:

```
=== RUN   TestAccKubernetesPersistentVolume_hostPath_nodeAffinity
    resource_kubernetes_persistent_volume_test.go:597: Step 4/4 error: Check failed: 1 error occurred:
        	* Check 5/9 error: kubernetes_persistent_volume.test: Attribute 'spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.match_expressions.#' not found
```

This PR should fix the assertion which I believe should ensure the number of keys is `1`.
