### PR TITLE
Ensure resources are created after cluster API becomes available

### DIFF
--- a/kubernetes/test-infra/eks/kubernetes-config/main.tf
+++ b/kubernetes/test-infra/eks/kubernetes-config/main.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_config_map" "name" {
+depends_on = [var.cluster_name]
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"
@@ -20,12 +21,14 @@ resource "null_resource" "generate-kubeconfig" {
 }
 
 resource "kubernetes_namespace" "test" {
+depends_on = [var.cluster_name]
   metadata {
     name = "test"
   }
 }
 
 resource "kubernetes_deployment" "test" {
+depends_on = [var.cluster_name]
   metadata {
     name = "test"
     namespace= kubernetes_namespace.test.metadata.0.name

--- a/kubernetes/test-infra/eks/kubernetes-config/main.tf
+++ b/kubernetes/test-infra/eks/kubernetes-config/main.tf
@@ -13,13 +13,6 @@ depends_on = [var.cluster_name]
   }
 }
 
-# Optional: this kubeconfig file is only used for manual CLI access to the cluster.
-resource "null_resource" "generate-kubeconfig" {
-  provisioner "local-exec" {
-    command = "aws eks update-kubeconfig --name ${var.cluster_name} --kubeconfig ${path.root}/kubeconfig"
-  }
-}
-
 resource "kubernetes_namespace" "test" {
 depends_on = [var.cluster_name]
   metadata {
@@ -27,47 +20,8 @@ depends_on = [var.cluster_name]
   }
 }
 
-resource "kubernetes_deployment" "test" {
-depends_on = [var.cluster_name]
-  metadata {
-    name = "test"
-    namespace= kubernetes_namespace.test.metadata.0.name
-  }
-  spec {
-    replicas = 2
-    selector {
-      match_labels = {
-        app  = "test"
-      }
-    }
-    template {
-      metadata {
-        labels = {
-          app  = "test"
-        }
-      }
-      spec {
-        container {
-          image = "nginx:1.19.4"
-          name  = "nginx"
-
-          resources {
-            limits = {
-              memory = "512M"
-              cpu = "1"
-            }
-            requests = {
-              memory = "256M"
-              cpu = "50m"
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 resource helm_release nginx_ingress {
+depends_on = [var.cluster_name]
   name       = "nginx-ingress-controller"
 
   repository = "https://charts.bitnami.com/bitnami"

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -75,9 +75,7 @@ module "cluster" {
   cluster_name    = module.vpc.cluster_name
   cluster_version = var.kubernetes_version
   manage_aws_auth = false # Managed in ./kubernetes-config/main.tf instead.
-  # This kubeconfig expires in 15 minutes, so we'll use an exec block instead.
-  # See ./kubernetes-config/main.tf provider block for details.
-  write_kubeconfig = false
+  write_kubeconfig = true
 
   workers_group_defaults = {
     root_volume_type = "gp2"


### PR DESCRIPTION
### Description

This should fix some test failures in CI. The Kubernetes resources have been trying to create before the EKS API is available, which is causing these errors:

```
 on kubernetes-config/main.tf line 1, in resource "kubernetes_config_map" "name":
   1: resource "kubernetes_config_map" "name" {
Error: Post "https://B8DC6A6DE53C1E86594E2625E5C63A71.gr7.us-east-1.eks.amazonaws.com/api/v1/namespaces": dial tcp 3.231.106.8:443: i/o timeout
```

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
