### PR TITLE
Fix perpetual diff in claim_ref

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -118,14 +118,16 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 							Type:        schema.TypeList,
 							Description: "A reference to the persistent volume claim details for statically managed PVs. More Info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#binding",
 							Optional:    true,
+							Computed:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"namespace": {
 										Type:        schema.TypeString,
-										Description: "The namespace of the PersistentVolumeClaim",
+										Description: "The namespace of the PersistentVolumeClaim. Uses 'default' namespace if none is specified.",
 										Elem:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
+										Default:     "default",
 									},
 									"name": {
 										Type:        schema.TypeString,

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -716,11 +716,6 @@ resource "kubernetes_persistent_volume" "test" {
       }
     }
   }
-  lifecycle {
-    ignore_changes = [
-      spec[0].claim_ref,
-    ]
-  }
 }
 resource "kubernetes_persistent_volume_claim" "test" {
   wait_until_bound = true

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -403,6 +403,17 @@ func flattenPersistentVolumeSpec(in v1.PersistentVolumeSpec) []interface{} {
 	return []interface{}{att}
 }
 
+func flattenObjectRef(in *v1.ObjectReference) []interface{} {
+	att := make(map[string]interface{})
+	if in.Name != "" {
+		att["name"] = in.Name
+	}
+	if in.Namespace != "" {
+		att["namespace"] = in.Namespace
+	}
+	return []interface{}{att}
+}
+
 func flattenPhotonPersistentDiskVolumeSource(in *v1.PhotonPersistentDiskVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["pd_id"] = in.PdID
@@ -1025,11 +1036,11 @@ func expandPersistentVolumeSpec(l []interface{}) (*v1.PersistentVolumeSpec, erro
 	return obj, nil
 }
 
-func expandClaimRef(v []interface{}) *v1.ObjectReference {
-	if len(v) == 0 || v[0] == nil {
-		return nil
+func expandClaimRef(l []interface{}) *v1.ObjectReference {
+	if len(l) == 0 || l[0] == nil {
+		return &v1.ObjectReference{}
 	}
-	o := v[0].(map[string]interface{})
+	o := l[0].(map[string]interface{})
 	return &v1.ObjectReference{
 		Name:      o["name"].(string),
 		Namespace: o["namespace"].(string),

--- a/kubernetes/structure_persistent_volume_spec_test.go
+++ b/kubernetes/structure_persistent_volume_spec_test.go
@@ -1,0 +1,40 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestFlattenObjectRef(t *testing.T) {
+	cases := []struct {
+		Input          *v1.ObjectReference
+		ExpectedOutput []interface{}
+	}{
+		{
+			&v1.ObjectReference{
+				Name:      "demo",
+				Namespace: "default",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":      "demo",
+					"namespace": "default",
+				},
+			},
+		},
+		{
+			&v1.ObjectReference{},
+			[]interface{}{map[string]interface{}{}},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenObjectRef(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -1028,14 +1028,3 @@ func expandContainerResourceRequirements(l []interface{}) (*v1.ResourceRequireme
 
 	return obj, nil
 }
-
-func flattenObjectRef(in *v1.ObjectReference) []interface{} {
-	att := make(map[string]interface{})
-	if in.Name != "" {
-		att["name"] = in.Name
-	}
-	if in.Namespace != "" {
-		att["namespace"] = in.Namespace
-	}
-	return []interface{}{att}
-}

--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -212,35 +212,3 @@ func TestExpandConfigMapKeyRef(t *testing.T) {
 		}
 	}
 }
-
-func TestFlattenObjectRef(t *testing.T) {
-	cases := []struct {
-		Input          *v1.ObjectReference
-		ExpectedOutput []interface{}
-	}{
-		{
-			&v1.ObjectReference{
-				Name:      "demo",
-				Namespace: "default",
-			},
-			[]interface{}{
-				map[string]interface{}{
-					"name":      "demo",
-					"namespace": "default",
-				},
-			},
-		},
-		{
-			&v1.ObjectReference{},
-			[]interface{}{map[string]interface{}{}},
-		},
-	}
-
-	for _, tc := range cases {
-		output := flattenObjectRef(tc.Input)
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
-	}
-}


### PR DESCRIPTION
The `claim_ref` attribute would perpetually show a diff if the PV was created without a `claim_ref` specified.
This is because all PVs gain a claimRef once a PVC binds to it. (This creates the bi-directional link between PV and PVC,
and it's done on the Kubernetes API side).

To support this, `claim_ref` is now a Computed attribute, and it will update to show the claimRef once a PVC has bound to the PV,
(only now it will do so without creating a diff in terraform).

Also added extra tests to catch this case and moved claim_ref's flatteners/expanders/tests into the correct files.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
go test -run TestFlattenObjectRef '-timeout=30s' '-parallel=4' /home/dakini/go/src/github.com/hashicorp/terraform-provider-kubernetes/kubernetes 
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   0.036s

=== RUN   TestAccKubernetesPersistentVolume_minimal
--- PASS: TestAccKubernetesPersistentVolume_minimal (2.53s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   2.578s


=== RUN   TestAccKubernetesPersistentVolume_hostpath_claimRef
--- PASS: TestAccKubernetesPersistentVolume_hostpath_claimRef (13.56s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   13.604s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix perpetual diff in claim_ref
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
