### PR TITLE
Add StateUpgraders for resources field change

### DIFF
--- a/kubernetes/resource_kubernetes_cron_job_migrate.go
+++ b/kubernetes/resource_kubernetes_cron_job_migrate.go
@@ -1,0 +1,17 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceKubernetesCronJobV0() *schema.Resource {
+	schemaV1 := resourceKubernetesCronJobSchemaV1()
+	schemaV0 := patchJobTemplatePodSpecWithResourcesFieldV0(schemaV1)
+	return &schema.Resource{Schema: schemaV0}
+}
+
+func resourceKubernetesCronJobUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	return upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+}

--- a/kubernetes/resource_kubernetes_daemonset_migrate.go
+++ b/kubernetes/resource_kubernetes_daemonset_migrate.go
@@ -6,12 +6,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceKubernetesDeploymentV0() *schema.Resource {
-	schemaV1 := resourceKubernetesDeploymentSchemaV1()
+func resourceKubernetesDaemonSetV0() *schema.Resource {
+	schemaV1 := resourceKubernetesDaemonSetSchemaV1()
 	schemaV0 := patchTemplatePodSpecWithResourcesFieldV0(schemaV1)
 	return &schema.Resource{Schema: schemaV0}
 }
 
-func resourceKubernetesDeploymentUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceKubernetesDaemonSetUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
 }

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -33,159 +33,169 @@ func resourceKubernetesDeployment() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourceKubernetesDeploymentV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceKubernetesDeploymentUpgradeV0,
+			},
+		},
+		SchemaVersion: 1,
+		Schema:        resourceKubernetesDeploymentSchemaV1(),
+	}
+}
 
