### PR TITLE
Add support for stand-alone debug mode (launch with -debug argument)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,23 @@
 package main
 
 import (
+	"context"
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-kubernetes/kubernetes"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: kubernetes.Provider})
+	debugFlag := flag.Bool("debug", false, "Start provider in stand-alone debug mode.")
+	flag.Parse()
+
+	serveOpts := &plugin.ServeOpts{
+		ProviderFunc: kubernetes.Provider,
+	}
+	if debugFlag != nil && *debugFlag {
+		plugin.Debug(context.Background(), "registry.terraform.io/hashicorp/kubernetes", serveOpts)
+	} else {
+		plugin.Serve(serveOpts)
+	}
 }


### PR DESCRIPTION
### Description

With this change, developers will be able to launch the provider binary in stand-alone mode and configure Terraform to attach to the running debugger. In this mode, the provider process can then be inspected with any Go debugger, such as Delve.

To launch the provider in debug mode, simply launch the provider binary on the command line and pass -debug as an argument. It will print out the connection details for Terraform, which look like this:

Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:

        TF_REATTACH_PROVIDERS='{"registry.terraform.io/hashicorp/kubernetes":{"Protocol":"grpc","Pid":34271,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/t7/z1g1xbgn4qzd6pck7d_s1zxh0000gn/T/plugin220728474"}}}'

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
