### PR TITLE
docs clarification for role_binding.subject[].api_group

### DIFF
--- a/website/docs/r/cluster_role_binding.html.markdown
+++ b/website/docs/r/cluster_role_binding.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 * `name` - (Required) The name of this ClusterRole to bind Subjects to.
 * `namespace` - (Optional) Namespace defines the namespace of the ServiceAccount to bind to. This value only applies to kind `ServiceAccount`
 * `kind` - (Required) The type of binding to use. This value must be `ServiceAccount`, `User` or `Group`
-* `api_group` - (Required) The API group to drive authorization decisions. This value only applies to kind `User` and `Group`. It must be `rbac.authorization.k8s.io`
+* `api_group` - (Optional) The API group to drive authorization decisions. This is required for kind `User` and `Group`, where the value must be `rbac.authorization.k8s.io`. This is not required for kind `ServiceAccount`
 
 ## Import
 

--- a/website/docs/r/role_binding.html.markdown
+++ b/website/docs/r/role_binding.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 * `name` - (Required) The name of this Role to bind Subjects to.
 * `namespace` - (Optional) Namespace defines the namespace of the ServiceAccount to bind to. This value only applies to kind `ServiceAccount`
 * `kind` - (Required) The type of binding to use. This value must be `ServiceAccount`, `User` or `Group`
-* `api_group` - (Required) The API group to drive authorization decisions. This value only applies to kind `User` and `Group`. It must be `rbac.authorization.k8s.io`
+* `api_group` - (Optional) The API group to drive authorization decisions. This is required for kind `User` and `Group`, where the value must be `rbac.authorization.k8s.io`. This is not required for kind `ServiceAccount`
 
 ## Import
 


### PR DESCRIPTION
### Description

This is a small clarification in the docs, for a field that is listed as "Required", but is not always required.

The role_binding and clusterrole_binding docs list subject.api_group as required, when it is only required for 2 out of 3 possible values for subject.kind. When you try to apply the config with kind = `ServiceAccount`, and with api_group set, eg:
```
subject {
    kind = "ServiceAccount"
    namespace = var.k8s_namespace
    name = var.k8s_service_account
    api_group = "rbac.authorization.k8s.io"
}
```
results in an error: `RoleBinding.rbac.authorization.k8s.io "{name}" is invalid: subjects[0].apiGroup: Unsupported value: "rbac.authorization.k8s.io": supported values: ""`

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):

```release-note
NONE
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