-		Schema: map[string]*schema.Schema{
-			"metadata": namespacedMetadataSchema("deployment", true),
-			"spec": {
-				Type:        schema.TypeList,
-				Description: "Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps",
-				Required:    true,
-				MaxItems:    1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"min_ready_seconds": {
-							Type:        schema.TypeInt,
-							Description: "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-							Optional:    true,
-							Default:     0,
-						},
-						"paused": {
-							Type:        schema.TypeBool,
-							Description: "Indicates that the deployment is paused.",
-							Optional:    true,
-							Default:     false,
-						},
-						"progress_deadline_seconds": {
-							Type:        schema.TypeInt,
-							Description: "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
-							Optional:    true,
-							Default:     600,
-						},
-						"replicas": {
-							Type:         schema.TypeString,
-							Description:  "Number of desired pods. This is a string to be able to distinguish between explicit zero and not specified.",
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validateTypeStringNullableInt,
-						},
-						"revision_history_limit": {
-							Type:        schema.TypeInt,
-							Description: "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
-							Optional:    true,
-							Default:     10,
-						},
-						"selector": {
-							Type:        schema.TypeList,
-							Description: "A label query over pods that should match the Replicas count.",
-							Optional:    true,
-							ForceNew:    true,
-							MaxItems:    1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"match_expressions": {
-										Type:        schema.TypeList,
-										Description: "A list of label selector requirements. The requirements are ANDed.",
-										Optional:    true,
-										ForceNew:    true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"key": {
-													Type:        schema.TypeString,
-													Description: "The label key that the selector applies to.",
-													Optional:    true,
-													ForceNew:    true,
-												},
-												"operator": {
-													Type:        schema.TypeString,
-													Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
-													Optional:    true,
-													ForceNew:    true,
-												},
-												"values": {
-													Type:        schema.TypeSet,
-													Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
-													Optional:    true,
-													ForceNew:    true,
-													Elem:        &schema.Schema{Type: schema.TypeString},
-													Set:         schema.HashString,
-												},
+func resourceKubernetesDeploymentSchemaV1() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": namespacedMetadataSchema("deployment", true),
+		"spec": {
+			Type:        schema.TypeList,
+			Description: "Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps",
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"min_ready_seconds": {
+						Type:        schema.TypeInt,
+						Description: "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+						Optional:    true,
+						Default:     0,
+					},
+					"paused": {
+						Type:        schema.TypeBool,
+						Description: "Indicates that the deployment is paused.",
+						Optional:    true,
+						Default:     false,
+					},
+					"progress_deadline_seconds": {
+						Type:        schema.TypeInt,
+						Description: "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+						Optional:    true,
+						Default:     600,
+					},
+					"replicas": {
+						Type:         schema.TypeString,
+						Description:  "Number of desired pods. This is a string to be able to distinguish between explicit zero and not specified.",
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: validateTypeStringNullableInt,
+					},
+					"revision_history_limit": {
+						Type:        schema.TypeInt,
+						Description: "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+						Optional:    true,
+						Default:     10,
+					},
+					"selector": {
+						Type:        schema.TypeList,
+						Description: "A label query over pods that should match the Replicas count.",
+						Optional:    true,
+						ForceNew:    true,
+						MaxItems:    1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"match_expressions": {
+									Type:        schema.TypeList,
+									Description: "A list of label selector requirements. The requirements are ANDed.",
+									Optional:    true,
+									ForceNew:    true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"key": {
+												Type:        schema.TypeString,
+												Description: "The label key that the selector applies to.",
+												Optional:    true,
+												ForceNew:    true,
 											},
-										},
-									},
-									"match_labels": {
-										Type:        schema.TypeMap,
-										Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-										Optional:    true,
-										ForceNew:    true,
-									},
-								},
-							},
-						},
-						"strategy": {
-							Type:        schema.TypeList,
-							Description: "The deployment strategy to use to replace existing pods with new ones.",
-							Optional:    true,
-							Computed:    true,
-							MaxItems:    1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"type": {
-										Type:         schema.TypeString,
-										Description:  "Type of deployment. Can be 'Recreate' or 'RollingUpdate'. Default is RollingUpdate.",
-										Optional:     true,
-										Default:      "RollingUpdate",
-										ValidateFunc: validation.StringInSlice([]string{"RollingUpdate", "Recreate"}, false),
-									},
-									"rolling_update": {
-										Type:        schema.TypeList,
-										Description: "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
-										Optional:    true,
-										Computed:    true,
-										MaxItems:    1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"max_surge": {
-													Type:         schema.TypeString,
-													Description:  "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
-													Optional:     true,
-													Default:      "25%",
-													ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
-												},
-												"max_unavailable": {
-													Type:         schema.TypeString,
-													Description:  "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
-													Optional:     true,
-													Default:      "25%",
-													ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
-												},
+											"operator": {
+												Type:        schema.TypeString,
+												Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
+												Optional:    true,
+												ForceNew:    true,
+											},
+											"values": {
+												Type:        schema.TypeSet,
+												Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
+												Optional:    true,
+												ForceNew:    true,
+												Elem:        &schema.Schema{Type: schema.TypeString},
+												Set:         schema.HashString,
 											},
 										},
 									},
 								},
+								"match_labels": {
+									Type:        schema.TypeMap,
+									Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+									Optional:    true,
+									ForceNew:    true,
+								},
 							},
 						},
-						"template": {
-							Type:        schema.TypeList,
-							Description: "Template describes the pods that will be created.",
-							Required:    true,
-							MaxItems:    1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"metadata": namespacedMetadataSchemaIsTemplate("pod", true, true),
-									"spec": {
-										Type:        schema.TypeList,
-										Description: "Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps",
-										Required:    true,
-										MaxItems:    1,
-										Elem: &schema.Resource{
-											Schema: podSpecFields(true, false, false),
+					},
+					"strategy": {
+						Type:        schema.TypeList,
+						Description: "The deployment strategy to use to replace existing pods with new ones.",
+						Optional:    true,
+						Computed:    true,
+						MaxItems:    1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"type": {
+									Type:         schema.TypeString,
+									Description:  "Type of deployment. Can be 'Recreate' or 'RollingUpdate'. Default is RollingUpdate.",
+									Optional:     true,
+									Default:      "RollingUpdate",
+									ValidateFunc: validation.StringInSlice([]string{"RollingUpdate", "Recreate"}, false),
+								},
+								"rolling_update": {
+									Type:        schema.TypeList,
+									Description: "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
+									Optional:    true,
+									Computed:    true,
+									MaxItems:    1,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"max_surge": {
+												Type:         schema.TypeString,
+												Description:  "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
+												Optional:     true,
+												Default:      "25%",
+												ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
+											},
+											"max_unavailable": {
+												Type:         schema.TypeString,
+												Description:  "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
+												Optional:     true,
+												Default:      "25%",
+												ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
+											},
 										},
+									},
+								},
+							},
+						},
+					},
+					"template": {
+						Type:        schema.TypeList,
+						Description: "Template describes the pods that will be created.",
+						Required:    true,
+						MaxItems:    1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"metadata": namespacedMetadataSchemaIsTemplate("pod", true, true),
+								"spec": {
+									Type:        schema.TypeList,
+									Description: "Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps",
+									Required:    true,
+									MaxItems:    1,
+									Elem: &schema.Resource{
+										Schema: podSpecFields(true, false, false),
 									},
 								},
 							},
