### PR TITLE
updating service docs

### DIFF
--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -83,19 +83,20 @@ The following arguments are supported:
 
 ## Attributes
 
+* `status` - Status is a list containing the most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
 ### `status`
+#### Attributes
 
-* `status` - Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `load_balancer` - a list containing the current status of the load-balancer, if one is present.
 
-#### `load_balancer`
+### `load_balancer`
+#### Attributes
 
-* LoadBalancer contains the current status of the load-balancer, if one is present.
+* `ingress` - a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
 
-##### `ingress`
-
-* `ingress` - Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
-
-###### Attributes
+### `ingress`
+#### Attributes
 
 * `ip` -  IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers).
 * `hostname` - Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers).

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -177,19 +177,20 @@ The following arguments are supported:
 
 ## Attributes
 
+* `status` - Status is a list containing the most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
 ### `status`
+#### Attributes
 
-* `status` - Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `load_balancer` - a list containing the current status of the load-balancer, if one is present.
 
-#### `load_balancer`
+### `load_balancer`
+#### Attributes
 
-* LoadBalancer contains the current status of the load-balancer, if one is present.
+* `ingress` - a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
 
-##### `ingress`
-
-* `ingress` - Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
-
-###### Attributes
+### `ingress`
+#### Attributes
 
 * `ip` -  IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers).
 * `hostname` - Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers).


### PR DESCRIPTION
### Description

The docs for a Kubernetes service (resource and data) aren't really that clear so I made some changes to be inline with code. It looks like changes were recently made here https://github.com/hashicorp/terraform-provider-kubernetes/pull/1125 but that doesn't really provide a lot of clarity since it deviates from what an actual Kubernetes status object looks like.


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update docs to reflect Kubernetes service status attribute
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
