### PR TITLE
r/resource_quota - support `scope_selector`

### DIFF
--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -80,7 +80,7 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 												},
 												"values": {
 													Type:        schema.TypeSet,
-													Description: "Represents a scope's relationship to a set of values.",
+													Description: "A list of scope selector requirements by scope of the resources.",
 													Optional:    true,
 													Elem:        &schema.Schema{Type: schema.TypeString},
 												},

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,16 +69,14 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"scope_name": {
-													Type:         schema.TypeString,
-													Description:  "The name of the scope that the selector applies to.",
-													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{"Terminating", "NotTerminating", "BestEffort", "NotBestEffort", "PriorityClass"}, false),
+													Type:        schema.TypeString,
+													Description: "The name of the scope that the selector applies to.",
+													Required:    true,
 												},
 												"operator": {
-													Type:         schema.TypeString,
-													Description:  "Represents a scope's relationship to a set of values.",
-													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{"In, NotIn, Exists, DoesNotExist"}, false),
+													Type:        schema.TypeString,
+													Description: "Represents a scope's relationship to a set of values.",
+													Required:    true,
 												},
 												"values": {
 													Type:        schema.TypeSet,

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,14 +70,16 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"scope_name": {
-													Type:        schema.TypeString,
-													Description: "The name of the scope that the selector applies to.",
-													Required:    true,
+													Type:         schema.TypeString,
+													Description:  "The name of the scope that the selector applies to.",
+													Required:     true,
+													ValidateFunc: validation.StringInSlice([]string{"Terminating", "NotTerminating", "BestEffort", "NotBestEffort"}, false),
 												},
 												"operator": {
-													Type:        schema.TypeString,
-													Description: "Represents a scope's relationship to a set of values.",
-													Required:    true,
+													Type:         schema.TypeString,
+													Description:  "Represents a scope's relationship to a set of values.",
+													Required:     true,
+													ValidateFunc: validation.StringInSlice([]string{"In", "NotIn", "Exists", "DoesNotExist"}, false),
 												},
 												"values": {
 													Type:        schema.TypeSet,

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +55,43 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 							ForceNew:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Set:         schema.HashString,
+						},
+						"scope_selector": {
+							Type:        schema.TypeList,
+							Description: "A collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.",
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"match_expression": {
+										Type:        schema.TypeList,
+										Description: "A list of scope selector requirements by scope of the resources.",
+										Optional:    true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"scope_name": {
+													Type:         schema.TypeString,
+													Description:  "The name of the scope that the selector applies to.",
+													Required:     true,
+													ValidateFunc: validation.StringInSlice([]string{"Terminating", "NotTerminating", "BestEffort", "NotBestEffort", "PriorityClass"}, false),
+												},
+												"operator": {
+													Type:         schema.TypeString,
+													Description:  "Represents a scope's relationship to a set of values.",
+													Required:     true,
+													ValidateFunc: validation.StringInSlice([]string{"In, NotIn, Exists, DoesNotExist"}, false),
+												},
+												"values": {
+													Type:        schema.TypeSet,
+													Description: "Represents a scope's relationship to a set of values.",
+													Optional:    true,
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -73,7 +73,7 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 													Type:         schema.TypeString,
 													Description:  "The name of the scope that the selector applies to.",
 													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{"Terminating", "NotTerminating", "BestEffort", "NotBestEffort"}, false),
+													ValidateFunc: validation.StringInSlice([]string{"Terminating", "NotTerminating", "BestEffort", "NotBestEffort", "PriorityClass"}, false),
 												},
 												"operator": {
 													Type:         schema.TypeString,

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -53,8 +53,11 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 							Description: "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
 							Optional:    true,
 							ForceNew:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-							Set:         schema.HashString,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{"Terminating", "NotTerminating", "BestEffort", "NotBestEffort", "PriorityClass"}, false),
+							},
+							Set: schema.HashString,
 						},
 						"scope_selector": {
 							Type:        schema.TypeList,

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -125,6 +125,12 @@ func TestAccKubernetesResourceQuota_generatedName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.#", "0"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+			},
 		},
 	})
 }
