### PR TITLE
Fix resource_field_ref schema for projected_volume

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -535,6 +535,7 @@ func TestAccKubernetesPod_with_projected_volume(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.0.container_name", "containername"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.0.resource", "limits.cpu"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.projected.0.sources.3.downward_api.0.items.1.resource_field_ref.0.divisor", "1"),
 				),
 			},
 		},

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -879,9 +879,12 @@ func volumeSchema(isUpdatable bool) *schema.Resource {
 																	Type:     schema.TypeString,
 																	Required: true,
 																},
-																"quantity": {
-																	Type:     schema.TypeString,
-																	Optional: true,
+																"divisor": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	Default:          "1",
+																	ValidateFunc:     validateResourceQuantity,
+																	DiffSuppressFunc: suppressEquivalentResourceQuantity,
 																},
 																"resource": {
 																	Type:        schema.TypeString,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -91,7 +91,7 @@ You can also configure the host, basic auth credentials, and client certificate 
 
 ```hcl
 provider "kubernetes" {
-  host     = "https://cluster_endpoint:port"
+  host = "https://cluster_endpoint:port"
 
   client_certificate     = file("~/.kube/client-cert.pem")
   client_key             = file("~/.kube/client-key.pem")

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -645,6 +645,7 @@ The `option` block supports the following:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
+* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to "1".
 
 ### `se_linux_options`
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -656,6 +656,7 @@ The `option` block supports the following:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
+* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to "1".
 
 ### `se_linux_options`
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -705,6 +705,7 @@ The `option` block supports the following:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
+* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to "1".
 
 ### `se_linux_options`
 


### PR DESCRIPTION
### Description

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1094 

The attribute was also missing from the documentation so I added it.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -run TestAccKubernetesPod_with_projected_volume -timeout 120m
=== RUN   TestAccKubernetesPod_with_projected_volume
--- PASS: TestAccKubernetesPod_with_projected_volume (40.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	41.770s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix bug in resource_field_ref schema for projected_volume
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
