### PR TITLE
Add diff suppression for hard limits on kubernetes_resource_quota

### DIFF
--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -41,11 +41,12 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"hard": {
-							Type:         schema.TypeMap,
-							Description:  "The set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
-							Optional:     true,
-							Elem:         schema.TypeString,
-							ValidateFunc: validateResourceList,
+							Type:             schema.TypeMap,
+							Description:      "The set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
+							Optional:         true,
+							Elem:             schema.TypeString,
+							ValidateFunc:     validateResourceList,
+							DiffSuppressFunc: suppressEquivalentResourceQuantity,
 						},
 						"scopes": {
 							Type:        schema.TypeSet,

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -254,7 +254,7 @@ func testAccKubernetesResourceQuotaConfig_basic(name string) string {
   spec {
     hard = {
       "limits.cpu"    = 2
-      "limits.memory" = "2Gi"
+      "limits.memory" = "2048Mi"
       pods            = 4
     }
   }


### PR DESCRIPTION
### Description

Adds DiffSuppressFunc to resource kubernetes_resource_quota with the intention of preventing `terraform plan` from coming up with non-ops such as 1k -> 1000.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
go vet .
rm -rf /home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform /home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform.lock.hcl || true
mkdir /home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform
mkdir -p /tmp/.terraform.d/localhost/test/kubernetes/9.9.9/linux_amd64 || true
ls /tmp/.terraform.d/localhost/test/kubernetes/9.9.9/linux_amd64/terraform-provider-kubernetes_9.9.9_linux_amd64 || go build -o /tmp/.terraform.d/localhost/test/kubernetes/9.9.9/linux_amd64/terraform-provider-kubernetes_9.9.9_linux_amd64
/tmp/.terraform.d/localhost/test/kubernetes/9.9.9/linux_amd64/terraform-provider-kubernetes_9.9.9_linux_amd64
cd /home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers && TF_CLI_CONFIG_FILE=/home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraformrc TF_PLUGIN_CACHE_DIR=/home/rous
seae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform terraform init -upgrade

Initializing the backend...

Initializing provider plugins...
- Finding localhost/test/kubernetes versions matching "9.9.9"...
- Installing localhost/test/kubernetes v9.9.9...
- Installed localhost/test/kubernetes v9.9.9 (unauthenticated)

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
TF_CLI_CONFIG_FILE=/home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraformrc TF_PLUGIN_CACHE_DIR=/home/rousseae/github/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform TF_AC
C=1 go test "/home/rousseae/github/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesResourceQuota -timeout 120m
=== RUN   TestAccKubernetesResourceQuota_basic
--- PASS: TestAccKubernetesResourceQuota_basic (12.80s)
=== RUN   TestAccKubernetesResourceQuota_generatedName
--- PASS: TestAccKubernetesResourceQuota_generatedName (3.74s)
=== RUN   TestAccKubernetesResourceQuota_withScopes
--- PASS: TestAccKubernetesResourceQuota_withScopes (7.08s)
PASS
ok  github.com/hashicorp/terraform-provider-kubernetes/kubernetes(cached)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Suppress non-op changes in kubernetes_resource_quota resource
```

### References
None.

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
