### PR TITLE
Fix perpetual diff in StatefulSet

### DIFF
--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -182,7 +182,13 @@ func flattenStatefulSetSpec(spec v1.StatefulSetSpec, d *schema.ResourceData) ([]
 	}
 	att["template"] = template
 	att["volume_claim_template"] = flattenPersistentVolumeClaim(spec.VolumeClaimTemplates, d)
-	att["update_strategy"] = flattenStatefulSetSpecUpdateStrategy(spec.UpdateStrategy)
+
+	// Only write update_strategy to state if the user has defined it,
+	// otherwise we get a perpetual diff.
+	updateStrategy := d.Get("spec.0.update_strategy")
+	if len(updateStrategy.([]interface{})) != 0 {
+		att["update_strategy"] = flattenStatefulSetSpecUpdateStrategy(spec.UpdateStrategy)
+	}
 
 	return []interface{}{att}, nil
 }


### PR DESCRIPTION
### Description

Fixes #1088 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

The acceptance test for this one is in #1074, but it passed a manual test using the reproducer from the bug:

```
kubernetes_stateful_set.test: Creating...
kubernetes_stateful_set.test: Creation complete after 8s [id=default/test]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ terraform plan
kubernetes_stateful_set.test: Refreshing state... [id=default/test]

No changes. Infrastructure is up-to-date.
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix perpetual diff in StatefulSet when update_strategy is not specified (#1088)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
