### PR TITLE
r/deployment - allow updating from rolling update to recreate strategy

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -278,6 +278,17 @@ func resourceKubernetesDeploymentUpdate(ctx context.Context, d *schema.ResourceD
 			Value: spec,
 		})
 	}
+
+	if d.HasChange("spec.0.strategy") {
+		o, n := d.GetChange("spec.0.strategy.0.type")
+
+		if o.(string) == "RollingUpdate" && n.(string) == "Recreate" {
+			ops = append(ops, &RemoveOperation{
+				Path: "/spec/strategy/rollingUpdate",
+			})
+		}
+	}
+
 	data, err := ops.MarshalJSON()
 	if err != nil {
 		return diag.Errorf("Failed to marshal update operations: %s", err)

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -746,6 +746,7 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate(t *testi
 
 	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := nginxImageVersion
+	resourceName := "kubernetes_deployment.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -755,12 +756,32 @@ func TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate(t *testi
 			{
 				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(deploymentName, "RollingUpdate", imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.strategy.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.strategy.0.type", "RollingUpdate"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.strategy.0.rolling_update.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.strategy.0.rolling_update.0.max_surge", "25%"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.strategy.0.rolling_update.0.max_unavailable", "25%"),
+					testAccCheckKubernetesDeploymentExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.type", "RollingUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.0.max_surge", "25%"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.0.max_unavailable", "25%"),
+				),
+			},
+			{
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(deploymentName, "Recreate", imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDeploymentExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.type", "Recreate"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.#", "0"),
+				),
+			},
+			{
+				Config: testAccKubernetesDeploymentConfigWithDeploymentStrategy(deploymentName, "RollingUpdate", imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDeploymentExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.type", "RollingUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.0.max_surge", "25%"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.0.max_unavailable", "25%"),
 				),
 			},
 		},


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesDeployment_'
--- PASS: TestAccKubernetesDeployment_minimal (5.73s)
--- PASS: TestAccKubernetesDeployment_basic (18.66s)--- PASS: TestAccKubernetesDeployment_initContainerForceNew (37.71s)--- PASS: TestAccKubernetesDeployment_generatedName (6.83s)--- PASS: TestAccKubernetesDeployment_with_security_context (4.34s)--- PASS: TestAccKubernetesDeployment_with_security_context_run_as_group (6.33s)--- PASS: TestAccKubernetesDeployment_with_security_context_sysctl (6.02s)--- PASS: TestAccKubernetesDeployment_with_tolerations (6.39s)
--- PASS: TestAccKubernetesDeployment_with_tolerations_unset_toleration_seconds (4.55s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (6.06s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (5.88s)
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (6.41s)
--- PASS: TestAccKubernetesDeployment_with_container_lifecycle (6.28s)
--- PASS: TestAccKubernetesDeployment_with_container_security_context (6.14s)
--- PASS: TestAccKubernetesDeployment_with_container_security_context_run_as_group (6.07s)
--- PASS: TestAccKubernetesDeployment_with_volume_mount (5.46s)
--- PASS: TestAccKubernetesDeployment_ForceNew (13.35s)
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (2.48s)
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (5.86s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate (10.07s)
--- PASS: TestAccKubernetesDeployment_with_share_process_namespace (6.05s)
--- PASS: TestAccKubernetesDeployment_no_rollout_wait (3.01s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc (9.99s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_200perc_max_unavailable_0perc (5.94s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_0_max_unavailable_1 (6.01s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_0 (4.01s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2 (4.21s)
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_recreate (4.00s)
--- PASS: TestAccKubernetesDeployment_with_host_aliases (4.02s)
--- PASS: TestAccKubernetesDeployment_with_resource_field_selector (9.85s)
--- PASS: TestAccKubernetesDeployment_config_with_automount_service_account_token (6.03s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_kubernetes_deployment - allow updating from rolling update to recreate strategy
...
```

### References
Closes #585

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
