### PR TITLE
Update ingress path doc and example to match Kubernetes defaults

### DIFF
--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -32,7 +32,7 @@ resource "kubernetes_ingress" "example_ingress" {
             service_port = 8080
           }
 
-          path = "/app1/*"
+          path = "/app1"
         }
 
         path {
@@ -41,7 +41,7 @@ resource "kubernetes_ingress" "example_ingress" {
             service_port = 8080
           }
 
-          path = "/app2/*"
+          path = "/app2"
         }
       }
     }
@@ -208,7 +208,7 @@ The following arguments are supported:
 
 #### `path`
 
-* `path` - (Required)  A string or an extended POSIX regular expression as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+* `path` - (Required) Path is matched against the URL path of the incoming request. The exact nature of this value depends on your ingress controller, see [Kubenetes reference](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) for more information. The reference NGINX ingress controller defaults to case insensitive string prefix, see [ingress path matching](https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/) in the NGINX ingress controller docs for more information.
 * `backend` - (Required) Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ### `tls`


### PR DESCRIPTION
### Description

The docs said that ingress rule path was a regexp, but the docs cannot really know that. According to https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types the default is implementation-specific. The reference NGINX ingress controller needs to be annotatetd to support regexes. This PR updates the path parameter description to a more general formulation with links to help the user understand what is likely to work.

Also, the corresponding examples looked like globs, which seems not to be used by any major ingress controller. This PR updates them to use prefixes which is more likely to work when pasted into the reader's environment.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update ingress path doc and example to match Kubernetes defaults 
```

### References

Fixes #1207 .

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
