### PR TITLE
Update test-infra for EKS

### DIFF
--- a/kubernetes/test-infra/aks/main.tf
+++ b/kubernetes/test-infra/aks/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     kubernetes = {
-      source = "localhost/test/kubernetes"
-      version = "9.9.9"
+      source = "hashicorp/kubernetes"
+      version = ">=2.0.3"
     }
   }
 }

--- a/kubernetes/test-infra/aks/main.tf
+++ b/kubernetes/test-infra/aks/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-      version = ">=2.0.3"
-    }
-  }
-}
-
 locals {
   random_prefix = "${var.prefix}-${random_id.tf-k8s-acc.hex}"
 }

--- a/kubernetes/test-infra/eks/kubernetes-config/main.tf
+++ b/kubernetes/test-infra/eks/kubernetes-config/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    kubernetes = {
+    kubernetes-local = {
       source = "localhost/test/kubernetes"
       version = "9.9.9"
     }
@@ -12,54 +12,30 @@ terraform {
 }
 
 resource "kubernetes_namespace" "test" {
+  provider = kubernetes-local
   metadata {
     name = "test"
   }
 }
 
-resource "kubernetes_deployment" "test" {
-  metadata {
-    name = "test"
-    namespace= kubernetes_namespace.test.metadata.0.name
-  }
-  spec {
-    replicas = 2
-    selector {
-      match_labels = {
-        app  = "test"
-      }
-    }
-    template {
-      metadata {
-        labels = {
-          app  = "test"
-        }
-      }
-      spec {
-        container {
-          image = "nginx:1.19.4"
-          name  = "nginx"
-
-          resources {
-            limits = {
-              memory = "512M"
-              cpu = "1"
-            }
-            requests = {
-              memory = "256M"
-              cpu = "50m"
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-resource "helm_release" "nginx_ingress" {
+resource helm_release nginx_ingress {
   wait       = false
   name       = "ingress-nginx"
+
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
   version    = "v3.24.0"
+
+  set {
+    name  = "controller.updateStrategy.rollingUpdate.maxUnavailable"
+    value = "1"
+  }
+  set {
+    name  = "controller.replicaCount"
+    value = "2"
+  }
+  set_sensitive {
+    name = "controller.maxmindLicenseKey"
+    value = "testSensitiveValue"
+  }
 }

--- a/kubernetes/test-infra/eks/output.tf
+++ b/kubernetes/test-infra/eks/output.tf
@@ -1,5 +1,5 @@
 output "kubeconfig_path" {
-  value = abspath("${path.root}/kubeconfig")
+  value = abspath("${module.cluster.kubeconfig_filename}")
 }
 
 output "cluster_name" {

--- a/kubernetes/test-infra/eks/output.tf
+++ b/kubernetes/test-infra/eks/output.tf
@@ -1,5 +1,5 @@
 output "kubeconfig_path" {
-  value = abspath("${module.cluster.kubeconfig_filename}")
+  value = abspath(module.cluster.kubeconfig_filename)
 }
 
 output "cluster_name" {

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     kubernetes = {
-      source = "localhost/test/kubernetes"
-      version = "9.9.9"
+      source = "hashicorp/kubernetes"
+      version = ">=2.0.3"
     }
   }
 }

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-      version = ">=2.0.3"
-    }
-  }
-}
-
 provider "google" {
   // Provider settings to be provided via ENV variables
 }


### PR DESCRIPTION
### Description

Updated the helm test, provider aliases, and kubeconfig_path output.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
