### PR TITLE
FIX resources state migration should migrate empty array

### DIFF
--- a/kubernetes/schema_resources_migrate.go
+++ b/kubernetes/schema_resources_migrate.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -120,10 +121,15 @@ func upgradeContainers(rawState map[string]interface{}) map[string]interface{} {
 				if req, ok := resources["requests"].([]interface{}); ok && len(req) > 0 {
 					requests := req[0].(map[string]interface{})
 					resources["requests"] = requests
+				} else {
+					resources["requests"] = map[string]interface{}{}
 				}
+
 				if lim, ok := resources["limits"].([]interface{}); ok && len(lim) > 0 {
 					limits := lim[0].(map[string]interface{})
 					resources["limits"] = limits
+				} else {
+					resources["limits"] = map[string]interface{}{}
 				}
 			}
 		}
@@ -136,10 +142,15 @@ func upgradeContainers(rawState map[string]interface{}) map[string]interface{} {
 				if req, ok := resources["requests"].([]interface{}); ok && len(req) > 0 {
 					requests := req[0].(map[string]interface{})
 					resources["requests"] = requests
+				} else {
+					resources["requests"] = map[string]interface{}{}
 				}
+
 				if lim, ok := resources["limits"].([]interface{}); ok && len(lim) > 0 {
 					limits := lim[0].(map[string]interface{})
 					resources["limits"] = limits
+				} else {
+					resources["limits"] = map[string]interface{}{}
 				}
 			}
 		}

--- a/kubernetes/schema_resources_migrate_test.go
+++ b/kubernetes/schema_resources_migrate_test.go
@@ -135,3 +135,61 @@ func TestUpgradeTemplatePodSpecWithResourcesFieldV0(t *testing.T) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
 	}
 }
+
+func TestUpgradeTemplatePodSpecWithResourcesFieldV0_empty(t *testing.T) {
+	v0 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"template": []interface{}{map[string]interface{}{
+				"spec": []interface{}{map[string]interface{}{
+					"init_container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": []interface{}{},
+								"limits":   []interface{}{},
+							}},
+						},
+					},
+					"container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": []interface{}{},
+								"limits":   []interface{}{},
+							}},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	v1 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"template": []interface{}{map[string]interface{}{
+				"spec": []interface{}{map[string]interface{}{
+					"init_container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": map[string]interface{}{},
+								"limits":   map[string]interface{}{},
+							}},
+						},
+					},
+					"container": []interface{}{
+						map[string]interface{}{
+							"resources": []interface{}{map[string]interface{}{
+								"requests": map[string]interface{}{},
+								"limits":   map[string]interface{}{},
+							}},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.TODO(), v0, nil)
+
+	if !reflect.DeepEqual(v1, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
+	}
+}


### PR DESCRIPTION
### Description

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -run TestAccKubernetesDeployment_regression -timeout 120m
=== RUN   TestAccKubernetesDeployment_regression
--- PASS: TestAccKubernetesDeployment_regression (146.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	154.428s
```

Unit test:

```
go test -run TestUpgradeTemplatePodSpecWithResourcesFieldV0_empty ./kubernetes -v -count=1
=== RUN   TestUpgradeTemplatePodSpecWithResourcesFieldV0_empty
--- PASS: TestUpgradeTemplatePodSpecWithResourcesFieldV0_empty (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	2.131s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FIX resources state migration should migrate empty array
```

### References

Fixes #1124 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
