### PR TITLE
r/validating_webhook_configuration - add validations

### DIFF
--- a/kubernetes/resource_kubernetes_validating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -56,13 +57,21 @@ func resourceKubernetesValidatingWebhookConfiguration() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: webhookDoc["failurePolicy"],
 							Optional:    true,
-							Default:     "Fail",
+							Default:     string(admissionregistrationv1.Fail),
+							ValidateFunc: validation.StringInSlice([]string{
+								string(admissionregistrationv1.Fail),
+								string(admissionregistrationv1.Ignore),
+							}, false),
 						},
 						"match_policy": {
 							Type:        schema.TypeString,
 							Description: webhookDoc["matchPolicy"],
 							Optional:    true,
-							Default:     "Equivalent",
+							Default:     string(admissionregistrationv1.Equivalent),
+							ValidateFunc: validation.StringInSlice([]string{
+								string(admissionregistrationv1.Equivalent),
+								string(admissionregistrationv1.Exact),
+							}, false),
 						},
 						"name": {
 							Type:        schema.TypeString,
@@ -100,12 +109,19 @@ func resourceKubernetesValidatingWebhookConfiguration() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: webhookDoc["sideEffects"],
 							Optional:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(admissionregistrationv1.SideEffectClassUnknown),
+								string(admissionregistrationv1.SideEffectClassNone),
+								string(admissionregistrationv1.SideEffectClassSome),
+								string(admissionregistrationv1.SideEffectClassNoneOnDryRun),
+							}, false),
 						},
 						"timeout_seconds": {
-							Type:        schema.TypeInt,
-							Description: webhookDoc["timeoutSeconds"],
-							Default:     10,
-							Optional:    true,
+							Type:         schema.TypeInt,
+							Description:  webhookDoc["timeoutSeconds"],
+							Default:      10,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 30),
 						},
 					},
 				},


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesValidatingWebhookConfiguration_'
--- PASS: TestAccKubernetesValidatingWebhookConfiguration_basic (5.89s)
--- PASS: TestAccKubernetesValidatingWebhookConfiguration_regressionV1 (425.74s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
