### PR TITLE
r/secret - add `immutable` argument + validations

### DIFF
--- a/kubernetes/data_source_kubernetes_secret.go
+++ b/kubernetes/data_source_kubernetes_secret.go
@@ -31,6 +31,11 @@ func dataSourceKubernetesSecret() *schema.Resource {
 				Description: "Type of secret",
 				Computed:    true,
 			},
+			"immutable": {
+				Type:        schema.TypeBool,
+				Description: "Ensures that data stored in the Secret cannot be updated (only object metadata can be modified).",
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/kubernetes/data_source_kubernetes_secret_test.go
+++ b/kubernetes/data_source_kubernetes_secret_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestAccKubernetesDataSourceSecret_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_secret.test"
+	datasourceName := "data.kubernetes_secret.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -17,43 +19,27 @@ func TestAccKubernetesDataSourceSecret_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesDataSourceSecretConfig_basic(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_secret.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.labels.TestLabelTwo", "two"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.labels.TestLabelThree", "three"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.%", "2"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.one", "first"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.two", "second"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "type", "Opaque"),
-					resource.TestCheckResourceAttr("kubernetes_secret.test", "binary_data.raw", "UmF3IGRhdGEgc2hvdWxkIGNvbWUgYmFjayBhcyBpcyBpbiB0aGUgcG9k"),
-				),
 			},
 			{
 				Config: testAccKubernetesDataSourceSecretConfig_basic(name) +
 					testAccKubernetesDataSourceSecretConfig_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.labels.TestLabelTwo", "two"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.labels.TestLabelThree", "three"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.%", "2"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.one", "first"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.two", "second"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "type", "Opaque"),
-					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "binary_data.raw", "UmF3IGRhdGEgc2hvdWxkIGNvbWUgYmFjayBhcyBpcyBpbiB0aGUgcG9k"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.name", resourceName, "metadata.0.name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.generation", resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.resource_version", resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.uid", resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.annotations.%", resourceName, "metadata.0.annotations.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.annotations.TestAnnotationOne", resourceName, "metadata.0.annotations.TestAnnotationOne"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.annotations.TestAnnotationTwo", resourceName, "metadata.0.annotations.TestAnnotationTwo"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.labels.TestLabelOne", resourceName, "metadata.0.labels.TestLabelOne"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.labels.TestLabelTwo", resourceName, "metadata.0.labels.TestLabelTwo"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata.0.labels.TestLabelThree", resourceName, "metadata.0.labels.TestLabelThree"),
+					resource.TestCheckResourceAttrPair(datasourceName, "data.%", resourceName, "data.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "data.one", resourceName, "data.one"),
+					resource.TestCheckResourceAttrPair(datasourceName, "data.two", resourceName, "data.two"),
+					resource.TestCheckResourceAttrPair(datasourceName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "immutable", resourceName, "immutable"),
+					resource.TestCheckResourceAttrPair(datasourceName, "binary_data.raw", resourceName, "binary_data.raw"),
 				),
 			},
 		},
@@ -92,7 +78,7 @@ func testAccKubernetesDataSourceSecretConfig_basic(name string) string {
 func testAccKubernetesDataSourceSecretConfig_read() string {
 	return fmt.Sprintf(`data "kubernetes_secret" "test" {
   metadata {
-    name = "${kubernetes_secret.test.metadata.0.name}"
+    name = kubernetes_secret.test.metadata.0.name
   }
 
   binary_data = {

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -60,7 +60,7 @@ func resourceKubernetesSecret() *schema.Resource {
 			"immutable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).",
+				Description: "Ensures that data stored in the Secret cannot be updated (only object metadata can be modified).",
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -67,3 +67,4 @@ data "kubernetes_secret" "example" {
 ```
 
 * `type` - The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
+* `immutable` - Ensures that data stored in the Secret cannot be updated (only object metadata can be modified).

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -100,6 +100,7 @@ The following arguments are supported:
 * `binary_data` - (Optional) A map base64 encoded map of the secret data.
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
+* `immutable` - (Optional) Ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time.
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccKubernetesDataSourceSecret_basic
--- PASS: TestAccKubernetesDataSourceSecret_basic (4.34s)
=== RUN   TestAccKubernetesPersistentVolume_cephFsSecretRef
--- PASS: TestAccKubernetesPersistentVolume_cephFsSecretRef (3.46s)
=== RUN   TestAccKubernetesSecret_basic
--- PASS: TestAccKubernetesSecret_basic (11.77s)
=== RUN   TestAccKubernetesSecret_immutable
--- PASS: TestAccKubernetesSecret_immutable (9.84s)
=== RUN   TestAccKubernetesSecret_generatedName
--- PASS: TestAccKubernetesSecret_generatedName (3.24s)
=== RUN   TestAccKubernetesSecret_binaryData
--- PASS: TestAccKubernetesSecret_binaryData (7.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	40.601s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_kubernetes_secret - add `immutable` argument
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
