### PR TITLE
fix/fix-docs-deployment-resources-definition

### DIFF
--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -43,11 +43,11 @@ resource "kubernetes_deployment" "example" {
           name  = "example"
 
           resources {
-            limits = {
+            limits {
               cpu    = "0.5"
               memory = "512Mi"
             }
-            requests = {
+            requests {
               cpu    = "250m"
               memory = "50Mi"
             }


### PR DESCRIPTION
### Description
fix documentation for kubernetes deployment.

with the "=" as it was we got:

32:             limits = {

An argument named "limits" is not expected here. Did you mean to define a
block of type "limits"?

36:             requests = {

An argument named "requests" is not expected here. Did you mean to define a
block of type "requests"?


<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
