### PR TITLE
Remove kubeconfig file check

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -293,9 +293,6 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 			if err != nil {
 				return nil, err
 			}
-			if _, err := os.Stat(path); err != nil {
-				return nil, fmt.Errorf("could not open kubeconfig %q: %v", p, err)
-			}
 
 			log.Printf("[DEBUG] Using kubeconfig: %s", path)
 			expandedPaths = append(expandedPaths, path)


### PR DESCRIPTION

### Description

The kubeconfig file check seems to cause some problems when using `local_file` to create the kubeconfig in the same apply.

Solves https://github.com/hashicorp/terraform-provider-kubernetes/issues/1142

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

Tested manually using Phil's Progressive Apply repo, since our acceptance tests didn't catch this.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Remove kubeconfig file check (#1142)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
