### PR TITLE
Add configurable provider level ignored metadata keys

### DIFF
--- a/kubernetes/data_source_kubernetes_namespace.go
+++ b/kubernetes/data_source_kubernetes_namespace.go
@@ -2,11 +2,12 @@ package kubernetes
 
 import (
 	"context"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"log"
 )
 
 func dataSourceKubernetesNamespace() *schema.Resource {
@@ -51,7 +52,7 @@ func dataSourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received namespace: %#v", namespace)
-	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/data_source_kubernetes_pod.go
+++ b/kubernetes/data_source_kubernetes_pod.go
@@ -3,10 +3,11 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"log"
 )
 
 func dataSourceKubernetesPod() *schema.Resource {
@@ -57,7 +58,7 @@ func dataSourceKubernetesPodRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	log.Printf("[INFO] Received pod: %#v", pod)
 
-	err = d.Set("metadata", flattenMetadata(pod.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(pod.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_api_service.go
+++ b/kubernetes/resource_kubernetes_api_service.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -144,7 +145,7 @@ func resourceKubernetesAPIServiceRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received API service: %#v", svc)
-	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/rbac/v1"
@@ -140,7 +141,7 @@ func resourceKubernetesClusterRoleRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received cluster role: %#v", cRole)
-	err = d.Set("metadata", flattenMetadata(cRole.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(cRole.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_cluster_role_binding.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/rbac/v1"
@@ -93,7 +94,7 @@ func resourceKubernetesClusterRoleBindingRead(ctx context.Context, d *schema.Res
 	}
 
 	log.Printf("[INFO] Received ClusterRoleBinding: %#v", binding)
-	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/core/v1"
@@ -86,7 +87,7 @@ func resourceKubernetesConfigMapRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received config map: %#v", cfgMap)
-	err = d.Set("metadata", flattenMetadata(cfgMap.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(cfgMap.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -167,12 +167,12 @@ func resourceKubernetesCronJobRead(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	err = d.Set("metadata", flattenMetadata(job.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(job.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	jobSpec, err := flattenCronJobSpec(job.Spec, d)
+	jobSpec, err := flattenCronJobSpec(job.Spec, d, meta.(ProviderConfig).IgnoredKeys())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_csi_driver.go
+++ b/kubernetes/resource_kubernetes_csi_driver.go
@@ -3,8 +3,9 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -107,7 +108,7 @@ func resourceKubernetesCSIDriverRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received CSIDriver: %#v", CSIDriver)
-	err = d.Set("metadata", flattenMetadata(CSIDriver.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(CSIDriver.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_daemonset.go
+++ b/kubernetes/resource_kubernetes_daemonset.go
@@ -250,12 +250,12 @@ func resourceKubernetesDaemonSetRead(ctx context.Context, d *schema.ResourceData
 	}
 	log.Printf("[INFO] Received daemonset: %#v", daemonset)
 
-	err = d.Set("metadata", flattenMetadata(daemonset.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(daemonset.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	spec, err := flattenDaemonSetSpec(daemonset.Spec, d)
+	spec, err := flattenDaemonSetSpec(daemonset.Spec, d, meta.(ProviderConfig).IgnoredKeys())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -327,12 +327,12 @@ func resourceKubernetesDeploymentRead(ctx context.Context, d *schema.ResourceDat
 	}
 	log.Printf("[INFO] Received deployment: %#v", deployment)
 
-	err = d.Set("metadata", flattenMetadata(deployment.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(deployment.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	spec, err := flattenDeploymentSpec(deployment.Spec, d)
+	spec, err := flattenDeploymentSpec(deployment.Spec, d, meta.(ProviderConfig).IgnoredKeys())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_endpoints.go
+++ b/kubernetes/resource_kubernetes_endpoints.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/core/v1"
@@ -82,7 +83,7 @@ func resourceKubernetesEndpointsRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("Failed to read endpoint because: %s", err)
 	}
 	log.Printf("[INFO] Received endpoints: %#v", ep)
-	err = d.Set("metadata", flattenMetadata(ep.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(ep.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.Errorf("Failed to read endpoints because: %s", err)
 	}

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/autoscaling/v1"
@@ -151,7 +152,7 @@ func resourceKubernetesHorizontalPodAutoscalerRead(ctx context.Context, d *schem
 	}
 
 	log.Printf("[INFO] Received horizontal pod autoscaler: %#v", hpa)
-	err = d.Set("metadata", flattenMetadata(hpa.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(hpa.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
@@ -64,7 +65,7 @@ func resourceKubernetesHorizontalPodAutoscalerV2Read(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received horizontal pod autoscaler: %#v", hpa)
-	err = d.Set("metadata", flattenMetadata(hpa.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(hpa.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -240,7 +240,7 @@ func resourceKubernetesIngressRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("Failed to read Ingress '%s' because: %s", buildId(ing.ObjectMeta), err)
 	}
 	log.Printf("[INFO] Received ingress: %#v", ing)
-	err = d.Set("metadata", flattenMetadata(ing.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(ing.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -199,12 +199,12 @@ func resourceKubernetesJobRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	err = d.Set("metadata", flattenMetadata(job.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(job.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	jobSpec, err := flattenJobSpec(job.Spec, d)
+	jobSpec, err := flattenJobSpec(job.Spec, d, meta.(ProviderConfig).IgnoredKeys())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/core/v1"
@@ -129,7 +130,7 @@ func resourceKubernetesLimitRangeRead(ctx context.Context, d *schema.ResourceDat
 	}
 	log.Printf("[INFO] Received limit range: %#v", limitRange)
 
-	err = d.Set("metadata", flattenMetadata(limitRange.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(limitRange.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -192,7 +193,7 @@ func resourceKubernetesMutatingWebhookConfigurationRead(ctx context.Context, d *
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("metadata", flattenMetadata(cfg.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(cfg.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return nil
 	}

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -3,9 +3,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -76,7 +77,7 @@ func resourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received namespace: %#v", namespace)
-	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -231,7 +231,7 @@ func testAccCheckMetaAnnotations(om *metav1.ObjectMeta, expected map[string]stri
 		annotations := om.Annotations
 		for key := range annotations {
 			_, isExpected := expected[key]
-			if isInternalKey(key) && !isExpected {
+			if isIgnoredKey([]string{}, key) && !isExpected {
 				delete(annotations, key)
 			}
 		}
@@ -254,7 +254,7 @@ func testAccCheckMetaLabels(om *metav1.ObjectMeta, expected map[string]string) r
 		labels := om.Labels
 		for key := range labels {
 			_, isExpected := expected[key]
-			if isInternalKey(key) && !isExpected {
+			if isIgnoredKey([]string{}, key) && !isExpected {
 				delete(labels, key)
 			}
 		}

--- a/kubernetes/resource_kubernetes_network_policy.go
+++ b/kubernetes/resource_kubernetes_network_policy.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/networking/v1"
@@ -286,7 +287,7 @@ func resourceKubernetesNetworkPolicyRead(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received network policy: %#v", svc)
-	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -247,7 +248,7 @@ func resourceKubernetesPersistentVolumeRead(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received persistent volume: %#v", volume)
-	err = d.Set("metadata", flattenMetadata(volume.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(volume.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -3,9 +3,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -177,7 +178,7 @@ func resourceKubernetesPersistentVolumeClaimRead(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received persistent volume claim: %#v", claim)
-	err = d.Set("metadata", flattenMetadata(claim.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(claim.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -174,7 +174,7 @@ func resourceKubernetesPodRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	log.Printf("[INFO] Received pod: %#v", pod)
 
-	err = d.Set("metadata", flattenMetadata(pod.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(pod.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/policy/v1beta1"
@@ -157,7 +158,7 @@ func resourceKubernetesPodDisruptionBudgetRead(ctx context.Context, d *schema.Re
 	}
 
 	log.Printf("[INFO] Received pod disruption budget: %#v", pdb)
-	err = d.Set("metadata", flattenMetadata(pdb.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(pdb.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_pod_security_policy.go
+++ b/kubernetes/resource_kubernetes_pod_security_policy.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	policy "k8s.io/api/policy/v1beta1"
@@ -416,7 +417,7 @@ func resourceKubernetesPodSecurityPolicyRead(ctx context.Context, d *schema.Reso
 	}
 
 	log.Printf("[INFO] Received PodSecurityPolicy: %#v", psp)
-	err = d.Set("metadata", flattenMetadata(psp.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(psp.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_priority_class.go
+++ b/kubernetes/resource_kubernetes_priority_class.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/scheduling/v1"
@@ -98,7 +99,7 @@ func resourceKubernetesPriorityClassRead(ctx context.Context, d *schema.Resource
 	}
 	log.Printf("[INFO] Received priority class: %#v", priorityClass)
 
-	err = d.Set("metadata", flattenMetadata(priorityClass.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(priorityClass.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -3,9 +3,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -162,12 +163,12 @@ func resourceKubernetesReplicationControllerRead(ctx context.Context, d *schema.
 	}
 	log.Printf("[INFO] Received replication controller: %#v", rc)
 
-	err = d.Set("metadata", flattenMetadata(rc.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(rc.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	spec, err := flattenReplicationControllerSpec(rc.Spec, d)
+	spec, err := flattenReplicationControllerSpec(rc.Spec, d, meta.(ProviderConfig).IgnoredKeys())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -3,9 +3,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -137,7 +138,7 @@ func resourceKubernetesResourceQuotaRead(ctx context.Context, d *schema.Resource
 		}
 	}
 
-	err = d.Set("metadata", flattenMetadata(resQuota.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(resQuota.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_role.go
+++ b/kubernetes/resource_kubernetes_role.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	v1 "k8s.io/api/rbac/v1"
@@ -116,7 +117,7 @@ func resourceKubernetesRoleRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	log.Printf("[INFO] Received role: %#v", role)
-	err = d.Set("metadata", flattenMetadata(role.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(role.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_role_binding.go
+++ b/kubernetes/resource_kubernetes_role_binding.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/rbac/v1"
@@ -97,7 +98,7 @@ func resourceKubernetesRoleBindingRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	log.Printf("[INFO] Received RoleBinding: %#v", binding)
-	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/core/v1"
@@ -94,7 +95,7 @@ func resourceKubernetesSecretRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[INFO] Received secret: %#v", secret)
-	err = d.Set("metadata", flattenMetadata(secret.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(secret.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -293,7 +293,7 @@ func resourceKubernetesServiceRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received service: %#v", svc)
-	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -241,7 +241,7 @@ func resourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] Received service account: %#v", svcAcc)
-	err = d.Set("metadata", flattenMetadata(svcAcc.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(svcAcc.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -166,10 +166,10 @@ func resourceKubernetesStatefulSetRead(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 	log.Printf("[INFO] Received stateful set: %#v", statefulSet)
-	if d.Set("metadata", flattenMetadata(statefulSet.ObjectMeta, d)) != nil {
+	if d.Set("metadata", flattenMetadata(statefulSet.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys())) != nil {
 		return diag.Errorf("Error setting `metadata`: %+v", err)
 	}
-	sss, err := flattenStatefulSetSpec(statefulSet.Spec, d)
+	sss, err := flattenStatefulSetSpec(statefulSet.Spec, d, meta.(ProviderConfig).IgnoredKeys())
 	if err != nil {
 		return diag.Errorf("Error flattening `spec`: %+v", err)
 	}

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -3,8 +3,9 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -168,7 +169,7 @@ func resourceKubernetesStorageClassRead(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[INFO] Received storage class: %#v", storageClass)
 
-	err = d.Set("metadata", flattenMetadata(storageClass.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(storageClass.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		diags = append(diags, diag.FromErr(err)[0])
 	}

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -186,7 +187,7 @@ func resourceKubernetesValidatingWebhookConfigurationRead(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("metadata", flattenMetadata(cfg.ObjectMeta, d))
+	err = d.Set("metadata", flattenMetadata(cfg.ObjectMeta, d, meta.(ProviderConfig).IgnoredKeys()))
 	if err != nil {
 		return nil
 	}

--- a/kubernetes/structure_cron_job.go
+++ b/kubernetes/structure_cron_job.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/api/batch/v1beta1"
 )
 
-func flattenCronJobSpec(in v1beta1.CronJobSpec, d *schema.ResourceData) ([]interface{}, error) {
+func flattenCronJobSpec(in v1beta1.CronJobSpec, d *schema.ResourceData, ignoredKeys []string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
 	att["concurrency_policy"] = in.ConcurrencyPolicy
@@ -16,7 +16,7 @@ func flattenCronJobSpec(in v1beta1.CronJobSpec, d *schema.ResourceData) ([]inter
 
 	att["schedule"] = in.Schedule
 
-	jobTemplate, err := flattenJobTemplate(in.JobTemplate, d)
+	jobTemplate, err := flattenJobTemplate(in.JobTemplate, d, ignoredKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -35,13 +35,13 @@ func flattenCronJobSpec(in v1beta1.CronJobSpec, d *schema.ResourceData) ([]inter
 	return []interface{}{att}, nil
 }
 
-func flattenJobTemplate(in v1beta1.JobTemplateSpec, d *schema.ResourceData) ([]interface{}, error) {
+func flattenJobTemplate(in v1beta1.JobTemplateSpec, d *schema.ResourceData, ignoredKeys []string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
-	meta := flattenMetadata(in.ObjectMeta, d)
+	meta := flattenMetadata(in.ObjectMeta, d, ignoredKeys)
 	att["metadata"] = meta
 
-	jobSpec, err := flattenJobSpec(in.Spec, d, "spec.0.job_template.0.spec.0.template.0.")
+	jobSpec, err := flattenJobSpec(in.Spec, d, ignoredKeys, "spec.0.job_template.0.spec.0.template.0.")
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -7,7 +7,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 )
 
-func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData, prefix ...string) ([]interface{}, error) {
+func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData, ignoredKeys []string, prefix ...string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
 	if in.ActiveDeadlineSeconds != nil {
@@ -44,7 +44,7 @@ func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData, prefix ...string
 		delete(labels, "job-name")
 	}
 
-	podSpec, err := flattenPodTemplateSpec(in.Template, d, prefix...)
+	podSpec, err := flattenPodTemplateSpec(in.Template, d, ignoredKeys, prefix...)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/structures_daemonset.go
+++ b/kubernetes/structures_daemonset.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData) ([]interface{}, error) {
+func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData, ignoredKeys []string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	att["min_ready_seconds"] = in.MinReadySeconds
 
@@ -26,7 +26,7 @@ func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData) ([]in
 	}
 	template := make(map[string]interface{})
 	template["spec"] = podSpec
-	template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
+	template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, ignoredKeys, "spec.0.template.0.")
 	att["template"] = []interface{}{template}
 
 	return []interface{}{att}, nil

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData) ([]interface{}, error) {
+func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData, ignoredKeys []string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	att["min_ready_seconds"] = in.MinReadySeconds
 
@@ -37,7 +37,7 @@ func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData) ([]
 	}
 	template := make(map[string]interface{})
 	template["spec"] = podSpec
-	template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
+	template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, ignoredKeys, "spec.0.template.0.")
 	att["template"] = []interface{}{template}
 
 	return []interface{}{att}, nil

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -2,10 +2,10 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
-func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, d *schema.ResourceData) ([]interface{}, error) {
+func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, d *schema.ResourceData, ignoredKeys []string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	att["min_ready_seconds"] = in.MinReadySeconds
 
@@ -24,7 +24,7 @@ func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, d *schema
 		}
 		template := make(map[string]interface{})
 		template["spec"] = podSpec
-		template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d)
+		template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, ignoredKeys)
 		att["template"] = []interface{}{template}
 	}
 

--- a/kubernetes/structures_test.go
+++ b/kubernetes/structures_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestIsInternalKey(t *testing.T) {
+func TestIsIgnoredKey(t *testing.T) {
 	testCases := []struct {
 		Key      string
 		Expected bool
@@ -17,10 +17,11 @@ func TestIsInternalKey(t *testing.T) {
 		{"any.kubernetes.io", true},
 		{"kubernetes.io", true},
 		{"pv.kubernetes.io/any/path", true},
+		{"deprecated.daemonset.template.generation", true},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			isInternal := isInternalKey(tc.Key)
+			isInternal := isIgnoredKey(internalKeys, tc.Key)
 			if tc.Expected && isInternal != tc.Expected {
 				t.Fatalf("Expected %q to be internal", tc.Key)
 			}

--- a/website/docs/guides/v2-upgrade-guide.markdown
+++ b/website/docs/guides/v2-upgrade-guide.markdown
@@ -35,7 +35,7 @@ We changed the `load_balancers_ingress` block on the Service and Ingress resourc
 
 ```hcl
 output "ingress_hostname" {
-    value = kubernetes_ingress.example_ingress.status[0].load_balancer[0].ingress[0].hostname
+  value = kubernetes_ingress.example_ingress.status[0].load_balancer[0].ingress[0].hostname
 }
 ```
 
@@ -73,8 +73,8 @@ resource "kubernetes_deployment" "example" {
           image = "nginx:1.7.8"
           name  = "example"
         }
-        
-        service_account_name = "default"
+
+        service_account_name            = "default"
         automount_service_account_token = false
       }
     }
@@ -85,6 +85,7 @@ resource "kubernetes_deployment" "example" {
 ### Normalize wait defaults across Deployment, DaemonSet, StatefulSet, Service, Ingress, and Job
 
 All of the `wait_for` attributes now default to `true`, including:
+
 - `wait_for_rollout` on the `kubernetes_deployment`, `kubernetes_daemonset`, and `kubernetes_stateful_set` resources
 - `wait_for_loadbalancer` on the `kubernetes_service` and `kubernetes_ingress` resources
 - `wait_for_completion` on the `kubernetes_job` resource
@@ -103,7 +104,7 @@ resource "kubernetes_service" "myapp1" {
     }
 
     session_affinity = "ClientIP"
-    type = "LoadBalancer"
+    type             = "LoadBalancer"
 
     port {
       port        = 8080
@@ -131,7 +132,7 @@ resource "kubernetes_pod" "test" {
     container {
       image = "nginx:1.7.9"
       name  = "example"
-      
+
       resources {
         limits = {
           cpu          = "0.5"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -133,3 +133,4 @@ The following arguments are supported:
     * `command` - (Required) Command to execute.
     * `args` - (Optional) List of arguments to pass when executing the plugin.
     * `env` - (Optional) Map of environment variables to set when executing the plugin.
+* `ignored_metadata_keys` - (Optional) List of metadata annotation and label keys that the provider will ignore for all resources and not manage. Regular expressions can be used.


### PR DESCRIPTION
This introduces a new provider configuration parameter
`ignored_metadata_keys` that allows the user to specify expressions to
ignore matching metadata annotations and labels on all kubernetes
resources.

For example:

```terraform
provider "kubernetes" {
  ignored_metadata_keys = ["cattle.io/status", "lifecycle.cattle.io/create.namespace-auth"]
}
```

This tries to be backwards compatible by hardcoding a list of internal
keys in `internalKeys`, which were previously ignored already.

I had to change a few things in the provider config to pass the `ignoredKeys`
to every resource. Let me know if there's a better approach on how to solve that.
It was a bit tedious to have to pass this down everywhere but I cannot think
of another way without introducing global state.

### Description


### Acceptance tests
~~- [ ] Have you added an acceptance test for the functionality being added?~~
- [x] Have you run the acceptance tests on this branch?

So far there are no acceptance tests for the provider config itself. I have modified the existing relevant unit test.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):

```release-note
Add configurable provider level ignored metadata keys
```

### References

Fixes #746

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
