### PR TITLE
validateTypeStringNullableIntOrPercent should tolerate `100%` value

### DIFF
--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -281,7 +281,7 @@ func validateTypeStringNullableIntOrPercent(v interface{}, key string) (ws []str
 		if err != nil {
 			es = append(es, fmt.Errorf("%s: cannot parse '%s' as percent: %s", key, value, err))
 		}
-		if percent < 0 || percent >= 100 {
+		if percent < 0 || percent > 100 {
 			es = append(es, fmt.Errorf("%s: '%s' is not between 0%% and 100%%", key, value))
 		}
 	} else if _, err := strconv.ParseInt(value, 10, 32); err != nil {

--- a/kubernetes/validators_test.go
+++ b/kubernetes/validators_test.go
@@ -131,3 +131,33 @@ func TestValidateNonNegativeInteger(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateTypeStringNullableIntOrPercent(t *testing.T) {
+	validCases := []string{
+		"",
+		"1",
+		"100",
+		"1%",
+		"100%",
+	}
+	for _, data := range validCases {
+		_, es := validateTypeStringNullableIntOrPercent(data, "replicas")
+		if len(es) > 0 {
+			t.Fatalf("Expected %q to be valid: %#v", data, es)
+		}
+	}
+	invalidCases := []string{
+		" ",
+		"0.1",
+		"test",
+		"!@@#$",
+		"💣",
+		"%",
+	}
+	for _, data := range invalidCases {
+		_, es := validateTypeStringNullableIntOrPercent(data, "replicas")
+		if len(es) == 0 {
+			t.Fatalf("Expected %q to be invalid", data)
+		}
+	}
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
kubernetes_pod_disruption_budget: `100%` now is a valid value
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Fixes #1106 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