@@ -157,6 +163,12 @@ func TestAccKubernetesResourceQuota_withScopes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.0", "BestEffort"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 			{
 				Config: testAccKubernetesResourceQuotaConfig_withScopesModified(name),

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -19,30 +19,30 @@ func TestAccKubernetesResourceQuota_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "kubernetes_resource_quota.test",
+		IDRefreshName:     resourceName,
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesResourceQuotaDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesResourceQuotaConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesResourceQuotaExists("kubernetes_resource_quota.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
 					//testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one"}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.%", "3"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.TestLabelThree", "three"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.TestLabelFour", "four"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelFour", "four"),
 					//testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelThree": "three", "TestLabelFour": "four"}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.%", "3"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.limits.cpu", "2"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.limits.memory", "2Gi"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.pods", "4"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.limits.cpu", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.limits.memory", "2Gi"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.pods", "4"),
 				),
 			},
 			{
@@ -54,43 +54,43 @@ func TestAccKubernetesResourceQuota_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesResourceQuotaConfig_metaModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesResourceQuotaExists("kubernetes_resource_quota.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.TestAnnotationTwo", "two"),
 					//testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.%", "3"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.TestLabelTwo", "two"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelThree", "three"),
 					//testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelTwo": "two", "TestLabelThree": "three"}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.%", "3"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.limits.cpu", "2"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.limits.memory", "2Gi"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.pods", "4"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.limits.cpu", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.limits.memory", "2Gi"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.pods", "4"),
 				),
 			},
 			{
 				Config: testAccKubernetesResourceQuotaConfig_specModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesResourceQuotaExists("kubernetes_resource_quota.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.%", "0"),
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "0"),
 					//testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "0"),
 					//testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.%", "4"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.limits.cpu", "4"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.requests.cpu", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.limits.memory", "4Gi"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.pods", "10"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.limits.cpu", "4"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.requests.cpu", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.limits.memory", "4Gi"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.pods", "10"),
 				),
 			},
 		},
@@ -100,28 +100,29 @@ func TestAccKubernetesResourceQuota_basic(t *testing.T) {
 func TestAccKubernetesResourceQuota_generatedName(t *testing.T) {
 	var conf api.ResourceQuota
 	prefix := "tf-acc-test-"
+	resourceName := "kubernetes_resource_quota.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "kubernetes_resource_quota.test",
+		IDRefreshName:     resourceName,
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesResourceQuotaDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesResourceQuotaConfig_generatedName(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesResourceQuotaExists("kubernetes_resource_quota.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.%", "0"),
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "0"),
 					//testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "0"),
 					//testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.generate_name", prefix),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.pods", "10"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.scopes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.generate_name", prefix),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.pods", "10"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.#", "0"),
 				),
 			},
 		},
@@ -131,47 +132,112 @@ func TestAccKubernetesResourceQuota_generatedName(t *testing.T) {
 func TestAccKubernetesResourceQuota_withScopes(t *testing.T) {
 	var conf api.ResourceQuota
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	resourceName := "kubernetes_resource_quota.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "kubernetes_resource_quota.test",
+		IDRefreshName:     resourceName,
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesResourceQuotaDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesResourceQuotaConfig_withScopes(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesResourceQuotaExists("kubernetes_resource_quota.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.%", "0"),
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "0"),
 					//testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "0"),
 					//testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.pods", "10"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.scopes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.scopes.0", "BestEffort"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.pods", "10"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.0", "BestEffort"),
 				),
 			},
 			{
 				Config: testAccKubernetesResourceQuotaConfig_withScopesModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesResourceQuotaExists("kubernetes_resource_quota.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.annotations.%", "0"),
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "0"),
 					//testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "0"),
 					//testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_resource_quota.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.%", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.hard.pods", "10"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.scopes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_resource_quota.test", "spec.0.scopes.0", "NotBestEffort"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.hard.pods", "10"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scopes.0", "NotBestEffort"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesResourceQuota_scopeSelector(t *testing.T) {
+	var conf api.ResourceQuota
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	resourceName := "kubernetes_resource_quota.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesResourceQuotaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesResourceQuotaConfigScopeSelector(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelFour", "four"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.scope_name", "PriorityClass"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.operator", "In"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.values.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.values.*", "medium"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+			},
+			{
+				Config: testAccKubernetesResourceQuotaConfigScopeSelectorModified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesResourceQuotaExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelFour", "four"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.scope_name", "PriorityClass"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.operator", "NotIn"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "spec.0.scope_selector.0.match_expression.0.values.*", "large"),
 				),
 			},
 		},
