### PR TITLE
Clean up makefile to remove duplicate tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: scripts/gogetcookie.sh
     - name: Run tests
       run: |
-        make ci-website-lint
+        make website-lint
         make depscheck
         make fmtcheck
         make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
       uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
       with:
         go-version: ${{ matrix.go-version }}
+    # Secrets are not available on pull requests.
     - name: Login to Docker Hub
+      if: github.ref == 'refs/heads/main'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.RO_DOCKERHUB_USER }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -155,34 +155,6 @@ website-lint: tools
 	@echo "==> Checking for broken links..."
 	@scripts/markdown-link-check.sh "$(DOCKER)" "$(DOCKER_RUN_OPTS)" "$(DOCKER_VOLUME_OPTS)" "$(PROVIDER_DIR)"
 
-# Contains everything in the website-lint target except calling out to markdown-link-check
-# Which runs in github actions as a separate CI job on merges to the repo's default branch
-ci-website-lint: tools
-	@echo "==> Checking website against linters..."
-	@misspell -error -source=text ./website || (echo; \
-		echo "Unexpected mispelling found in website files."; \
-		echo "To automatically fix the misspelling, run 'make website-lint-fix' and commit the changes."; \
-		exit 1)
-	@echo "==> Running markdownlint-cli using DOCKER='$(DOCKER)', DOCKER_RUN_OPTS='$(DOCKER_RUN_OPTS)' and DOCKER_VOLUME_OPTS='$(DOCKER_VOLUME_OPTS)'"
-	@$(DOCKER) run $(DOCKER_RUN_OPTS) -v $(PROVIDER_DIR):/workspace:$(DOCKER_VOLUME_OPTS) -w /workspace 06kellyjac/markdownlint-cli ./website || (echo; \
-		echo "Unexpected issues found in website Markdown files."; \
-		echo "To apply any automatic fixes, run 'make website-lint-fix' and commit the changes."; \
-		exit 1)
-	@echo "==> Running terrafmt diff..."
-	@terrafmt diff ./website --check --pattern '*.markdown' --quiet || (echo; \
-		echo "Unexpected differences in website HCL formatting."; \
-		echo "To see the full differences, run: terrafmt diff ./website --pattern '*.markdown'"; \
-		echo "To automatically fix the formatting, run 'make website-lint-fix' and commit the changes."; \
-		exit 1)
-	@echo "==> Statically compiling provider for tfproviderdocs..."
-	@env CGO_ENABLED=0 GOOS=$$(go env GOOS) GOARCH=$$(go env GOARCH) go build -a -o $(TF_PROV_DOCS)/terraform-provider-kubernetes
-	@echo "==> Getting provider schema for tfproviderdocs..."
-		@$(DOCKER) run $(DOCKER_RUN_OPTS) -v $(TF_PROV_DOCS):/workspace:$(DOCKER_VOLUME_OPTS) -w /workspace hashicorp/terraform:0.12.29 init
-		@$(DOCKER) run $(DOCKER_RUN_OPTS) -v $(TF_PROV_DOCS):/workspace:$(DOCKER_VOLUME_OPTS) -w /workspace hashicorp/terraform:0.12.29 providers schema -json > $(TF_PROV_DOCS)/schema.json
-	@echo "==> Running tfproviderdocs..."
-	@tfproviderdocs check -providers-schema-json $(TF_PROV_DOCS)/schema.json -provider-name kubernetes
-	@rm -f $(TF_PROV_DOCS)/schema.json $(TF_PROV_DOCS)/terraform-provider-kubernetes
-
 website-lint-fix: tools
 	@echo "==> Applying automatic website linter fixes..."
 	@misspell -w -source=text ./website

--- a/scripts/markdown-link-check.sh
+++ b/scripts/markdown-link-check.sh
@@ -15,6 +15,12 @@ DOCKER_RUN_OPTS=${2:-}
 DOCKER_VOLUME_OPTS=${3:-}
 PROVIDER_DIR=${4:-}
 
+# In CI, we use a Github Action instead of this script.
+if [ ${CI:-} ]; then
+  echo "Running inside of Github Actions. Exiting"
+  exit 0
+fi
+
 if [ -z "${PROVIDER_DIR}" ]; then
   echo "Please specify the directory containing the kubernetes provider"
   exit  1


### PR DESCRIPTION
* Clean up duplicate lint target in makefile.

* Conditionally run docker login in GH actions, to fix PR test failures.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/pull/1283

https://github.com/hashicorp/terraform-provider-kubernetes/runs/2689361355?check_suite_focus=true

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
