### PR TITLE
Datasource: `kubernetes_secret`: add `binary_data` attribute

### DIFF
--- a/kubernetes/data_source_kubernetes_secret.go
+++ b/kubernetes/data_source_kubernetes_secret.go
@@ -20,11 +20,11 @@ func dataSourceKubernetesSecret() *schema.Resource {
 				Computed:    true,
 				Sensitive:   true,
 			},
-			"binary_data" : {
-				Type: schema.TypeMap,
+			"binary_data": {
+				Type:        schema.TypeMap,
 				Description: "A map of the secret data with values encoded in base64 format",
-				Optional: true,
-				Sensitive: true,
+				Optional:    true,
+				Sensitive:   true,
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/kubernetes/data_source_kubernetes_secret.go
+++ b/kubernetes/data_source_kubernetes_secret.go
@@ -20,10 +20,10 @@ func dataSourceKubernetesSecret() *schema.Resource {
 				Computed:    true,
 				Sensitive:   true,
 			},
-			"base64_data" : {
+			"binary_data" : {
 				Type: schema.TypeMap,
 				Description: "A map of the secret data with values encoded in base64 format",
-				Computed: true,
+				Optional: true,
 				Sensitive: true,
 			},
 			"type": {

--- a/kubernetes/data_source_kubernetes_secret.go
+++ b/kubernetes/data_source_kubernetes_secret.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +19,12 @@ func dataSourceKubernetesSecret() *schema.Resource {
 				Description: "A map of the secret data.",
 				Computed:    true,
 				Sensitive:   true,
+			},
+			"base64_data" : {
+				Type: schema.TypeMap,
+				Description: "A map of the secret data with values encoded in base64 format",
+				Computed: true,
+				Sensitive: true,
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/kubernetes/data_source_kubernetes_secret_test.go
+++ b/kubernetes/data_source_kubernetes_secret_test.go
@@ -32,6 +32,7 @@ func TestAccKubernetesDataSourceSecret_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.one", "first"),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "data.two", "second"),
 					resource.TestCheckResourceAttr("kubernetes_secret.test", "type", "Opaque"),
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "binary_data.raw", "UmF3IGRhdGEgc2hvdWxkIGNvbWUgYmFjayBhcyBpcyBpbiB0aGUgcG9k"),
 				),
 			},
 			{
@@ -52,6 +53,7 @@ func TestAccKubernetesDataSourceSecret_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.one", "first"),
 					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.two", "second"),
 					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "type", "Opaque"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "binary_data.raw", "UmF3IGRhdGEgc2hvdWxkIGNvbWUgYmFjayBhcyBpcyBpbiB0aGUgcG9k"),
 				),
 			},
 		},
@@ -79,6 +81,10 @@ func testAccKubernetesDataSourceSecretConfig_basic(name string) string {
     one = "first"
     two = "second"
   }
+
+  binary_data = {
+    raw = "${base64encode("Raw data should come back as is in the pod")}"
+  }
 }
 `, name)
 }
@@ -87,6 +93,10 @@ func testAccKubernetesDataSourceSecretConfig_read() string {
 	return fmt.Sprintf(`data "kubernetes_secret" "test" {
   metadata {
     name = "${kubernetes_secret.test.metadata.0.name}"
+  }
+
+  binary_data = {
+    raw = ""
   }
 }
 `)

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -38,13 +38,6 @@ func resourceKubernetesSecret() *schema.Resource {
 				Sensitive:   true,
 				Description: "A map of the secret data in base64 encoding. Use this for binary data.",
 			},
-			"base64_data": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Computed:    true,
-				Sensitive:   true,
-				Description: "A map of the secret data with values in base64 encoding.",
-			},
 			"type": {
 				Type:        schema.TypeString,
 				Description: "Type of secret",
@@ -145,7 +138,6 @@ func resourceKubernetesSecretRead(ctx context.Context, d *schema.ResourceData, m
 		delete(secret.Data, k)
 	}
 	d.Set("data", flattenByteMapToStringMap(secret.Data))
-	d.Set("base64_data", flattenByteMapToBase64Map(secret.Data))
 	d.Set("type", secret.Type)
 	return nil
 }

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -38,6 +38,13 @@ func resourceKubernetesSecret() *schema.Resource {
 				Sensitive:   true,
 				Description: "A map of the secret data in base64 encoding. Use this for binary data.",
 			},
+			"base64_data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "A map of the secret data with values in base64 encoding.",
+			},
 			"type": {
 				Type:        schema.TypeString,
 				Description: "Type of secret",
@@ -138,6 +145,7 @@ func resourceKubernetesSecretRead(ctx context.Context, d *schema.ResourceData, m
 		delete(secret.Data, k)
 	}
 	d.Set("data", flattenByteMapToStringMap(secret.Data))
+	d.Set("base64_data", flattenByteMapToBase64Map(secret.Data))
 	d.Set("type", secret.Type)
 	return nil
 }

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -49,4 +49,5 @@ The following arguments are supported:
 ## Attribute Reference
 
 * `data` - A map of the secret data.
+* `base64_data` - A map of the secret data with values encoded in base64 format.
 * `type` - The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -49,5 +49,21 @@ The following arguments are supported:
 ## Attribute Reference
 
 * `data` - A map of the secret data.
-* `base64_data` - A map of the secret data with values encoded in base64 format.
+* `binary_data` - A map of the secret data with values encoded in base64 format.
+
+~> In case the secret has been created outside terraform in order to retrieve binary data from the secret in base64 format you need to define a `binary_data` map with data to retrieve as key and an empty string as a value
+
+```hcl
+data "kubernetes_secret" "example" {
+  metadata {
+    name      = "example-secret"
+    namespace = "kube-system"
+  }
+  binary_data = {
+    "keystore.p12" = ""
+    another_field  = ""
+  }
+}
+```
+
 * `type` - The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)


### PR DESCRIPTION
### Description
In case where we're dealing with secrets that contain, for instance, SSL certificates in PFX format - binary value of the secret becomes corrupted on retrieval.

This additional attribute encodes only the values in base64, allowing us to consume binary data as is.

**Use-case**: Azure AKS cluster with cert-manager fetching LE certiicates creates a secret with certs in both PEM and PFX format. While retrieving that secret - PEM parts work, PFX becomes garbled, since it's encoded to a string. Some other services (like Application Gateway) do not accept PEM certificates and only want PFX, which forces us to do dark magic with CLI to extract the cert. This change would allow us to do it all nicely inside terraform code. 

Tested with a custom-built provider - works like a charm.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
N/A I think, but can add one if team deems necessary.
- [ ] Have you run the acceptance tests on this branch?
N/A I think, but can add one if team deems necessary.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
```release-note
Datasource `kubernetes_secret`: Add `binary_data` attribute where secret data values are encoded in base64 format.
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
