### PR TITLE
Add binary_data attribute to kubernetes_secret

### DIFF
--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -29,6 +29,7 @@ func resourceKubernetesSecret() *schema.Resource {
 				Type:        schema.TypeMap,
 				Description: "A map of the secret data.",
 				Optional:    true,
+				Computed:    true,
 				Sensitive:   true,
 			},
 			"binary_data": {
@@ -133,15 +134,11 @@ func resourceKubernetesSecretRead(ctx context.Context, d *schema.ResourceData, m
 		d.Set("binary_data", base64EncodeByteMap(binaryData))
 	}
 
-	if _, ok := d.GetOk("data"); ok {
-		for _, k := range binaryDataKeys {
-			delete(secret.Data, k)
-		}
-		d.Set("data", flattenByteMapToStringMap(secret.Data))
+	for _, k := range binaryDataKeys {
+		delete(secret.Data, k)
 	}
-
+	d.Set("data", flattenByteMapToStringMap(secret.Data))
 	d.Set("type", secret.Type)
-
 	return nil
 }
 
@@ -166,8 +163,8 @@ func resourceKubernetesSecretUpdate(ctx context.Context, d *schema.ResourceData,
 			newData[k] = v
 		}
 	} else if v, ok := d.GetOk("data"); ok {
-		for k, vv := range v.(map[string]interface{}) {
-			newData[k] = base64EncodeStringMap(vv.(map[string]interface{}))
+		for k, vv := range base64EncodeStringMap(v.(map[string]interface{})) {
+			newData[k] = vv
 		}
 	}
 	if d.HasChange("binary_data") {

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -385,6 +385,8 @@ func testAccKubernetesSecretConfig_noData(name string) string {
   metadata {
     name = "%s"
   }
+
+  data = {}
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -194,38 +194,41 @@ func TestAccKubernetesSecret_generatedName(t *testing.T) {
 	})
 }
 
-// Disabled - this test loads binary data from a file and passes it through configuration
-//            which is no longer supported in TF 0.12.
-//            Instead, the resource attribute should be adapted to transport base64 encoded
-//            data and decode it when constructing the API object for client-go.
-//
-// func TestAccKubernetesSecret_binaryData(t *testing.T) {
-//   var conf api.Secret
-//   prefix := "tf-acc-test-gen-"
-//
-//   resource.Test(t, resource.TestCase{
-//     PreCheck:      func() { testAccPreCheck(t) },
-//     IDRefreshName: "kubernetes_secret.test",
-//     ProviderFactories: testAccProviderFactories,
-//     CheckDestroy:  testAccCheckKubernetesSecretDestroy,
-//     Steps: []resource.TestStep{
-//       {
-//         Config: testAccKubernetesSecretConfig_binaryData(prefix),
-//         Check: resource.ComposeAggregateTestCheckFunc(
-//           testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
-//           resource.TestCheckResourceAttr("kubernetes_secret.test", "data.%", "1"),
-//         ),
-//       },
-//       {
-//         Config: testAccKubernetesSecretConfig_binaryData2(prefix),
-//         Check: resource.ComposeAggregateTestCheckFunc(
-//           testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
-//           resource.TestCheckResourceAttr("kubernetes_secret.test", "data.%", "2"),
-//         ),
-//       },
-//     },
-//   })
-// }
+func TestAccKubernetesSecret_binaryData(t *testing.T) {
+	var conf api.Secret
+	prefix := "tf-acc-test-gen-"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     "kubernetes_secret.test",
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesSecretDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesSecretConfig_binaryData(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "binary_data.%", "1"),
+				),
+			},
+			{
+				Config: testAccKubernetesSecretConfig_binaryData2(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "binary_data.%", "2"),
+				),
+			},
+			{
+				Config: testAccKubernetesSecretConfig_binaryDataCombined(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesSecretExists("kubernetes_secret.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "binary_data.%", "2"),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckSecretData(m *api.Secret, expected map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -422,11 +425,8 @@ func testAccKubernetesSecretConfig_binaryData(prefix string) string {
     generate_name = "%s"
   }
 
-  data = {
-    one = <<EOF
-"${filebase64("./test-fixtures/binary.data")}"
-EOF
-
+  binary_data = {
+    one = filebase64("./test-fixtures/binary.data")
   }
 }
 `, prefix)
@@ -438,15 +438,28 @@ func testAccKubernetesSecretConfig_binaryData2(prefix string) string {
     generate_name = "%s"
   }
 
+  binary_data = {
+    one = filebase64("./test-fixtures/binary.data")
+    two = filebase64("./test-fixtures/binary2.data")
+  }
+}
+`, prefix)
+}
+
+func testAccKubernetesSecretConfig_binaryDataCombined(prefix string) string {
+	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+  metadata {
+    generate_name = "%s"
+  }
+
   data = {
-    one = <<EOF
-"${filebase64("./test-fixtures/binary2.data")}"
-EOF
+	  "HOST" = "127.0.0.1"
+	  "PORT" = "80"
+  }
 
-    two = <<EOF
-"${filebase64("./test-fixtures/binary.data")}"
-EOF
-
+  binary_data = {
+    one = filebase64("./test-fixtures/binary.data")
+    two = filebase64("./test-fixtures/binary2.data")
   }
 }
 `, prefix)

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -218,6 +218,26 @@ func base64EncodeStringMap(m map[string]interface{}) map[string]interface{} {
 	return result
 }
 
+func base64EncodeByteMap(m map[string][]byte) map[string]interface{} {
+	result := map[string]interface{}{}
+	for k, v := range m {
+		result[k] = base64.StdEncoding.EncodeToString(v)
+	}
+	return result
+}
+
+func base64DecodeStringMap(m map[string]interface{}) (map[string][]byte, error) {
+	mm := map[string][]byte{}
+	for k, v := range m {
+		d, err := base64.StdEncoding.DecodeString(v.(string))
+		if err != nil {
+			return nil, err
+		}
+		mm[k] = []byte(d)
+	}
+	return mm, nil
+}
+
 func flattenResourceList(l api.ResourceList) map[string]string {
 	m := make(map[string]string)
 	for k, v := range l {

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -99,6 +99,7 @@ resource "kubernetes_secret" "example" {
 The following arguments are supported:
 
 * `data` - (Optional) A map of the secret data.
+* `binary_data` - (Optional) A map base64 encoded map of the secret data.
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
 


### PR DESCRIPTION
### Description

This PR adds a `binary_data` field to the `kubernetes_secret` resource. This lets users supply binary data that is base64 encoded, e.g by using `filebase64`

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -run TestAccKubernetesSecret -timeout 120m
=== RUN   TestAccKubernetesSecret_basic
--- PASS: TestAccKubernetesSecret_basic (13.81s)
=== RUN   TestAccKubernetesSecret_generatedName
--- PASS: TestAccKubernetesSecret_generatedName (3.96s)
=== RUN   TestAccKubernetesSecret_binaryData
--- PASS: TestAccKubernetesSecret_binaryData (7.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	26.589s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add binary_data field to kubernetes secret
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
