### PR TITLE
fix diff suppression for resource quantities in pv and pvc

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -96,11 +96,12 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 							Set: schema.HashString,
 						},
 						"capacity": {
-							Type:         schema.TypeMap,
-							Description:  "A description of the persistent volume's resources and capacity. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity",
-							Required:     true,
-							Elem:         schema.TypeString,
-							ValidateFunc: validateResourceList,
+							Type:             schema.TypeMap,
+							Description:      "A description of the persistent volume's resources and capacity. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity",
+							Required:         true,
+							Elem:             schema.TypeString,
+							ValidateFunc:     validateResourceList,
+							DiffSuppressFunc: suppressEquivalentResourceQuantity,
 						},
 						"persistent_volume_reclaim_policy": {
 							Type:        schema.TypeString,

--- a/kubernetes/schema_persistent_volume_claim.go
+++ b/kubernetes/schema_persistent_volume_claim.go
@@ -45,16 +45,18 @@ func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"limits": {
-						Type:        schema.TypeMap,
-						Description: "Map describing the maximum amount of compute resources allowed. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
-						Optional:    true,
-						ForceNew:    true,
+						Type:             schema.TypeMap,
+						Description:      "Map describing the maximum amount of compute resources allowed. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
+						Optional:         true,
+						ForceNew:         true,
+						DiffSuppressFunc: suppressEquivalentResourceQuantity,
 					},
 					// This is the only field the API will allow modifying in-place, so ForceNew is not used.
 					"requests": {
-						Type:        schema.TypeMap,
-						Description: "Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
-						Optional:    true,
+						Type:             schema.TypeMap,
+						Description:      "Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
+						Optional:         true,
+						DiffSuppressFunc: suppressEquivalentResourceQuantity,
 					},
 				},
 			},


### PR DESCRIPTION
### Description

This PR adds diff suppression to `kubernetes_persistent_volume` and `kubernetes_persistent_volume_claim` for the capacity and resources attributes.

Fixes #1118 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add diff suppression to persistent_volume and persistent_volume_claim
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
