### PR TITLE
Minor update to EKS test-infra

### DIFF
--- a/kubernetes/test-infra/eks/kubernetes-config/main.tf
+++ b/kubernetes/test-infra/eks/kubernetes-config/main.tf
@@ -56,14 +56,10 @@ resource "kubernetes_deployment" "test" {
   }
 }
 
-resource helm_release nginx_ingress {
-  name       = "nginx-ingress-controller"
-
-  repository = "https://charts.bitnami.com/bitnami"
-  chart      = "nginx-ingress-controller"
-
-  set {
-    name  = "service.type"
-    value = "ClusterIP"
-  }
+resource "helm_release" "nginx_ingress" {
+  wait       = false
+  name       = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  version    = "v3.24.0"
 }

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -83,6 +83,7 @@ module "cluster" {
   cluster_version  = var.kubernetes_version
   manage_aws_auth  = true
   write_kubeconfig = true
+  kubeconfig_name  = "kubeconfig"
 
   # See this file for more options
   # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/local.tf#L28


### PR DESCRIPTION
### Description

This is just a minor change for CI. It updates the helm chart to one that's managed by the Kubernetes org instead of Bitnami, and names the kubeconfig file something static so we can use it more easily.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
