### PR TITLE
Update resource_kubernetes_ingress.go

### DIFF
--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -73,7 +73,7 @@ func resourceKubernetesIngressSchemaV1() map[string]*schema.Schema {
 								},
 								"http": {
 									Type:        schema.TypeList,
-									Required:    true,
+									Optional:    true,
 									MaxItems:    1,
 									Description: "http is a list of http selectors pointing to backends. In the example: http:///? -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
 									Elem: &schema.Resource{


### PR DESCRIPTION
change spec.backend.rule.http to optional

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? -No
- [ ] Have you run the acceptance tests on this branch? - No

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Needed to close issue: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1199
This will need to be optional for mergable-ingress types provided by nginx
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
- https://github.com/hashicorp/terraform-provider-kubernetes/issues/1199
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
