### PR TITLE
r/ingress_class - new resource

### DIFF
--- a/kubernetes/data_source_kubernetes_ingress.go
+++ b/kubernetes/data_source_kubernetes_ingress.go
@@ -27,6 +27,11 @@ func dataSourceKubernetesIngress() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"ingress_class_name": {
+							Type:        schema.TypeString,
+							Description: docIngressSpec["ingressClassName"],
+							Computed:    true,
+						},
 						"backend": backendSpecFields(defaultBackendDescription),
 						"rule": {
 							Type:        schema.TypeList,

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -189,6 +189,7 @@ func Provider() *schema.Provider {
 			"kubernetes_endpoints":                        resourceKubernetesEndpoints(),
 			"kubernetes_horizontal_pod_autoscaler":        resourceKubernetesHorizontalPodAutoscaler(),
 			"kubernetes_ingress":                          resourceKubernetesIngress(),
+			"kubernetes_ingress_class":                    resourceKubernetesIngressClass(),
 			"kubernetes_job":                              resourceKubernetesJob(),
 			"kubernetes_limit_range":                      resourceKubernetesLimitRange(),
 			"kubernetes_namespace":                        resourceKubernetesNamespace(),

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -34,7 +34,7 @@ func resourceKubernetesIngressClassSchema() map[string]*schema.Schema {
 	docIngressClassSpecParametes := core.TypedLocalObjectReference{}.SwaggerDoc()
 
 	return map[string]*schema.Schema{
-		"metadata": namespacedMetadataSchema("IngressClass", true),
+		"metadata": metadataSchema("ingress_class", true),
 		"spec": {
 			Type:        schema.TypeList,
 			Description: docIngressClass["spec"],
@@ -44,7 +44,7 @@ func resourceKubernetesIngressClassSchema() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"controller": {
 						Type:        schema.TypeString,
-						Description: docIngressClassSpec["Controller"],
+						Description: docIngressClassSpec["controller"],
 						Optional:    true,
 					},
 					"parameters": {

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -1,0 +1,299 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	core "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1beta1"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func resourceKubernetesIngressClass() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKubernetesIngressClassCreate,
+		ReadContext:   resourceKubernetesIngressClassRead,
+		UpdateContext: resourceKubernetesIngressClassUpdate,
+		DeleteContext: resourceKubernetesIngressClassDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: resourceKubernetesIngressClassSchema(),
+	}
+}
+
+func resourceKubernetesIngressClassSchema() map[string]*schema.Schema {
+	docIngressClass := networking.IngressClass{}.SwaggerDoc()
+	docIngressClassSpec := networking.IngressClassSpec{}.SwaggerDoc()
+	docIngressClassSpecParametes := core.TypedLocalObjectReference{}.SwaggerDoc()
+
+	return map[string]*schema.Schema{
+		"metadata": namespacedMetadataSchema("IngressClass", true),
+		"spec": {
+			Type:        schema.TypeList,
+			Description: docIngressClass["spec"],
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"controller": {
+						Type:        schema.TypeString,
+						Description: docIngressClassSpec["Controller"],
+						Optional:    true,
+					},
+					"parameters": {
+						Type:        schema.TypeList,
+						Description: docIngressClass["parameters"],
+						Optional:    true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"api_group": {
+									Type:        schema.TypeString,
+									Description: docIngressClassSpecParametes["apiGroup"],
+									Optional:    true,
+								},
+								"kind": {
+									Type:        schema.TypeString,
+									Description: docIngressClassSpecParametes["kind"],
+									Required:    true,
+								},
+								"name": {
+									Type:        schema.TypeString,
+									Description: docIngressClassSpecParametes["name"],
+									Required:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceKubernetesIngressClassCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	ing := &networking.IngressClass{
+		Spec: expandIngressClassSpec(d.Get("spec").([]interface{})),
+	}
+	ing.ObjectMeta = metadata
+	log.Printf("[INFO] Creating new Ingress Class: %#v", ing)
+	out, err := conn.NetworkingV1beta1().IngressClasses().Create(ctx, ing, metav1.CreateOptions{})
+	if err != nil {
+		return diag.Errorf("Failed to create Ingress Class '%s' because: %s", buildId(ing.ObjectMeta), err)
+	}
+	log.Printf("[INFO] Submitted new IngressClass: %#v", out)
+	d.SetId(buildId(out.ObjectMeta))
+
+	return diag.Diagnostics{}
+}
+
+func resourceKubernetesIngressClassRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	exists, err := resourceKubernetesIngressClassExists(ctx, d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if !exists {
+		d.SetId("")
+		return diag.Diagnostics{}
+	}
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, name, err := idParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Reading Ingress Class %s", name)
+	ing, err := conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return diag.Errorf("Failed to read Ingress Class '%s' because: %s", buildId(ing.ObjectMeta), err)
+	}
+	log.Printf("[INFO] Received Ingress Class: %#v", ing)
+	err = d.Set("metadata", flattenMetadata(ing.ObjectMeta, d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	flattened := flattenIngressClassSpec(ing.Spec)
+	log.Printf("[DEBUG] Flattened Ingress Class spec: %#v", flattened)
+	err = d.Set("spec", flattened)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceKubernetesIngressClassUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec := expandIngressClassSpec(d.Get("spec").([]interface{}))
+
+	if metadata.Namespace == "" {
+		metadata.Namespace = "default"
+	}
+
+	ingressClass := &networking.IngressClass{
+		ObjectMeta: metadata,
+		Spec:       spec,
+	}
+
+	out, err := conn.NetworkingV1beta1().IngressClasses().Update(ctx, ingressClass, metav1.UpdateOptions{})
+	if err != nil {
+		return diag.Errorf("Failed to update Ingress Class %s because: %s", buildId(ingressClass.ObjectMeta), err)
+	}
+	log.Printf("[INFO] Submitted updated Ingress Class: %#v", out)
+
+	return resourceKubernetesIngressClassRead(ctx, d, meta)
+}
+
+func resourceKubernetesIngressClassDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, name, err := idParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Deleting Ingress Class: %#v", name)
+	err = conn.NetworkingV1beta1().IngressClasses().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return diag.Errorf("Failed to delete Ingress Class %s because: %s", d.Id(), err)
+	}
+
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		e := fmt.Errorf("Ingress Class (%s) still exists", d.Id())
+		return resource.RetryableError(e)
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Ingress Class %s deleted", name)
+
+	d.SetId("")
+	return nil
+}
+
+func resourceKubernetesIngressClassExists(ctx context.Context, d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
+
+	_, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
+	log.Printf("[INFO] Checking Ingress Class %s", name)
+	_, err = conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return false, nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+	}
+	return true, err
+}
+
+func expandIngressClassSpec(l []interface{}) networking.IngressClassSpec {
+	if len(l) == 0 || l[0] == nil {
+		return networking.IngressClassSpec{}
+	}
+	in := l[0].(map[string]interface{})
+	obj := networking.IngressClassSpec{}
+
+	if v, ok := in["controller"].(string); ok && len(v) > 0 {
+		obj.Controller = v
+	}
+
+	if v, ok := in["parameters"].([]interface{}); ok && len(v) > 0 {
+		obj.Parameters = expandIngressClassParameters(v)
+	}
+
+	return obj
+}
+
+func expandIngressClassParameters(l []interface{}) *core.TypedLocalObjectReference {
+	if len(l) == 0 || l[0] == nil {
+		return &core.TypedLocalObjectReference{}
+	}
+	in := l[0].(map[string]interface{})
+	obj := &core.TypedLocalObjectReference{}
+
+	if v, ok := in["api_group"].(string); ok {
+		obj.APIGroup = &v
+	}
+
+	if v, ok := in["kind"].(string); ok {
+		obj.Kind = v
+	}
+
+	if v, ok := in["name"].(string); ok {
+		obj.Name = v
+	}
+
+	return obj
+}
+
+func flattenIngressClassSpec(in networking.IngressClassSpec) []interface{} {
+	att := make(map[string]interface{})
+
+	if in.Controller != "" {
+		att["controller"] = in.Controller
+	}
+
+	if in.Parameters != nil {
+		att["parameters"] = flattenIngressClassParameters(in.Parameters)
+	}
+
+	return []interface{}{att}
+}
+
+func flattenIngressClassParameters(in *core.TypedLocalObjectReference) []interface{} {
+	att := make([]interface{}, 1, 1)
+
+	m := make(map[string]interface{})
+	m["kind"] = in.Kind
+	m["name"] = in.Name
+
+	if in.APIGroup != nil {
+		m["api_group"] = &in.APIGroup
+	}
+
+	att[0] = m
+
+	return att
+}

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -68,6 +68,16 @@ func resourceKubernetesIngressClassSchema() map[string]*schema.Schema {
 									Description: docIngressClassSpecParametes["name"],
 									Required:    true,
 								},
+								"scope": {
+									Type:        schema.TypeString,
+									Description: docIngressClassSpecParametes["scope"],
+									Optional:    true,
+								},
+								"namespace": {
+									Type:        schema.TypeString,
+									Description: docIngressClassSpecParametes["namespace"],
+									Optional:    true,
+								},
 							},
 						},
 					},
@@ -246,12 +256,12 @@ func expandIngressClassSpec(l []interface{}) networking.IngressClassSpec {
 	return obj
 }
 
-func expandIngressClassParameters(l []interface{}) *core.TypedLocalObjectReference {
+func expandIngressClassParameters(l []interface{}) *networking.IngressClassParametersReference {
 	if len(l) == 0 || l[0] == nil {
-		return &core.TypedLocalObjectReference{}
+		return &networking.IngressClassParametersReference{}
 	}
 	in := l[0].(map[string]interface{})
-	obj := &core.TypedLocalObjectReference{}
+	obj := &networking.IngressClassParametersReference{}
 
 	if v, ok := in["api_group"].(string); ok && v != "" {
 		obj.APIGroup = &v
@@ -263,6 +273,14 @@ func expandIngressClassParameters(l []interface{}) *core.TypedLocalObjectReferen
 
 	if v, ok := in["name"].(string); ok {
 		obj.Name = v
+	}
+
+	if v, ok := in["scope"].(string); ok {
+		obj.Scope = &v
+	}
+
+	if v, ok := in["namespace"].(string); ok {
+		obj.Namespace = &v
 	}
 
 	return obj
@@ -282,7 +300,7 @@ func flattenIngressClassSpec(in networking.IngressClassSpec) []interface{} {
 	return []interface{}{att}
 }
 
-func flattenIngressClassParameters(in *core.TypedLocalObjectReference) []interface{} {
+func flattenIngressClassParameters(in *networking.IngressClassParametersReference) []interface{} {
 	att := make([]interface{}, 1, 1)
 
 	m := make(map[string]interface{})
@@ -291,6 +309,14 @@ func flattenIngressClassParameters(in *core.TypedLocalObjectReference) []interfa
 
 	if in.APIGroup != nil {
 		m["api_group"] = *in.APIGroup
+	}
+
+	if in.Scope != nil {
+		m["scope"] = *in.Scope
+	}
+
+	if in.Namespace != nil {
+		m["namespace"] = *in.Namespace
 	}
 
 	att[0] = m

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -253,7 +253,7 @@ func expandIngressClassParameters(l []interface{}) *core.TypedLocalObjectReferen
 	in := l[0].(map[string]interface{})
 	obj := &core.TypedLocalObjectReference{}
 
-	if v, ok := in["api_group"].(string); ok {
+	if v, ok := in["api_group"].(string); ok && v != "" {
 		obj.APIGroup = &v
 	}
 

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -106,7 +106,7 @@ func resourceKubernetesIngressClassCreate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("Failed to create Ingress Class '%s' because: %s", buildId(ing.ObjectMeta), err)
 	}
 	log.Printf("[INFO] Submitted new IngressClass: %#v", out)
-	d.SetId(buildId(out.ObjectMeta))
+	d.SetId(out.ObjectMeta.GetName())
 
 	return diag.Diagnostics{}
 }
@@ -125,10 +125,7 @@ func resourceKubernetesIngressClassRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	name := d.Id()
 
 	log.Printf("[INFO] Reading Ingress Class %s", name)
 	ing, err := conn.NetworkingV1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
@@ -185,10 +182,7 @@ func resourceKubernetesIngressClassDelete(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	name := d.Id()
 
 	log.Printf("[INFO] Deleting Ingress Class: %#v", name)
 	err = conn.NetworkingV1().IngressClasses().Delete(ctx, name, metav1.DeleteOptions{})
@@ -224,10 +218,7 @@ func resourceKubernetesIngressClassExists(ctx context.Context, d *schema.Resourc
 		return false, err
 	}
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return false, err
-	}
+	name := d.Id()
 
 	log.Printf("[INFO] Checking Ingress Class %s", name)
 	_, err = conn.NetworkingV1().IngressClasses().Get(ctx, name, metav1.GetOptions{})

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -69,9 +70,10 @@ func resourceKubernetesIngressClassSchema() map[string]*schema.Schema {
 									Required:    true,
 								},
 								"scope": {
-									Type:        schema.TypeString,
-									Description: docIngressClassSpecParametes["scope"],
-									Optional:    true,
+									Type:         schema.TypeString,
+									Description:  docIngressClassSpecParametes["scope"],
+									Optional:     true,
+									ValidateFunc: validation.StringInSlice([]string{"Cluster", "Namespace"}, false),
 								},
 								"namespace": {
 									Type:        schema.TypeString,

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -217,10 +217,10 @@ resource "kubernetes_ingress_class" "test" {
   }
   spec {
     controller = "example.com/ingress-controller"
-	parameters {
+    parameters {
       kind = "IngressParameters"
       name = %[2]q
-	}
+    }
   }
 }
 `, name, paramName)
@@ -234,11 +234,11 @@ resource "kubernetes_ingress_class" "test" {
   }
   spec {
     controller = "example.com/ingress-controller"
-	parameters {
+    parameters {
 	  api_group = %[2]q
       kind      = "IngressParameters"
       name      = %[2]q
-	}
+    }
   }
 }
 `, name, paramName)

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -1,0 +1,109 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAccKubernetesIngressClass_basic(t *testing.T) {
+	var conf networking.IngressClass
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_ingress_class.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesIngressClassDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesIngressClassConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesIngressClassExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.controller", "example.com/ingress-controller"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesIngressClassDestroy(s *terraform.State) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+
+	if err != nil {
+		return err
+	}
+	ctx := context.TODO()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kubernetes_ingress_class" {
+			continue
+		}
+
+		_, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			if resp.Name == rs.Primary.ID {
+				return fmt.Errorf("Ingress still exists: %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckKubernetesIngressClassExists(n string, obj *networking.IngressClass) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+		ctx := context.TODO()
+
+		_, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		out, err := conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		*obj = *out
+		return nil
+	}
+}
+
+func testAccKubernetesIngressClassConfig_basic(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_ingress_class" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    controller = "example.com/ingress-controller"
+	
+
+  }
+}`, name)
+}

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -90,6 +90,55 @@ func TestAccKubernetesIngressClass_parameters(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesIngressClass_parameters_apiGroup(t *testing.T) {
+	var conf networking.IngressClass
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameUpdated := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kubernetes_ingress_class.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesIngressClassDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesIngressClassConfigParametersApiGroup(rName, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesIngressClassExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.controller", "example.com/ingress-controller"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.0.kind", "IngressParameters"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.0.api_group", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccKubernetesIngressClassConfigParametersApiGroup(rName, rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesIngressClassExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.controller", "example.com/ingress-controller"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.0.kind", "IngressParameters"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.0.name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.0.api_group", rNameUpdated),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesIngressClassDestroy(s *terraform.State) error {
 	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
@@ -108,7 +157,7 @@ func testAccCheckKubernetesIngressClassDestroy(s *terraform.State) error {
 			return err
 		}
 
-		resp, err := conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+		resp, err := conn.NetworkingV1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
 				return fmt.Errorf("Ingress still exists: %s", rs.Primary.ID)
@@ -137,7 +186,7 @@ func testAccCheckKubernetesIngressClassExists(n string, obj *networking.IngressC
 			return err
 		}
 
-		out, err := conn.NetworkingV1beta1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
+		out, err := conn.NetworkingV1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -171,6 +220,24 @@ resource "kubernetes_ingress_class" "test" {
 	parameters {
       kind = "IngressParameters"
       name = %[2]q
+	}
+  }
+}
+`, name, paramName)
+}
+
+func testAccKubernetesIngressClassConfigParametersApiGroup(name, paramName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_class" "test" {
+  metadata {
+    name = %[1]q
+  }
+  spec {
+    controller = "example.com/ingress-controller"
+	parameters {
+	  api_group = %[2]q
+      kind      = "IngressParameters"
+      name      = %[2]q
 	}
   }
 }

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -235,7 +235,7 @@ resource "kubernetes_ingress_class" "test" {
   spec {
     controller = "example.com/ingress-controller"
     parameters {
-	  api_group = %[2]q
+      api_group = %[2]q
       kind      = "IngressParameters"
       name      = %[2]q
     }

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -96,14 +96,14 @@ func testAccCheckKubernetesIngressClassExists(n string, obj *networking.IngressC
 }
 
 func testAccKubernetesIngressClassConfig_basic(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_class" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_class" "test" {
   metadata {
     name = "%s"
   }
   spec {
     controller = "example.com/ingress-controller"
-	
-
   }
-}`, name)
+}
+`, name)
 }

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccKubernetesIngressClass_basic(t *testing.T) {
 	var conf networking.IngressClass
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "kubernetes_ingress_class.test"
 
 	resource.Test(t, resource.TestCase{
@@ -24,15 +24,20 @@ func TestAccKubernetesIngressClass_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKubernetesIngressClassDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesIngressClassConfig_basic(name),
+				Config: testAccKubernetesIngressClassConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesIngressClassExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.controller", "example.com/ingress-controller"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.parameters.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_ingress_class_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -141,22 +142,17 @@ func TestAccKubernetesIngressClass_parameters_apiGroup(t *testing.T) {
 
 func testAccCheckKubernetesIngressClassDestroy(s *terraform.State) error {
 	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
-
 	if err != nil {
 		return err
 	}
-	ctx := context.TODO()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_ingress_class" {
 			continue
 		}
 
-		_, name, err := idParts(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
+		ctx := context.Background()
+		name := rs.Primary.ID
 		resp, err := conn.NetworkingV1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
@@ -179,13 +175,9 @@ func testAccCheckKubernetesIngressClassExists(n string, obj *networking.IngressC
 		if err != nil {
 			return err
 		}
-		ctx := context.TODO()
 
-		_, name, err := idParts(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
+		ctx := context.Background()
+		name := rs.Primary.ID
 		out, err := conn.NetworkingV1().IngressClasses().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return err

--- a/website/docs/d/ingress.html.markdown
+++ b/website/docs/d/ingress.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 * `backend` - Backend defines the referenced service endpoint to which the traffic will be forwarded. See `backend` block attributes below.
 * `rule` - A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend. See `rule` block attributes below.
 * `tls` - TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI. See `tls` block attributes below.
+* `ingress_class_name` - The name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field.
 
 ### `backend`
 

--- a/website/docs/r/ingress_class.html.markdown
+++ b/website/docs/r/ingress_class.html.markdown
@@ -77,6 +77,8 @@ The following arguments are supported:
 * `name` - (Required) The name of resource being referenced.
 * `kind` - (Required) The type of resource being referenced.
 * `api_group` - (Optional) The group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group.
+* `scope` - (Optional) Refers to a cluster or namespace scoped resource. This may be set to "Cluster" (default) or "Namespace". Field can be enabled with IngressClassNamespacedParams feature gate.
+* `namespace` - (Optional) The namespace of the resource being referenced. This field is required when scope is set to "Namespace" and must be unset when scope is set to "Cluster".
 
 ## Import
 

--- a/website/docs/r/ingress_class.html.markdown
+++ b/website/docs/r/ingress_class.html.markdown
@@ -21,9 +21,9 @@ resource "kubernetes_ingress_class" "example" {
   spec {
     controller = "example.com/ingress-controller"
     parameters = {
-        api_group = "k8s.example.com/v1alpha"
-        kind = "IngressParameters"
-        name = "external-lb"
+      api_group = "k8s.example.com/v1alpha"
+      kind      = "IngressParameters"
+      name      = "external-lb"
     }
   }
 }

--- a/website/docs/r/ingress_class.html.markdown
+++ b/website/docs/r/ingress_class.html.markdown
@@ -1,0 +1,93 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_ingress_class"
+description: |-
+  Ingresses can be implemented by different controllers, often with different configuration. Each Ingress should specify a class, a reference to an IngressClass resource that contains additional configuration including the name of the controller that should implement the class.
+---
+
+# kubernetes_ingress_class
+
+Ingresses can be implemented by different controllers, often with different configuration. Each Ingress should specify a class, a reference to an IngressClass resource that contains additional configuration including the name of the controller that should implement the class.
+
+
+## Example Usage
+
+```hcl
+resource "kubernetes_ingress_class" "example" {
+  metadata {
+    name = "example"
+  }
+
+  spec {
+    controller = "example.com/ingress-controller"
+    parameters = {
+        api_group = "k8s.example.com/v1alpha"
+        kind = "IngressParameters"
+        name = "external-lb"
+    }
+  }
+}
+```
+
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard ingress's metadata. For more info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+* `spec` - (Required) Spec defines the behavior of a ingress. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `wait_for_load_balancer` - (Optional) Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created. Defaults to `false`.
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the ingress that may be used to store arbitrary metadata.
+
+~> By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info: http://kubernetes.io/docs/user-guide/annotations
+
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services.
+
+~> By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info: http://kubernetes.io/docs/user-guide/labels
+
+* `name` - (Optional) Name of the ingress class, must be unique. Cannot be updated. For more info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+#### Attributes
+
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+* `uid` - The unique in time and space value for this service. For more info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+### `spec`
+
+#### Arguments
+
+* `controller` - (Required) the name of the controller that should handle this class.
+* `parameters` - (Optional) Parameters is a link to a custom resource containing additional configuration for the controller. See `parameters` block attributes below.
+
+### `parameters`
+
+#### Arguments
+
+* `name` - (Required) The name of resource being referenced.
+* `kind` - (Required) The type of resource being referenced.
+* `api_group` - (Optional) The group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group.
+
+## Import
+
+Ingress Classes can be imported using its name:
+
+```
+terraform import kubernetes_ingress_class.<TERRAFORM_RESOURCE_NAME> <KUBE_INGRESS_CLASS_NAME>
+```
+
+e.g.
+
+```
+$ terraform import kubernetes_ingress_class.example terraform-name
+```

--- a/website/docs/r/ingress_class.html.markdown
+++ b/website/docs/r/ingress_class.html.markdown
@@ -20,8 +20,8 @@ resource "kubernetes_ingress_class" "example" {
 
   spec {
     controller = "example.com/ingress-controller"
-    parameters = {
-      api_group = "k8s.example.com/v1alpha"
+    parameters {
+      api_group = "k8s.example.com"
       kind      = "IngressParameters"
       name      = "external-lb"
     }
@@ -82,14 +82,8 @@ The following arguments are supported:
 
 ## Import
 
-Ingress Classes can be imported using its name:
+Ingress Classes can be imported using its name, e.g:
 
 ```
-terraform import kubernetes_ingress_class.<TERRAFORM_RESOURCE_NAME> <KUBE_INGRESS_CLASS_NAME>
-```
-
-e.g.
-
-```
-$ terraform import kubernetes_ingress_class.example terraform-name
+$ terraform import kubernetes_ingress_class.example example
 ```


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesIngressClass_'
--- PASS: TestAccKubernetesIngressClass_basic (2.98s)
--- PASS: TestAccKubernetesIngressClass_parameters (4.78s)
--- PASS: TestAccKubernetesIngressClass_parameters_apiGroup (4.82s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_kubernetes_ingress_class - new resource
```

### References
Closes #1217
Closes #1218
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
