### PR TITLE
Remove imports with incompatible licenses

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -6,6 +6,4 @@ import (
 	_ "github.com/bflad/tfproviderdocs"
 	_ "github.com/bflad/tfproviderlint/cmd/tfproviderlint"
 	_ "github.com/client9/misspell/cmd/misspell"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/katbyte/terrafmt"
 )


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Going through and removing imports with incompatible licenses:

Version 1.13.3:
- [ ] vendor\github.com\golangci\golangcli-lint

Version 2.0.2:
- [ ] vendor\github.com\golangci\golangcli-lint
- [ ] github.com/golangci/check
- [ ] github.com/denis-tingajkin/go-header 
- [ ] github.com/OpenPeeDeeP/depguard 1.0.1
- [ ] github.com/katbyte/terrafmt

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
