### PR TITLE
r/deployment - remove computed from volume_mount

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -603,7 +603,6 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Optional:    true,
 			ForceNew:    !isUpdatable,
-			Computed:    true,
 			Description: "Pod volumes to mount into the container's filesystem. Cannot be updated.",
 			Elem: &schema.Resource{
 				Schema: volumeMountFields(),


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesDeployment_'
--- PASS: TestAccKubernetesDeployment_minimal (7.88s)
--- PASS: TestAccKubernetesDeployment_basic (18.10s)
--- PASS: TestAccKubernetesDeployment_initContainerForceNew (34.08s)
--- PASS: TestAccKubernetesDeployment_generatedName (6.41s)
--- PASS: TestAccKubernetesDeployment_with_security_context (3.89s)
--- PASS: TestAccKubernetesDeployment_with_security_context_run_as_group (6.37s)
--- PASS: TestAccKubernetesDeployment_with_security_context_sysctl (6.22s)
--- PASS: TestAccKubernetesDeployment_with_tolerations (5.99s)
--- PASS: TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds (6.11s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (6.20s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (6.10s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (5.97s)
--- PASS: TestAccKubernetesDeployment_with_container_lifecycle (5.91s)
--- PASS: TestAccKubernetesDeployment_with_container_security_context (5.82s)
--- PASS: TestAccKubernetesDeployment_with_container_security_context_run_as_group (6.02s)
--- PASS: TestAccKubernetesDeployment_with_volume_mount (8.48s)
--- PASS: TestAccKubernetesDeployment_ForceNew (13.80s)
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (2.62s)
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (7.98s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate (3.97s)
--- PASS: TestAccKubernetesDeployment_with_share_process_namespace (6.15s)
--- PASS: TestAccKubernetesDeployment_no_rollout_wait (2.91s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc (18.05s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_200perc_max_unavailable_0perc (4.18s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_0_max_unavailable_1 (4.08s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_0 (3.91s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2 (5.80s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_recreate (3.75s)
--- PASS: TestAccKubernetesDeployment_with_host_aliases (5.72s)
--- PASS: TestAccKubernetesDeployment_regression (211.33s)
--- PASS: TestAccKubernetesDeployment_with_resource_field_selector (8.83s)
--- PASS: TestAccKubernetesDeployment_config_with_automount_service_account_token (5.98s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_kubernets_deployment - allow removing volume mount
```

### References
Closes #870
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