@@ -193,12 +203,12 @@ func resourceKubernetesDeployment() *schema.Resource {
 					},
 				},
 			},
-			"wait_for_rollout": {
-				Type:        schema.TypeBool,
-				Description: "Wait for the rollout of the deployment to complete. Defaults to true.",
-				Default:     true,
-				Optional:    true,
-			},
+		},
+		"wait_for_rollout": {
+			Type:        schema.TypeBool,
+			Description: "Wait for the rollout of the deployment to complete. Defaults to true.",
+			Default:     true,
+			Optional:    true,
 		},
 	}
 }

--- a/kubernetes/resource_kubernetes_deployment_migrate.go
+++ b/kubernetes/resource_kubernetes_deployment_migrate.go
@@ -1,0 +1,17 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceKubernetesDeploymentV0() *schema.Resource {
+	schemaV1 := resourceKubernetesDeploymentSchemaV1()
+	schemaV0 := patchTemplatePodSpecWithResourcesFieldV0(schemaV1, "template")
+	return &schema.Resource{Schema: schemaV0}
+}
+
+func resourceKubernetesDeploymentUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta, "template")
+}

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -27,30 +27,40 @@ func resourceKubernetesJob() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourceKubernetesJobV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceKubernetesJobUpgradeV0,
+			},
+		},
+		SchemaVersion: 1,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Update: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
+		Schema: resourceKubernetesJobSchemaV1(),
+	}
+}
 
-		Schema: map[string]*schema.Schema{
-			"metadata": jobMetadataSchema(),
-			"spec": {
-				Type:        schema.TypeList,
-				Description: "Spec of the job owned by the cluster",
-				Required:    true,
-				MaxItems:    1,
-				ForceNew:    true,
-				Elem: &schema.Resource{
-					Schema: jobSpecFields(),
-				},
+func resourceKubernetesJobSchemaV1() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": jobMetadataSchema(),
+		"spec": {
+			Type:        schema.TypeList,
+			Description: "Spec of the job owned by the cluster",
+			Required:    true,
+			MaxItems:    1,
+			ForceNew:    true,
+			Elem: &schema.Resource{
+				Schema: jobSpecFields(),
 			},
-			"wait_for_completion": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		},
+		"wait_for_completion": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
 		},
 	}
 }

--- a/kubernetes/resource_kubernetes_job_migrate.go
+++ b/kubernetes/resource_kubernetes_job_migrate.go
@@ -6,12 +6,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceKubernetesDeploymentV0() *schema.Resource {
-	schemaV1 := resourceKubernetesDeploymentSchemaV1()
+func resourceKubernetesJobV0() *schema.Resource {
+	schemaV1 := resourceKubernetesJobSchemaV1()
 	schemaV0 := patchTemplatePodSpecWithResourcesFieldV0(schemaV1)
 	return &schema.Resource{Schema: schemaV0}
 }
 
-func resourceKubernetesDeploymentUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceKubernetesJobUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
 }

--- a/kubernetes/resource_kubernetes_pod_migrate.go
+++ b/kubernetes/resource_kubernetes_pod_migrate.go
@@ -1,0 +1,17 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceKubernetesPodV0() *schema.Resource {
+	schemaV1 := resourceKubernetesPodSchemaV1()
+	schemaV0 := patchPodSpecWithResourcesFieldV0(schemaV1)
+	return &schema.Resource{Schema: schemaV0}
+}
+
+func resourceKubernetesPodUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	return upgradePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+}

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -29,33 +29,43 @@ func resourceKubernetesStatefulSet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourceKubernetesStatefulSetV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceKubernetesStatefulSetUpgradeV0,
+			},
+		},
+		SchemaVersion: 1,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Read:   schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		Schema: resourceKubernetesStatefulSetSchemaV1(),
+	}
+}
 
