### PR TITLE
kubernetes_cron_job should not force new

### DIFF
--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -54,7 +54,7 @@ func resourceKubernetesJobSchemaV1() map[string]*schema.Schema {
 			MaxItems:    1,
 			ForceNew:    false,
 			Elem: &schema.Resource{
-				Schema: jobSpecFields(),
+				Schema: jobSpecFields(false),
 			},
 		},
 		"wait_for_completion": {

--- a/kubernetes/schema_cron_job_spec.go
+++ b/kubernetes/schema_cron_job_spec.go
@@ -37,7 +37,7 @@ func cronJobSpecFields() map[string]*schema.Schema {
 						Required:    true,
 						MaxItems:    1,
 						Elem: &schema.Resource{
-							Schema: jobSpecFields(),
+							Schema: jobSpecFields(true),
 						},
 					},
 				},

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func jobMetadataSchema() *schema.Schema {
@@ -13,7 +14,7 @@ func jobMetadataSchema() *schema.Schema {
 	return m
 }
 
-func jobSpecFields() map[string]*schema.Schema {
+func jobSpecFields(specUpdatable bool) map[string]*schema.Schema {
 	podTemplateFields := map[string]*schema.Schema{
 		"metadata": metadataSchema("job", true),
 		"spec": {
@@ -23,7 +24,7 @@ func jobSpecFields() map[string]*schema.Schema {
 			ForceNew:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
-				Schema: podSpecFields(false, false),
+				Schema: podSpecFields(specUpdatable, false),
 			},
 		},
 	}


### PR DESCRIPTION
### Description

`kubernetes_cron_job` was showing ForceNew when you changed things in the template, which it shoudn't.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -run TestAccKubernetesCronJob -timeout 120m
=== RUN   TestAccKubernetesCronJob_basic
--- PASS: TestAccKubernetesCronJob_basic (5.95s)
=== RUN   TestAccKubernetesCronJob_extra
--- PASS: TestAccKubernetesCronJob_extra (5.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	13.413s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix kubernetes_cron_job ForceNew when modifying job_template
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
