### PR TITLE
Fix namespace resource in ingress example

### DIFF
--- a/_examples/ingress/main.tf
+++ b/_examples/ingress/main.tf
@@ -8,8 +8,7 @@ terraform {
 
 resource "kubernetes_namespace" "test" {
   metadata {
-    name      = "test"
-    namespace = "test"
+    name = "test"
   }
 }
 


### PR DESCRIPTION
### Description
Found this tiny error in our examples. Namespaces don't need a namespaces :1st_place_medal: 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
