### PR TITLE
Fix datasource documentation wording

### DIFF
--- a/website/docs/d/ingress.html.markdown
+++ b/website/docs/d/ingress.html.markdown
@@ -2,7 +2,7 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress"
 description: |-
-  Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
+This data source reads data from an Ingress.
 ---
 
 # kubernetes_ingress

--- a/website/docs/d/persistent_volume_claim.html.markdown
+++ b/website/docs/d/persistent_volume_claim.html.markdown
@@ -2,7 +2,7 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume_claim"
 description: |-
-  A PersistentVolumeClaim (PVC) is a request for storage by a user. This data source retrieves information about the specified PVC.
+  Queries attributes of a PersistentVolumeClaim (PVC).
 ---
 
 # kubernetes_persistent_volume_claim

--- a/website/docs/d/pod.html.markdown
+++ b/website/docs/d/pod.html.markdown
@@ -2,7 +2,7 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod"
 description: |-
-   A pod is a group of one or more containers, the shared storage for those containers, and options about how to run the containers. Pods are always co-located and co-scheduled, and run in a shared context.
+   Queries attributes of a pod.
 ---
 
 # kubernetes_pod

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -2,18 +2,15 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_secret"
 description: |-
-  The resource provides mechanisms to inject containers with sensitive information while keeping containers agnostic of Kubernetes.
+This data source reads data from a Secret.
 ---
 
 # kubernetes_secret
 
-The resource provides mechanisms to inject containers with sensitive information, such as passwords, while keeping containers agnostic of Kubernetes.
+Secrets provide mechanisms to inject containers with sensitive information, such as passwords, while keeping containers agnostic of Kubernetes.
 Secrets can be used to store sensitive information either as individual properties or coarse-grained entries like entire files or JSON blobs.
-The resource will by default create a secret which is available to any pod in the specified (or default) namespace.
 
-~> Read more about security properties and risks involved with using Kubernetes secrets: [Kubernetes reference](https://kubernetes.io/docs/user-guide/secrets/#security-properties)
-
-~> **Note:** All arguments including the secret data will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+The data source will lookup secret resource by name, enabling access to its data.
 
 ## Example Usage
 

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -2,7 +2,7 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service"
 description: |-
-  A Service is an abstraction which defines a logical set of pods and a policy by which to access them - sometimes called a micro-service.
+  Queries attributes of a Service.
 ---
 
 # kubernetes_service

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -2,7 +2,7 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_account"
 description: |-
-  A service account provides an identity for processes that run in a Pod.
+This data source reads data from a service account.
 ---
 
 # kubernetes_service_account

--- a/website/docs/d/storage_class.html.markdown
+++ b/website/docs/d/storage_class.html.markdown
@@ -2,7 +2,7 @@
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_storage_class"
 description: |-
-  Storage class is the foundation of dynamic provisioning, allowing cluster administrators to define abstractions for the underlying storage platform.
+This data source reads data from a Storage class.
 ---
 
 # kubernetes_storage_class


### PR DESCRIPTION
### Description

Datasource documentation was apparently duplicated from corresponding resources documentation.

### Acceptance tests
N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix datasource documentation wording
```

### References
N/A
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