@@ -352,6 +418,76 @@ func testAccKubernetesResourceQuotaConfig_withScopesModified(name string) string
     }
 
     scopes = ["NotBestEffort"]
+  }
+}
+`, name)
+}
+
+func testAccKubernetesResourceQuotaConfigScopeSelector(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_resource_quota" "test" {
+  metadata {
+    annotations = {
+      TestAnnotationOne = "one"
+    }
+
+    labels = {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+      TestLabelFour  = "four"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    hard = {
+      "limits.cpu"    = 2
+      "limits.memory" = "2Gi"
+      pods            = 4
+    }
+
+	scope_selector {
+	  match_expression {
+        scope_name = "PriorityClass"
+		operator   = "In"
+		values     = ["medium"]
+	  }
+	}
+  }
+}
+`, name)
+}
+
+func testAccKubernetesResourceQuotaConfigScopeSelectorModified(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_resource_quota" "test" {
+  metadata {
+    annotations = {
+      TestAnnotationOne = "one"
+    }
+
+    labels = {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+      TestLabelFour  = "four"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    hard = {
+      "limits.cpu"    = 2
+      "limits.memory" = "2Gi"
+      pods            = 4
+    }
+
+	scope_selector {
+	  match_expression {
+        scope_name = "PriorityClass"
+		operator   = "NotIn"
+		values     = ["large"]
+	  }
+	}
   }
 }
 `, name)

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -293,6 +293,10 @@ func flattenResourceQuotaSpec(in api.ResourceQuotaSpec) []interface{} {
 	m["hard"] = flattenResourceList(in.Hard)
 	m["scopes"] = flattenResourceQuotaScopes(in.Scopes)
 
+	if in.ScopeSelector != nil {
+		m["scope_selector"] = flattenResourceQuotaScopes(in.Scopes)
+	}
+
 	out[0] = m
 	return out
 }
@@ -316,6 +320,10 @@ func expandResourceQuotaSpec(s []interface{}) (*api.ResourceQuotaSpec, error) {
 		out.Scopes = expandResourceQuotaScopes(v.(*schema.Set).List())
 	}
 
+	if v, ok := m["scope_selector"]; ok {
+		out.ScopeSelector = expandResourceQuotaScopeSelector(v.([]interface{}))
+	}
+
 	return out, nil
 }
 
@@ -334,6 +342,70 @@ func expandResourceQuotaScopes(s []interface{}) []api.ResourceQuotaScope {
 	}
 	return out
 }
+
+func expandResourceQuotaScopeSelector(s []interface{}) *api.ScopeSelector {
+	if len(s) < 1 {
+		return nil
+	}
+	m := s[0].(map[string]interface{})
+
+	att := &api.ScopeSelector{}
+
+	if v, ok := m["match_expression"].([]interface{}); ok {
+		att.MatchExpressions = expandResourceQuotaScopeSelectorMatchExpressions(v)
+	}
+
+	return att
+}
+
+func expandResourceQuotaScopeSelectorMatchExpressions(s []interface{}) []api.ScopedResourceSelectorRequirement {
+	out := make([]api.ScopedResourceSelectorRequirement, len(s), len(s))
+
+	for i, raw := range s {
+		matchExp := raw.(map[string]interface{})
+
+		if v, ok := matchExp["scope_name"].(string); ok {
+			out[i].ScopeName = api.ResourceQuotaScope(v)
+		}
+
+		if v, ok := matchExp["operator"].(string); ok {
+			out[i].Operator = api.ScopeSelectorOperator(v)
+		}
+
+		if v, ok := matchExp["values"].(*schema.Set); ok && v.Len() > 0 {
+			out[i].Values = sliceOfString(v.List())
+		}
+	}
+	return out
+}
+
+func flattenResourceQuotaScopeSelector(in api.ScopeSelector) []interface{} {
+	out := make([]interface{}, 1)
+
+	m := make(map[string]interface{}, 0)
+	m["match_expression"] = flattenResourceQuotaScopeSelectorMatchExpressions(in.MatchExpressions)
+
+	out[0] = m
+	return out
+}
+
+func flattenResourceQuotaScopeSelectorMatchExpressions(in []api.ScopedResourceSelectorRequirement]) []interface{} {
+	if len(in) == 0 {
+		return []interface{}{}
+	}
+
+	for i, l := range in {
+		m := make(map[string]interface{}, 0)
+		m["default"] = string(l.Operator)
+		m["default_request"] = string(l.ScopeName)
+
+		limits[i] = m
+	}
+	out[0] = map[string]interface{}{
+	}
+	return out
+}
+
 
 func newStringSet(f schema.SchemaSetFunc, in []string) *schema.Set {
 	var out = make([]interface{}, len(in), len(in))

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -294,7 +294,7 @@ func flattenResourceQuotaSpec(in api.ResourceQuotaSpec) []interface{} {
 	m["scopes"] = flattenResourceQuotaScopes(in.Scopes)
 
 	if in.ScopeSelector != nil {
-		m["scope_selector"] = flattenResourceQuotaScopes(in.Scopes)
+		m["scope_selector"] = flattenResourceQuotaScopeSelector(in.ScopeSelector)
 	}
 
 	out[0] = m
@@ -379,7 +379,7 @@ func expandResourceQuotaScopeSelectorMatchExpressions(s []interface{}) []api.Sco
 	return out
 }
 
-func flattenResourceQuotaScopeSelector(in api.ScopeSelector) []interface{} {
+func flattenResourceQuotaScopeSelector(in *api.ScopeSelector) []interface{} {
 	out := make([]interface{}, 1)
 
 	m := make(map[string]interface{}, 0)
@@ -389,23 +389,25 @@ func flattenResourceQuotaScopeSelector(in api.ScopeSelector) []interface{} {
 	return out
 }
 
-func flattenResourceQuotaScopeSelectorMatchExpressions(in []api.ScopedResourceSelectorRequirement]) []interface{} {
+func flattenResourceQuotaScopeSelectorMatchExpressions(in []api.ScopedResourceSelectorRequirement) []interface{} {
 	if len(in) == 0 {
 		return []interface{}{}
 	}
+	out := make([]interface{}, 1)
 
 	for i, l := range in {
 		m := make(map[string]interface{}, 0)
-		m["default"] = string(l.Operator)
-		m["default_request"] = string(l.ScopeName)
+		m["operator"] = string(l.Operator)
+		m["scope_name"] = string(l.ScopeName)
 
-		limits[i] = m
-	}
-	out[0] = map[string]interface{}{
+		if l.Values != nil && len(l.Values) > 0 {
+			m["values"] = newStringSet(schema.HashString, l.Values)
+		}
+
+		out[i] = m
 	}
 	return out
 }
-
 
 func newStringSet(f schema.SchemaSetFunc, in []string) *schema.Set {
 	var out = make([]interface{}, len(in), len(in))

--- a/website/docs/r/resource_quota.html.markdown
+++ b/website/docs/r/resource_quota.html.markdown
@@ -63,6 +63,21 @@ The following arguments are supported:
 
 * `hard` - (Optional) The set of desired hard limits for each named resource. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/policy/resource-quotas)
 * `scopes` - (Optional) A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+* `scope_selector` - (Optional) A collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. See `scope_selector` below for more details.
+
+#### `scope_selector`
+
+##### Arguments
+
+* `match_expression` - (Optional) A list of scope selector requirements by scope of the resources. See `match_expression` below for more details.
+
+##### `match_expression`
+
+###### Arguments
+
+* `scope_name` - (Required) The name of the scope that the selector applies to. Valid values are `Terminating`, `NotTerminating`, `BestEffort`, `NotBestEffort`, and `PriorityClass`.
+* `operator` - (Required) Represents a scope's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists`, `DoesNotExist`.
+* `values` - (Optional)  A list of scope selector requirements by scope of the resources.
 
 ## Import
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesResourceQuota_'
--- PASS: TestAccKubernetesResourceQuota_basic (7.67s)
--- PASS: TestAccKubernetesResourceQuota_generatedName (2.87s)
--- PASS: TestAccKubernetesResourceQuota_withScopes (4.74s)
--- PASS: TestAccKubernetesResourceQuota_scopeSelector (5.26s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_kubernetes_resource_quota - support `scope_selector`
```

### References
Closes #1157
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
