### PR TITLE
r/deployment - allow removing resource block

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -103,7 +103,6 @@ func resourcesFieldV1() map[string]*schema.Schema {
 		"limits": {
 			Type:        schema.TypeMap,
 			Optional:    true,
-			Computed:    true,
 			Description: "Describes the maximum amount of compute resources allowed. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -113,7 +112,6 @@ func resourcesFieldV1() map[string]*schema.Schema {
 		"requests": {
 			Type:        schema.TypeMap,
 			Optional:    true,
-			Computed:    true,
 			Description: "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -572,11 +570,13 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			Elem:        probeSchema(),
 		},
 		"resources": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			MaxItems:    1,
-			ForceNew:    !isUpdatable,
-			Computed:    true,
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			ForceNew: !isUpdatable,
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return old == "1" && new == "0"
+			},
 			Description: "Compute Resources required by this container. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources",
 			Elem: &schema.Resource{
 				Schema: resourcesFieldV1(),


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesDeployment_'
--- PASS: TestAccKubernetesDeployment_minimal (5.81s)
--- PASS: TestAccKubernetesDeployment_basic (18.35s)
--- PASS: TestAccKubernetesDeployment_initContainerForceNew (47.41s)
--- PASS: TestAccKubernetesDeployment_generatedName (6.77s)
--- PASS: TestAccKubernetesDeployment_with_security_context (27.94s)
--- PASS: TestAccKubernetesDeployment_with_security_context_run_as_group (6.44s)
--- PASS: TestAccKubernetesDeployment_with_security_context_sysctl (3.90s)
--- PASS: TestAccKubernetesDeployment_with_tolerations (5.79s)
--- PASS: TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds (3.75s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (9.84s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (9.98s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (5.89s)
--- PASS: TestAccKubernetesDeployment_with_container_lifecycle (6.11s)
--- PASS: TestAccKubernetesDeployment_with_container_security_context (5.93s)
--- PASS: TestAccKubernetesDeployment_with_container_security_context_run_as_group (5.87s)
--- PASS: TestAccKubernetesDeployment_with_volume_mount (3.89s)
--- PASS: TestAccKubernetesDeployment_ForceNew (13.41s)
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (4.21s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate (3.94s)
--- PASS: TestAccKubernetesDeployment_with_share_process_namespace (5.98s)
--- PASS: TestAccKubernetesDeployment_no_rollout_wait (2.85s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc (5.93s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_200perc_max_unavailable_0perc (9.82s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_0_max_unavailable_1 (5.90s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_0 (3.91s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2 (3.84s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_recreate (5.88s)
--- PASS: TestAccKubernetesDeployment_with_host_aliases (3.78s)
--- PASS: TestAccKubernetesDeployment_regression (158.87s)
--- PASS: TestAccKubernetesDeployment_with_resource_field_selector (8.63s)
--- PASS: TestAccKubernetesDeployment_config_with_automount_service_account_token (5.92s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_kubernetes_deployment - allow removing resource block
```

### References
Closes #1230
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
