### PR TITLE
Change fs_group, run_as_user, run_as_group to strings

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -636,9 +636,10 @@ func securityContextSchema() *schema.Resource {
 			Description: "Whether this container has a read-only root filesystem. Default is false.",
 		},
 		"run_as_group": {
-			Type:        schema.TypeInt,
-			Description: "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+			Optional:     true,
+			ValidateFunc: validateTypeStringNullableInt,
 		},
 		"run_as_non_root": {
 			Type:        schema.TypeBool,
@@ -646,9 +647,10 @@ func securityContextSchema() *schema.Resource {
 			Optional:    true,
 		},
 		"run_as_user": {
-			Type:        schema.TypeInt,
-			Description: "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+			Optional:     true,
+			ValidateFunc: validateTypeStringNullableInt,
 		},
 		"se_linux_options": {
 			Type:        schema.TypeList,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -247,14 +247,16 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"fs_group": {
-						Type:        schema.TypeInt,
-						Description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume.",
-						Optional:    true,
+						Type:         schema.TypeString,
+						Description:  "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume.",
+						Optional:     true,
+						ValidateFunc: validateTypeStringNullableInt,
 					},
 					"run_as_group": {
-						Type:        schema.TypeInt,
-						Description: "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
-						Optional:    true,
+						Type:         schema.TypeString,
+						Description:  "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+						Optional:     true,
+						ValidateFunc: validateTypeStringNullableInt,
 					},
 					"run_as_non_root": {
 						Type:        schema.TypeBool,
@@ -262,9 +264,10 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 						Optional:    true,
 					},
 					"run_as_user": {
-						Type:        schema.TypeInt,
-						Description: "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
-						Optional:    true,
+						Type:         schema.TypeString,
+						Description:  "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+						Optional:     true,
+						ValidateFunc: validateTypeStringNullableInt,
 					},
 					"se_linux_options": {
 						Type:        schema.TypeList,


### PR DESCRIPTION
### Description

This PR changes `fs_group`, `run_as_user` and `run_as_group` to be strings so we can differentiate between `0` and not set by using an empty string.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Change fs_type, run_as_user, run_as_group to TypeString
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
