### PR TITLE
csi pod volume

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -495,6 +495,40 @@ func TestAccKubernetesPod_with_cfg_map_volume_mount(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPod_with_csi_volume(t *testing.T) {
+	var conf api.Pod
+
+	podName := acctest.RandomWithPrefix("tf-acc-test")
+	secretName := acctest.RandomWithPrefix("tf-acc-test")
+	volumeName := acctest.RandomWithPrefix("tf-acc-test")
+	imageName := "busybox:1.32"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodCSIVolume(imageName, podName, secretName, volumeName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.mount_path", "/volume"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.name", volumeName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.read_only", "true"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.name", volumeName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.csi.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.csi.0.driver", "hostpath.csi.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.csi.0.read_only", "true"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.csi.0.node_publish_secret_ref.0.name", secretName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesPod_with_projected_volume(t *testing.T) {
 	var conf api.Pod
 
@@ -1646,6 +1680,53 @@ resource "kubernetes_pod" "test" {
   }
 }
 `, secretName, podName, imageName)
+}
+
+func testAccKubernetesPodCSIVolume(imageName, podName, secretName, volumeName string) string {
+	return fmt.Sprintf(`resource "kubernetes_secret" "test-secret" {
+	metadata {
+		name = %[3]q
+	}
+  
+	data = {
+		secret = "test-secret"
+	}
+}
+	
+resource "kubernetes_pod" "test" {
+	metadata {
+        labels = {
+          "label" = "web"
+        }
+		name = %[1]q
+      }
+      spec {
+        container {
+          image   = %[2]q
+          name    = %[1]q
+		  command = ["sleep", "36000"]
+          volume_mount {
+            name       = %[4]q
+            mount_path = "/volume"
+            read_only  = true
+          }
+        }
+        restart_policy = "Never"
+        volume {
+			name = %[4]q
+			csi {
+			  driver    = "hostpath.csi.k8s.io"
+			  read_only = true
+			  volume_attributes = {
+				"secretProviderClass" = "secret-provider"
+			  }
+			  node_publish_secret_ref {
+				name = %[3]q
+			  }
+			}
+		  }
+      }
+    }`, podName, imageName, secretName, volumeName)
 }
 
 func testAccKubernetesPodProjectedVolume(cfgMapName, cfgMap2Name, secretName, podName, imageName string) string {

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -894,6 +894,51 @@ func volumeSchema(isUpdatable bool) *schema.Resource {
 			},
 		},
 	}
+	v["csi"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "Represents a CSI Volume. More info: http://kubernetes.io/docs/user-guide/volumes#csi",
+		Optional:    true,
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"driver": {
+					Type:        schema.TypeString,
+					Description: "the name of the volume driver to use. More info: https://kubernetes.io/docs/concepts/storage/volumes/#csi",
+					Required:    true,
+				},
+				"volume_attributes": {
+					Type:        schema.TypeMap,
+					Description: "Attributes of the volume to publish.",
+					Optional:    true,
+				},
+				"fs_type": {
+					Type:        schema.TypeString,
+					Description: "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					Optional:    true,
+				},
+				"read_only": {
+					Type:        schema.TypeBool,
+					Description: "Whether to set the read-only property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://kubernetes.io/docs/user-guide/volumes#csi",
+					Optional:    true,
+				},
+				"node_publish_secret_ref": {
+					Type:        schema.TypeList,
+					Description: "A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls.",
+					Optional:    true,
+					MaxItems:    1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:        schema.TypeString,
+								Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+								Optional:    true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	return &schema.Resource{
 		Schema: v,
 	}

--- a/kubernetes/schema_volume_source.go
+++ b/kubernetes/schema_volume_source.go
@@ -6,8 +6,48 @@ import (
 )
 
 func persistentVolumeSourceSchema() *schema.Resource {
+	sources := commonVolumeSources()
+	sources["csi"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "Represents a CSI Volume. More info: http://kubernetes.io/docs/user-guide/volumes#csi",
+		Optional:    true,
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"driver": {
+					Type:        schema.TypeString,
+					Description: "the name of the volume driver to use. More info: https://kubernetes.io/docs/concepts/storage/volumes/#csi",
+					Required:    true,
+				},
+				"volume_handle": {
+					Type:        schema.TypeString,
+					Description: "A string value that uniquely identifies the volume. More info: https://kubernetes.io/docs/concepts/storage/volumes/#csi",
+					Required:    true,
+				},
+				"volume_attributes": {
+					Type:        schema.TypeMap,
+					Description: "Attributes of the volume to publish.",
+					Optional:    true,
+				},
+				"fs_type": {
+					Type:        schema.TypeString,
+					Description: "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					Optional:    true,
+				},
+				"read_only": {
+					Type:        schema.TypeBool,
+					Description: "Whether to set the read-only property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://kubernetes.io/docs/user-guide/volumes#csi",
+					Optional:    true,
+				},
+				"controller_publish_secret_ref": commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls."),
+				"node_stage_secret_ref":         commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls."),
+				"node_publish_secret_ref":       commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls."),
+				"controller_expand_secret_ref":  commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call."),
+			},
+		},
+	}
 	return &schema.Resource{
-		Schema: commonVolumeSources(),
+		Schema: sources,
 	}
 }
 
@@ -207,45 +247,6 @@ func commonVolumeSources() map[string]*schema.Schema {
 						Description: "Volume ID used to identify the volume in Cinder. More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
 						Required:    true,
 					},
-				},
-			},
-		},
-		"csi": {
-			Type:        schema.TypeList,
-			Description: "Represents a CSI Volume. More info: http://kubernetes.io/docs/user-guide/volumes#csi",
-			Optional:    true,
-			MaxItems:    1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"driver": {
-						Type:        schema.TypeString,
-						Description: "the name of the volume driver to use. More info: https://kubernetes.io/docs/concepts/storage/volumes/#csi",
-						Required:    true,
-					},
-					"volume_handle": {
-						Type:        schema.TypeString,
-						Description: "A string value that uniquely identifies the volume. More info: https://kubernetes.io/docs/concepts/storage/volumes/#csi",
-						Required:    true,
-					},
-					"volume_attributes": {
-						Type:        schema.TypeMap,
-						Description: "Attributes of the volume to publish.",
-						Optional:    true,
-					},
-					"fs_type": {
-						Type:        schema.TypeString,
-						Description: "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-						Optional:    true,
-					},
-					"read_only": {
-						Type:        schema.TypeBool,
-						Description: "Whether to set the read-only property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://kubernetes.io/docs/user-guide/volumes#csi",
-						Optional:    true,
-					},
-					"controller_publish_secret_ref": commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls."),
-					"node_stage_secret_ref":         commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls."),
-					"node_publish_secret_ref":       commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls."),
-					"controller_expand_secret_ref":  commonVolumeSourcesSecretRef("A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call."),
 				},
 			},
 		},

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -433,7 +433,21 @@ func flattenCSIPersistentVolumeSource(in *v1.CSIPersistentVolumeSource) []interf
 }
 
 func flattenCSIVolumeSource(in *v1.CSIVolumeSource) []interface{} {
-	panic("NOT IMPLEMENTED")
+	att := make(map[string]interface{})
+	att["driver"] = in.Driver
+	if in.ReadOnly != nil {
+		att["read_only"] = *in.ReadOnly
+	}
+	if in.FSType != nil {
+		att["fs_type"] = *in.FSType
+	}
+	if len(in.VolumeAttributes) > 0 {
+		att["volume_attributes"] = in.VolumeAttributes
+	}
+	if in.NodePublishSecretRef != nil {
+		att["node_publish_secret_ref"] = flattenLocalObjectReference(in.NodePublishSecretRef)
+	}
+	return []interface{}{att}
 }
 
 func flattenQuobyteVolumeSource(in *v1.QuobyteVolumeSource) []interface{} {
@@ -1065,7 +1079,26 @@ func expandCSIPersistentDiskVolumeSource(l []interface{}) *v1.CSIPersistentVolum
 }
 
 func expandCSIVolumeSource(l []interface{}) *v1.CSIVolumeSource {
-	panic("NOT IMPLEMENTED")
+	if len(l) == 0 || l[0] == nil {
+		return &v1.CSIVolumeSource{}
+	}
+	in := l[0].(map[string]interface{})
+	obj := &v1.CSIVolumeSource{
+		Driver: in["driver"].(string),
+	}
+	if v, ok := in["read_only"].(bool); ok {
+		obj.ReadOnly = &v
+	}
+	if v, ok := in["fs_type"].(string); ok {
+		obj.FSType = &v
+	}
+	if v, ok := in["volume_attributes"].(map[string]interface{}); ok {
+		obj.VolumeAttributes = expandStringMap(v)
+	}
+	if v, ok := in["node_publish_secret_ref"].([]interface{}); ok && len(v) > 0 {
+		obj.NodePublishSecretRef = expandLocalObjectReference(v)
+	}
+	return obj
 }
 
 func expandQuobyteVolumeSource(l []interface{}) *v1.QuobyteVolumeSource {

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -364,7 +364,7 @@ func flattenPersistentVolumeSource(in v1.PersistentVolumeSource) []interface{} {
 		att["photon_persistent_disk"] = flattenPhotonPersistentDiskVolumeSource(in.PhotonPersistentDisk)
 	}
 	if in.CSI != nil {
-		att["csi"] = flattenCSIVolumeSource(in.CSI)
+		att["csi"] = flattenCSIPersistentVolumeSource(in.CSI)
 	}
 	return []interface{}{att}
 }
@@ -406,7 +406,7 @@ func flattenPhotonPersistentDiskVolumeSource(in *v1.PhotonPersistentDiskVolumeSo
 	return []interface{}{att}
 }
 
-func flattenCSIVolumeSource(in *v1.CSIPersistentVolumeSource) []interface{} {
+func flattenCSIPersistentVolumeSource(in *v1.CSIPersistentVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["driver"] = in.Driver
 	att["volume_handle"] = in.VolumeHandle
@@ -430,6 +430,10 @@ func flattenCSIVolumeSource(in *v1.CSIPersistentVolumeSource) []interface{} {
 		att["node_stage_secret_ref"] = flattenSecretReference(in.NodeStageSecretRef)
 	}
 	return []interface{}{att}
+}
+
+func flattenCSIVolumeSource(in *v1.CSIVolumeSource) []interface{} {
+	panic("NOT IMPLEMENTED")
 }
 
 func flattenQuobyteVolumeSource(in *v1.QuobyteVolumeSource) []interface{} {
@@ -1058,6 +1062,10 @@ func expandCSIPersistentDiskVolumeSource(l []interface{}) *v1.CSIPersistentVolum
 		obj.ControllerExpandSecretRef = expandSecretReference(v)
 	}
 	return obj
+}
+
+func expandCSIVolumeSource(l []interface{}) *v1.CSIVolumeSource {
+	panic("NOT IMPLEMENTED")
 }
 
 func expandQuobyteVolumeSource(l []interface{}) *v1.QuobyteVolumeSource {

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -331,6 +331,9 @@ func flattenVolumes(volumes []v1.Volume) ([]interface{}, error) {
 		if v.CephFS != nil {
 			obj["ceph_fs"] = flattenCephFSVolumeSource(v.CephFS)
 		}
+		if v.CSI != nil {
+			obj["csi"] = flattenCSIVolumeSource(v.CSI)
+		}
 		if v.FC != nil {
 			obj["fc"] = flattenFCVolumeSource(v.FC)
 		}
@@ -1348,6 +1351,9 @@ func expandVolumes(volumes []interface{}) ([]v1.Volume, error) {
 		}
 		if v, ok := m["ceph_fs"].([]interface{}); ok && len(v) > 0 {
 			vl[i].CephFS = expandCephFSVolumeSource(v)
+		}
+		if v, ok := m["csi"].([]interface{}); ok && len(v) > 0 {
+			vl[i].CSI = expandCSIVolumeSource(v)
 		}
 		if v, ok := m["fc"].([]interface{}); ok && len(v) > 0 {
 			vl[i].FC = expandFCVolumeSource(v)

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -558,3 +558,141 @@ func TestExpandThenFlatten_projected_volume(t *testing.T) {
 	}
 
 }
+
+func TestExpandCSIVolumeSource(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput []*v1.CSIVolumeSource
+	}{
+		{
+			Input: []interface{}{
+				map[string]interface{}{
+					"driver":    "secrets-store.csi.k8s.io",
+					"read_only": true,
+					"volume_attributes": map[string]string{
+						"secretProviderClass": "azure-keyvault",
+					},
+					"fs_type": "nfs",
+					"node_publish_secret_ref": map[string]interface{}{
+						"name":      "secrets-store",
+						"namespace": "default",
+					},
+				},
+			},
+			ExpectedOutput: []*v1.CSIVolumeSource{
+				&v1.CSIVolumeSource{
+					Driver:   "secrets-store.csi.k8s.io",
+					ReadOnly: ptrToBool(true),
+					FSType:   ptrToString("nfs"),
+					VolumeAttributes: map[string]string{
+						"secretProviderClass": "azure-keyvault",
+					},
+					NodePublishSecretRef: &v1.LocalObjectReference{
+						Name: "secrets-store",
+					},
+				},
+			},
+		},
+		{
+			Input: []interface{}{
+				map[string]interface{}{
+					"driver": "other-csi-driver.k8s.io",
+					"volume_attributes": map[string]string{
+						"objects": `array: 
+						- |
+							objectName: secret-1
+							objectType: secret `,
+					},
+				},
+			},
+			ExpectedOutput: []*v1.CSIVolumeSource{
+				&v1.CSIVolumeSource{
+					Driver:   "other-csi-driver.k8s.io",
+					ReadOnly: nil,
+					FSType:   nil,
+					VolumeAttributes: map[string]string{
+						"objects": `array: 
+						- |
+							objectName: secret-1
+							objectType: secret `,
+					},
+					NodePublishSecretRef: nil,
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		output := expandCSIVolumeSource(tc.Input)
+		if !reflect.DeepEqual(tc.ExpectedOutput, output) {
+			t.Fatalf("Unexpected output from CSI Volume Source Expander. \nExpected: %#v, Given: %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenCSIVolumeSource(t *testing.T) {
+	cases := []struct {
+		Input          *v1.CSIVolumeSource
+		ExpectedOutput []interface{}
+	}{
+		{
+			Input: &v1.CSIVolumeSource{
+				Driver:   "secrets-store.csi.k8s.io",
+				ReadOnly: ptrToBool(true),
+				FSType:   ptrToString("nfs"),
+				VolumeAttributes: map[string]string{
+					"secretProviderClass": "azure-keyvault",
+				},
+				NodePublishSecretRef: &v1.LocalObjectReference{
+					Name: "secrets-store",
+				},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"driver":    "secrets-store.csi.k8s.io",
+					"read_only": true,
+					"volume_attributes": map[string]string{
+						"secretProviderClass": "azure-keyvault",
+					},
+					"fs_type": "nfs",
+					"node_publish_secret_ref": map[string]interface{}{
+						"name":      "secrets-store",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+		{
+			Input: &v1.CSIVolumeSource{
+				Driver:   "other-csi-driver.k8s.io",
+				ReadOnly: nil,
+				FSType:   nil,
+				VolumeAttributes: map[string]string{
+					"objects": `array: 
+					- |
+						objectName: secret-1
+						objectType: secret `,
+				},
+				NodePublishSecretRef: nil,
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"driver": "other-csi-driver.k8s.io",
+					"volume_attributes": map[string]string{
+						"objects": `array: 
+						- |
+							objectName: secret-1
+							objectType: secret `,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		output := flattenCSIVolumeSource(tc.Input)
+		if !reflect.DeepEqual(tc.ExpectedOutput, output) {
+			t.Fatalf("Unexpected result from flattener. \nExpected %#v, \nGiven %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -562,34 +562,33 @@ func TestExpandThenFlatten_projected_volume(t *testing.T) {
 func TestExpandCSIVolumeSource(t *testing.T) {
 	cases := []struct {
 		Input          []interface{}
-		ExpectedOutput []*v1.CSIVolumeSource
+		ExpectedOutput *v1.CSIVolumeSource
 	}{
 		{
 			Input: []interface{}{
 				map[string]interface{}{
 					"driver":    "secrets-store.csi.k8s.io",
 					"read_only": true,
-					"volume_attributes": map[string]string{
+					"volume_attributes": map[string]interface{}{
 						"secretProviderClass": "azure-keyvault",
 					},
 					"fs_type": "nfs",
-					"node_publish_secret_ref": map[string]interface{}{
-						"name":      "secrets-store",
-						"namespace": "default",
+					"node_publish_secret_ref": []interface{}{
+						map[string]interface{}{
+							"name": "secrets-store",
+						},
 					},
 				},
 			},
-			ExpectedOutput: []*v1.CSIVolumeSource{
-				&v1.CSIVolumeSource{
-					Driver:   "secrets-store.csi.k8s.io",
-					ReadOnly: ptrToBool(true),
-					FSType:   ptrToString("nfs"),
-					VolumeAttributes: map[string]string{
-						"secretProviderClass": "azure-keyvault",
-					},
-					NodePublishSecretRef: &v1.LocalObjectReference{
-						Name: "secrets-store",
-					},
+			ExpectedOutput: &v1.CSIVolumeSource{
+				Driver:   "secrets-store.csi.k8s.io",
+				ReadOnly: ptrToBool(true),
+				FSType:   ptrToString("nfs"),
+				VolumeAttributes: map[string]string{
+					"secretProviderClass": "azure-keyvault",
+				},
+				NodePublishSecretRef: &v1.LocalObjectReference{
+					Name: "secrets-store",
 				},
 			},
 		},
@@ -597,7 +596,7 @@ func TestExpandCSIVolumeSource(t *testing.T) {
 			Input: []interface{}{
 				map[string]interface{}{
 					"driver": "other-csi-driver.k8s.io",
-					"volume_attributes": map[string]string{
+					"volume_attributes": map[string]interface{}{
 						"objects": `array: 
 						- |
 							objectName: secret-1
@@ -605,19 +604,17 @@ func TestExpandCSIVolumeSource(t *testing.T) {
 					},
 				},
 			},
-			ExpectedOutput: []*v1.CSIVolumeSource{
-				&v1.CSIVolumeSource{
-					Driver:   "other-csi-driver.k8s.io",
-					ReadOnly: nil,
-					FSType:   nil,
-					VolumeAttributes: map[string]string{
-						"objects": `array: 
+			ExpectedOutput: &v1.CSIVolumeSource{
+				Driver:   "other-csi-driver.k8s.io",
+				ReadOnly: nil,
+				FSType:   nil,
+				VolumeAttributes: map[string]string{
+					"objects": `array: 
 						- |
 							objectName: secret-1
 							objectType: secret `,
-					},
-					NodePublishSecretRef: nil,
 				},
+				NodePublishSecretRef: nil,
 			},
 		},
 	}
@@ -655,9 +652,10 @@ func TestFlattenCSIVolumeSource(t *testing.T) {
 						"secretProviderClass": "azure-keyvault",
 					},
 					"fs_type": "nfs",
-					"node_publish_secret_ref": map[string]interface{}{
-						"name":      "secrets-store",
-						"namespace": "default",
+					"node_publish_secret_ref": []interface{}{
+						map[string]interface{}{
+							"name": "secrets-store",
+						},
 					},
 				},
 			},
@@ -680,9 +678,9 @@ func TestFlattenCSIVolumeSource(t *testing.T) {
 					"driver": "other-csi-driver.k8s.io",
 					"volume_attributes": map[string]string{
 						"objects": `array: 
-						- |
-							objectName: secret-1
-							objectType: secret `,
+					- |
+						objectName: secret-1
+						objectType: secret `,
 					},
 				},
 			},

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -365,6 +365,16 @@ The following arguments are supported:
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `optional` - (Optional) Specify whether the ConfigMap or its key must be defined
 
+### `csi`
+
+#### Arguments
+
+* `driver` - (Required) the name of the volume driver to use. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#csi).
+* `volume_attributes` - (Optional) Attributes of the volume to publish.
+* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. `ext4`, `xfs`, `ntfs`.
+* `read_only` - (Optional) Whether to set the read-only property in VolumeMounts to `true`. If omitted, the default is `false`.
+* `node_publish_secret_ref` - (Optional) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. see [secret_ref](#secret_ref) for more details.
+
 ### `dns_config`
 
 #### Arguments
@@ -785,6 +795,7 @@ The `items` block supports the following:
 * `ceph_fs` - (Optional) Represents a Ceph FS mount on the host that shares a pod's lifetime
 * `cinder` - (Optional) Represents a cinder volume attached and mounted on kubelets host machine. For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
 * `config_map` - (Optional) ConfigMap represents a configMap that should populate this volume
+* `csi` - (Optional) CSI represents storage that is handled by an external CSI driver. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#csi)
 * `downward_api` - (Optional) DownwardAPI represents downward API about the pod that should populate this volume
 * `empty_dir` - (Optional) EmptyDir represents a temporary directory that shares a pod's lifetime. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#emptydir)
 * `fc` - (Optional) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -376,6 +376,16 @@ The following arguments are supported:
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `optional` - (Optional) Specify whether the ConfigMap or its key must be defined
 
+### `csi`
+
+#### Arguments
+
+- `driver` - (Required) the name of the volume driver to use. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#csi).
+- `volume_attributes` - (Optional) Attributes of the volume to publish.
+- `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. `ext4`, `xfs`, `ntfs`.
+- `read_only` - (Optional) Whether to set the read-only property in VolumeMounts to `true`. If omitted, the default is `false`.
+- `node_publish_secret_ref` - (Optional) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. see [secret_ref](#secret_ref) for more details.
+
 ### `dns_config`
 
 #### Arguments
@@ -798,6 +808,7 @@ The `items` block supports the following:
 * `ceph_fs` - (Optional) Represents a Ceph FS mount on the host that shares a pod's lifetime
 * `cinder` - (Optional) Represents a cinder volume attached and mounted on kubelets host machine. For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
 * `config_map` - (Optional) ConfigMap represents a configMap that should populate this volume
+* `csi` - (Optional) CSI represents storage that is handled by an external CSI driver. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#csi)
 * `downward_api` - (Optional) DownwardAPI represents downward API about the pod that should populate this volume
 * `empty_dir` - (Optional) EmptyDir represents a temporary directory that shares a pod's lifetime. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#emptydir)
 * `fc` - (Optional) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -424,6 +424,16 @@ The following arguments are supported:
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `optional` - (Optional) Specify whether the Secret or its key must be defined
 
+### `csi`
+
+#### Arguments
+
+* `driver` - (Required) the name of the volume driver to use. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#csi).
+* `volume_attributes` - (Optional) Attributes of the volume to publish.
+* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. `ext4`, `xfs`, `ntfs`.
+* `read_only` - (Optional) Whether to set the read-only property in VolumeMounts to `true`. If omitted, the default is `false`.
+* `node_publish_secret_ref` - (Optional) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. see [secret_ref](#secret_ref) for more details.
+
 ### `dns_config`
 
 #### Arguments
@@ -846,6 +856,7 @@ The `items` block supports the following:
 * `ceph_fs` - (Optional) Represents a Ceph FS mount on the host that shares a pod's lifetime
 * `cinder` - (Optional) Represents a cinder volume attached and mounted on kubelets host machine. For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
 * `config_map` - (Optional) ConfigMap represents a configMap that should populate this volume
+* `csi` - (Optional) CSI represents storage that is handled by an external CSI driver. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#csi)
 * `downward_api` - (Optional) DownwardAPI represents downward API about the pod that should populate this volume
 * `empty_dir` - (Optional) EmptyDir represents a temporary directory that shares a pod's lifetime. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#emptydir)
 * `fc` - (Optional) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.


### PR DESCRIPTION
### Description
Get ephemeral CSI volumes working and update schema to reflect the differences in the API between ephemeral and persistent CSI Volumes

I would like some feedback regarding how to make acceptance tests for this. Finding this required installing a Helm chart for Azure keyvault integration specifically, and that does not seem like a good way to go about acceptance testing this change.
Output from acceptance testing:
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...Fix CSI ephemeral pod volumes
```

### References
#1086 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
