### PR TITLE
Enable helm pre-release test in TC

### DIFF
--- a/kubernetes/test-infra/external-providers/.terraformrc
+++ b/kubernetes/test-infra/external-providers/.terraformrc
@@ -1,7 +1,10 @@
 provider_installation {
   filesystem_mirror {
     path    = "/tmp/.terraform.d"
-    include = ["localhost/test/kubernetes"]
+    include = [
+      "localhost/test/kubernetes",
+      "localhost/test/helm",
+    ]
   }
   direct {
     include = ["registry.terraform.io/*/*"]


### PR DESCRIPTION

### Description

Test helm provider with the latest change before release.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
