### PR TITLE
kubernetes_service: cluster_ip should support None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.1 (Unreleased)
+
+BUG FIXES:
+* `cluster_ip` for `kubernetes_service` should support value `None` (#1291)
+
 ## 2.3.0 (June 02, 2021)
 
 BUG FIXES:

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -53,12 +53,15 @@ func resourceKubernetesServiceSchemaV1() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"cluster_ip": {
-						Type:         schema.TypeString,
-						Description:  "The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
-						Optional:     true,
-						ForceNew:     true,
-						Computed:     true,
-						ValidateFunc: validation.IsIPAddress,
+						Type:        schema.TypeString,
+						Description: "The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
+						Optional:    true,
+						ForceNew:    true,
+						Computed:    true,
+						ValidateFunc: validation.Any(
+							validation.StringInSlice([]string{api.ClusterIPNone}, false),
+							validation.IsIPAddress,
+						),
 					},
 					"external_ips": {
 						Type:        schema.TypeSet,


### PR DESCRIPTION
### Description

Fixes #1291

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -run TestAccKubernetesService_headless -timeout 120m
=== RUN   TestAccKubernetesService_headless
--- PASS: TestAccKubernetesService_headless (3.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	3.967s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`cluster_ip` for `kubernetes_service` should support value `None` (#1291)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
