### PR TITLE
Add kubernetes_config data resource

### DIFF
--- a/kubernetes/data_source_kubernetes_context.go
+++ b/kubernetes/data_source_kubernetes_context.go
@@ -1,0 +1,86 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceKubernetesConfig() *schema.Resource {
+
+	return &schema.Resource{
+		ReadContext: dataSourceKubernetesConfigRead,
+		Schema: map[string]*schema.Schema{
+			"host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_certificate": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"client_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"cluster_ca_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientSets := meta.(kubeClientsets)
+	cfg := clientSets.config
+
+	d.SetId(cfg.Host)
+
+	if err := d.Set("host", cfg.Host); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("client_certificate", string(cfg.TLSClientConfig.CertData)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("client_key", string(cfg.TLSClientConfig.KeyData)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("cluster_ca_certificate", string(cfg.TLSClientConfig.CAData)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("username", cfg.Username); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("password", cfg.Password); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("token", cfg.BearerToken); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -137,6 +137,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"kubernetes_config":                  dataSourceKubernetesConfig(),
 			"kubernetes_all_namespaces":          dataSourceKubernetesAllNamespaces(),
 			"kubernetes_config_map":              dataSourceKubernetesConfigMap(),
 			"kubernetes_ingress":                 dataSourceKubernetesIngress(),


### PR DESCRIPTION
### Description

Hi, this PR adds a new data resource that allows to pull KUBECONFIG data .. similarly as [google_client_config](https://github.com/hashicorp/terraform-provider-google/blob/master/google/data_source_google_client_config.go) for example. The use-case is to be able to provide auth data to kubectl command wrappers or other terraform modules that are sometimes used in cases where the provider is not sufficient.

I agree that the use-cases for this PR might not be the best practices tho but .... you know. I wonder if this makes sense for other people

### Acceptance tests

**WIP** (not sure yet how to exactly pull test values).

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

