### PR TITLE
Remove default token volume and volume_mount from Pod state

### DIFF
--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -414,6 +414,7 @@ func flattenContainers(in []v1.Container, serviceAccountRegex string) ([]interfa
 				}
 				if nameMatchesDefaultToken {
 					v.VolumeMounts = removeVolumeMountFromContainer(num, v.VolumeMounts)
+					break
 				}
 			}
 

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -262,14 +262,6 @@ func flattenContainerVolumeMounts(in []v1.VolumeMount) ([]interface{}, error) {
 	att := make([]interface{}, len(in))
 
 	for i, v := range in {
-		// To avoid perpetual diff, skip adding default service account volumeMount to state.
-		skip, err := volumeMountIsDefaultServiceAccount(&v)
-		if err != nil {
-			return att, err
-		}
-		if skip {
-			continue
-		}
 		m := map[string]interface{}{}
 		m["read_only"] = v.ReadOnly
 
@@ -290,17 +282,6 @@ func flattenContainerVolumeMounts(in []v1.VolumeMount) ([]interface{}, error) {
 		att[i] = m
 	}
 	return att, nil
-}
-
-func volumeMountIsDefaultServiceAccount(v *v1.VolumeMount) (bool, error) {
-	nameMatchesDefaultToken, err := regexp.MatchString("default-token-([a-z0-9]{5})", v.Name)
-	if err != nil {
-		return false, err
-	}
-	if v.MountPath == "/var/run/secrets/kubernetes.io/serviceaccount" && nameMatchesDefaultToken {
-		return true, nil
-	}
-	return false, nil
 }
 
 func flattenContainerEnvs(in []v1.EnvVar) []interface{} {

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -353,7 +353,7 @@ func flattenContainerResourceRequirements(in v1.ResourceRequirements) ([]interfa
 	return []interface{}{att}, nil
 }
 
-func flattenContainers(in []v1.Container) ([]interface{}, error) {
+func flattenContainers(in []v1.Container, serviceAccountRegex string) ([]interface{}, error) {
 	att := make([]interface{}, len(in))
 	for i, v := range in {
 		c := make(map[string]interface{})
@@ -408,7 +408,7 @@ func flattenContainers(in []v1.Container) ([]interface{}, error) {
 		if len(v.VolumeMounts) > 0 {
 			for num, m := range v.VolumeMounts {
 				// To avoid perpetual diff, remove the default service account token volume from the container's list of volumeMounts.
-				nameMatchesDefaultToken, err := regexp.MatchString("default-token-([a-z0-9]{5})", m.Name)
+				nameMatchesDefaultToken, err := regexp.MatchString(serviceAccountRegex, m.Name)
 				if err != nil {
 					return att, err
 				}

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -124,6 +124,7 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 			}
 			if nameMatchesDefaultToken {
 				in.Volumes = removeVolumeFromPodSpec(i, in.Volumes)
+				break
 			}
 		}
 

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -116,12 +116,8 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 				if err != nil {
 					return []interface{}{att}, err
 				}
-				if nameMatchesDefaultToken && volume.Secret != nil {
-					for _, secretVolume := range volume.Secret.Items {
-						if secretVolume.Path == "/var/run/secrets/kubernetes.io/serviceaccount" {
-							removeVolume(i, in.Volumes)
-						}
-					}
+				if nameMatchesDefaultToken  {
+					in.Volumes = removeVolume(i, in.Volumes)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1085

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:


```
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):

```release-note
Ensure default service account token is not saved in Pod state.
```

### References


### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