-		Schema: map[string]*schema.Schema{
-			"metadata": namespacedMetadataSchema("stateful set", true),
-			"spec": {
-				Type:        schema.TypeList,
-				Description: "Spec defines the desired identities of pods in this set.",
-				Required:    true,
-				MaxItems:    1,
-				MinItems:    1,
-				ForceNew:    true,
-				Elem: &schema.Resource{
-					Schema: statefulSetSpecFields(false),
-				},
+func resourceKubernetesStatefulSetSchemaV1() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": namespacedMetadataSchema("stateful set", true),
+		"spec": {
+			Type:        schema.TypeList,
+			Description: "Spec defines the desired identities of pods in this set.",
+			Required:    true,
+			MaxItems:    1,
+			MinItems:    1,
+			ForceNew:    true,
+			Elem: &schema.Resource{
+				Schema: statefulSetSpecFields(false),
 			},
-			"wait_for_rollout": {
-				Type:        schema.TypeBool,
-				Description: "Wait for the rollout of the stateful set to complete. Defaults to true.",
-				Default:     true,
-				Optional:    true,
-			},
+		},
+		"wait_for_rollout": {
+			Type:        schema.TypeBool,
+			Description: "Wait for the rollout of the stateful set to complete. Defaults to true.",
+			Default:     true,
+			Optional:    true,
 		},
 	}
 }

--- a/kubernetes/resource_kubernetes_stateful_set_migrate.go
+++ b/kubernetes/resource_kubernetes_stateful_set_migrate.go
@@ -6,12 +6,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceKubernetesDeploymentV0() *schema.Resource {
-	schemaV1 := resourceKubernetesDeploymentSchemaV1()
+func resourceKubernetesStatefulSetV0() *schema.Resource {
+	schemaV1 := resourceKubernetesStatefulSetSchemaV1()
 	schemaV0 := patchTemplatePodSpecWithResourcesFieldV0(schemaV1)
 	return &schema.Resource{Schema: schemaV0}
 }
 
-func resourceKubernetesDeploymentUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceKubernetesStatefulSetUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
 }

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -92,7 +92,7 @@ func handlerFields() map[string]*schema.Schema {
 	}
 }
 
