### PR TITLE
docs/stateful_set: add import section

### DIFF
--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -316,3 +316,11 @@ The following [Timeout](/docs/configuration/resources.html#operation-timeouts) c
 * `read`   - (Default `10 minutes`) Used for reading a StatefulSet
 * `update` - (Default `10 minutes`) Used for updating a StatefulSet
 * `delete` - (Default `10 minutes`) Used for destroying a StatefulSet
+
+## Import
+
+kubernetes_stateful_set can be imported using its namespace and name, e.g.
+
+```
+$ terraform import kubernetes_stateful_set.example default/terraform-example
+```


### PR DESCRIPTION
### Description

Add a `terraform import` section to the `kubernetes_stateful_set` resource docs.

### Acceptance tests

From what I understand, this docs change does not require acceptance tests.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Docs: add Import section to `kubernetes_stateful_set` resource.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
