### PR TITLE
Use locally compiled k8s provider in TC tests

### DIFF
--- a/kubernetes/test-infra/aks/main.tf
+++ b/kubernetes/test-infra/aks/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "localhost/test/kubernetes"
+      version = "9.9.9"
+    }
+  }
+}
+
 locals {
   random_prefix = "${var.prefix}-${random_id.tf-k8s-acc.hex}"
 }

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source = "localhost/test/kubernetes"
-      version = ">= 2.0.2"
+      version = "9.9.9"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source = "localhost/test/kubernetes"
       version = ">= 2.0.2"
     }
     helm = {

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "localhost/test/kubernetes"
+      version = "9.9.9"
+    }
+  }
+}
+
 provider "google" {
   // Provider settings to be provided via ENV variables
 }


### PR DESCRIPTION
### Description

There have been some incidents where we push a change to the Kubernetes provider that inadvertently breaks our CI tests. This caused the issue in #1142 to go undetected until a bug report was filed. This PR should enable us to catch similar CI specific errors sooner.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