-func resourcesField() map[string]*schema.Schema {
+func resourcesFieldV1() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"limits": {
 			Type:        schema.TypeMap,
@@ -113,6 +113,45 @@ func resourcesField() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 			DiffSuppressFunc: suppressEquivalentResourceQuantity,
+		},
+	}
+}
+
+func resourcesFieldV0() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"limits": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cpu": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"memory": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"requests": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cpu": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"memory": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -474,7 +513,7 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 			Computed:    true,
 			Description: "Compute Resources required by this container. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources",
 			Elem: &schema.Resource{
-				Schema: resourcesField(),
+				Schema: resourcesFieldV1(),
 			},
 		},
 		"security_context": {

--- a/kubernetes/schema_resources_migrate.go
+++ b/kubernetes/schema_resources_migrate.go
@@ -47,7 +47,7 @@ func upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState
 
 	spec := s[0].(map[string]interface{})
 	jt, ok := spec["job_template"].([]interface{})
-	if !ok || len(jt) > 0 {
+	if !ok || len(jt) == 0 {
 		return rawState, nil
 	}
 

--- a/kubernetes/schema_resources_migrate.go
+++ b/kubernetes/schema_resources_migrate.go
@@ -1,0 +1,90 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func patchTemplatePodSpecWithResourcesFieldV0(m map[string]*schema.Schema, templateFieldName string) map[string]*schema.Schema {
+	spec := m["spec"].Elem.(*schema.Resource)
+	template := spec.Schema[templateFieldName].Elem.(*schema.Resource)
+	podSpec := template.Schema["spec"].Elem.(*schema.Resource)
+
+	initContainer := podSpec.Schema["init_container"].Elem.(*schema.Resource)
+	initContainer.Schema["resources"].Elem = &schema.Resource{
+		Schema: resourcesFieldV0(),
+	}
+
+	container := podSpec.Schema["container"].Elem.(*schema.Resource)
+	container.Schema["resources"].Elem = &schema.Resource{
+		Schema: resourcesFieldV0(),
+	}
+	return m
+}
+
+func patchPodSpecWithResourcesFieldV0(m map[string]*schema.Schema, templateFieldName string) map[string]*schema.Schema {
+	spec := m["spec"].Elem.(*schema.Resource)
+
+	initContainer := spec.Schema["init_container"].Elem.(*schema.Resource)
+	initContainer.Schema["resources"].Elem = &schema.Resource{
+		Schema: resourcesFieldV0(),
+	}
+
+	container := spec.Schema["container"].Elem.(*schema.Resource)
+	container.Schema["resources"].Elem = &schema.Resource{
+		Schema: resourcesFieldV0(),
+	}
+	return m
+}
+
+func upgradeTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}, templateFieldName string) (map[string]interface{}, error) {
+	if s, ok := rawState["spec"].([]interface{}); ok && len(s) > 0 {
+		spec := s[0].(map[string]interface{})
+		if t, ok := spec[templateFieldName].([]interface{}); ok && len(t) > 0 {
+			template := t[0].(map[string]interface{})
+			if ps, ok := template["spec"].([]interface{}); ok && len(ps) > 0 {
+				podSpec := ps[0].(map[string]interface{})
+				upgradedPodSpec := upgradePodSpecWithResourcesFieldV0(podSpec)
+				template["spec"] = []interface{}{upgradedPodSpec}
+			}
+		}
+	}
+	return rawState, nil
+}
+
+func upgradePodSpecWithResourcesFieldV0(rawState map[string]interface{}) map[string]interface{} {
+	if initContainers, ok := rawState["init_container"].([]interface{}); ok && len(initContainers) > 0 {
+		for _, c := range initContainers {
+			initContainer := c.(map[string]interface{})
+			if r, ok := initContainer["resources"].([]interface{}); ok && len(r) > 0 {
+				resources := r[0].(map[string]interface{})
+				if req, ok := resources["requests"].([]interface{}); ok && len(req) > 0 {
+					requests := req[0].(map[string]interface{})
+					resources["requests"] = requests
+				}
+				if lim, ok := resources["limits"].([]interface{}); ok && len(lim) > 0 {
+					limits := lim[0].(map[string]interface{})
+					resources["limits"] = limits
+				}
+			}
+		}
+	}
+	if containers, ok := rawState["container"].([]interface{}); ok && len(containers) > 0 {
+		for _, c := range containers {
+			container := c.(map[string]interface{})
+			if r, ok := container["resources"].([]interface{}); ok && len(r) > 0 {
+				resources := r[0].(map[string]interface{})
+				if req, ok := resources["requests"].([]interface{}); ok && len(req) > 0 {
+					requests := req[0].(map[string]interface{})
+					resources["requests"] = requests
+				}
+				if lim, ok := resources["limits"].([]interface{}); ok && len(lim) > 0 {
+					limits := lim[0].(map[string]interface{})
+					resources["limits"] = limits
+				}
+			}
+		}
+	}
+	return rawState
+}

--- a/kubernetes/schema_resources_migrate.go
+++ b/kubernetes/schema_resources_migrate.go
@@ -6,31 +6,32 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func patchTemplatePodSpecWithResourcesFieldV0(m map[string]*schema.Schema, templateFieldName string) map[string]*schema.Schema {
+// NOTE these functions are for patching the schemas for resources with containers
+// to use the old schema for the resources block so we can migrate it to the new format
+// without having to duplicate the entire schema
+
+func patchJobTemplatePodSpecWithResourcesFieldV0(m map[string]*schema.Schema) map[string]*schema.Schema {
 	spec := m["spec"].Elem.(*schema.Resource)
-	template := spec.Schema[templateFieldName].Elem.(*schema.Resource)
-	podSpec := template.Schema["spec"].Elem.(*schema.Resource)
-
-	initContainer := podSpec.Schema["init_container"].Elem.(*schema.Resource)
-	initContainer.Schema["resources"].Elem = &schema.Resource{
-		Schema: resourcesFieldV0(),
-	}
-
-	container := podSpec.Schema["container"].Elem.(*schema.Resource)
-	container.Schema["resources"].Elem = &schema.Resource{
-		Schema: resourcesFieldV0(),
-	}
+	jobTemplate := spec.Schema["job_template"].Elem.(*schema.Resource)
+	jobSpec := jobTemplate.Schema["spec"].Elem.(*schema.Resource)
+	template := jobSpec.Schema["template"].Elem.(*schema.Resource)
+	template.Schema = patchPodSpecWithResourcesFieldV0(template.Schema)
 	return m
 }
 
-func patchPodSpecWithResourcesFieldV0(m map[string]*schema.Schema, templateFieldName string) map[string]*schema.Schema {
+func patchTemplatePodSpecWithResourcesFieldV0(m map[string]*schema.Schema) map[string]*schema.Schema {
 	spec := m["spec"].Elem.(*schema.Resource)
+	template := spec.Schema["template"].Elem.(*schema.Resource)
+	template.Schema = patchPodSpecWithResourcesFieldV0(template.Schema)
+	return m
+}
 
+func patchPodSpecWithResourcesFieldV0(m map[string]*schema.Schema) map[string]*schema.Schema {
+	spec := m["spec"].Elem.(*schema.Resource)
 	initContainer := spec.Schema["init_container"].Elem.(*schema.Resource)
 	initContainer.Schema["resources"].Elem = &schema.Resource{
 		Schema: resourcesFieldV0(),
 	}
-
 	container := spec.Schema["container"].Elem.(*schema.Resource)
 	container.Schema["resources"].Elem = &schema.Resource{
 		Schema: resourcesFieldV0(),
@@ -38,22 +39,80 @@ func patchPodSpecWithResourcesFieldV0(m map[string]*schema.Schema, templateField
 	return m
 }
 
-func upgradeTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}, templateFieldName string) (map[string]interface{}, error) {
-	if s, ok := rawState["spec"].([]interface{}); ok && len(s) > 0 {
-		spec := s[0].(map[string]interface{})
-		if t, ok := spec[templateFieldName].([]interface{}); ok && len(t) > 0 {
-			template := t[0].(map[string]interface{})
-			if ps, ok := template["spec"].([]interface{}); ok && len(ps) > 0 {
-				podSpec := ps[0].(map[string]interface{})
-				upgradedPodSpec := upgradePodSpecWithResourcesFieldV0(podSpec)
-				template["spec"] = []interface{}{upgradedPodSpec}
-			}
-		}
+func upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	s, ok := rawState["spec"].([]interface{})
+	if !ok || len(s) == 0 {
+		return rawState, nil
 	}
+
+	spec := s[0].(map[string]interface{})
+	jt, ok := spec["job_template"].([]interface{})
+	if !ok || len(jt) > 0 {
+		return rawState, nil
+	}
+
+	jobTemplate := jt[0].(map[string]interface{})
+	js, ok := jobTemplate["spec"].([]interface{})
+	if !ok || len(js) == 0 {
+		return rawState, nil
+	}
+
+	jobSpec := js[0].(map[string]interface{})
+	t, ok := jobSpec["template"].([]interface{})
+	if !ok || len(t) == 0 {
+		return rawState, nil
+	}
+
+	template := t[0].(map[string]interface{})
+	ps, ok := template["spec"].([]interface{})
+	if !ok || len(ps) == 0 {
+		return rawState, nil
+	}
+
+	podSpec := ps[0].(map[string]interface{})
+	template["spec"] = []interface{}{upgradeContainers(podSpec)}
+
 	return rawState, nil
 }
 
-func upgradePodSpecWithResourcesFieldV0(rawState map[string]interface{}) map[string]interface{} {
+func upgradeTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	s, ok := rawState["spec"].([]interface{})
+	if !ok || len(s) == 0 {
+		return rawState, nil
+	}
+
+	spec := s[0].(map[string]interface{})
+	t, ok := spec["template"].([]interface{})
+	if !ok || len(t) == 0 {
+		return rawState, nil
+	}
+
+	template := t[0].(map[string]interface{})
+	ps, ok := template["spec"].([]interface{})
+
+	if !ok || len(ps) == 0 {
+		return rawState, nil
+	}
+
+	podSpec := ps[0].(map[string]interface{})
+	template["spec"] = []interface{}{upgradeContainers(podSpec)}
+
+	return rawState, nil
+}
+
+func upgradePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	s, ok := rawState["spec"].([]interface{})
+	if !ok || len(s) == 0 {
+		return rawState, nil
+	}
+
+	spec := s[0].(map[string]interface{})
+	rawState["spec"] = []interface{}{upgradeContainers(spec)}
+
+	return rawState, nil
+}
+
+func upgradeContainers(rawState map[string]interface{}) map[string]interface{} {
 	if initContainers, ok := rawState["init_container"].([]interface{}); ok && len(initContainers) > 0 {
 		for _, c := range initContainers {
 			initContainer := c.(map[string]interface{})

--- a/kubernetes/schema_resources_migrate_test.go
+++ b/kubernetes/schema_resources_migrate_test.go
@@ -1,0 +1,137 @@
+package kubernetes
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestUpgradeTemplatePodSpecWithResourcesFieldV0(t *testing.T) {
+	v0 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"template": []interface{}{map[string]interface{}{
+				"spec": []interface{}{map[string]interface{}{
+					"init_container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": []interface{}{map[string]interface{}{
+									"cpu":    "500m",
+									"memory": "56Mi",
+								}},
+								"limits": []interface{}{map[string]interface{}{
+									"cpu":    "750m",
+									"memory": "128Mi",
+								}},
+							}},
+						},
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": []interface{}{map[string]interface{}{
+									"cpu":    "200m",
+									"memory": "16Mi",
+								}},
+								"limits": []interface{}{map[string]interface{}{
+									"cpu":    "300m",
+									"memory": "32Mi",
+								}},
+							}},
+						},
+					},
+					"container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": []interface{}{map[string]interface{}{
+									"cpu":    "500m",
+									"memory": "56Mi",
+								}},
+								"limits": []interface{}{map[string]interface{}{
+									"cpu":    "750m",
+									"memory": "128Mi",
+								}},
+							}},
+						},
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": []interface{}{map[string]interface{}{
+									"cpu":    "200m",
+									"memory": "16Mi",
+								}},
+								"limits": []interface{}{map[string]interface{}{
+									"cpu":    "300m",
+									"memory": "32Mi",
+								}},
+							}},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	v1 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"template": []interface{}{map[string]interface{}{
+				"spec": []interface{}{map[string]interface{}{
+					"init_container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": map[string]interface{}{
+									"cpu":    "500m",
+									"memory": "56Mi",
+								},
+								"limits": map[string]interface{}{
+									"cpu":    "750m",
+									"memory": "128Mi",
+								},
+							}},
+						},
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": map[string]interface{}{
+									"cpu":    "200m",
+									"memory": "16Mi",
+								},
+								"limits": map[string]interface{}{
+									"cpu":    "300m",
+									"memory": "32Mi",
+								},
+							}},
+						},
+					},
+					"container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": map[string]interface{}{
+									"cpu":    "500m",
+									"memory": "56Mi",
+								},
+								"limits": map[string]interface{}{
+									"cpu":    "750m",
+									"memory": "128Mi",
+								},
+							}},
+						},
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": map[string]interface{}{
+									"cpu":    "200m",
+									"memory": "16Mi",
+								},
+								"limits": map[string]interface{}{
+									"cpu":    "300m",
+									"memory": "32Mi",
+								},
+							}},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.Background(), v0, nil, "template")
+
+	if !reflect.DeepEqual(v1, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
+	}
+}

--- a/kubernetes/schema_resources_migrate_test.go
+++ b/kubernetes/schema_resources_migrate_test.go
@@ -129,7 +129,7 @@ func TestUpgradeTemplatePodSpecWithResourcesFieldV0(t *testing.T) {
 		}},
 	}
 
-	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.Background(), v0, nil)
+	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.TODO(), v0, nil)
 
 	if !reflect.DeepEqual(v1, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)

--- a/kubernetes/schema_resources_migrate_test.go
+++ b/kubernetes/schema_resources_migrate_test.go
@@ -129,7 +129,7 @@ func TestUpgradeTemplatePodSpecWithResourcesFieldV0(t *testing.T) {
 		}},
 	}
 
-	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.Background(), v0, nil, "template")
+	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.Background(), v0, nil)
 
 	if !reflect.DeepEqual(v1, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)


### PR DESCRIPTION
### Description

This PR adds StateUpgraders to handle migrating resources with `resources` fields from TypeList to TypeMap, without this Terraform will error out when trying to parse the old version of the state.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
