### PR TITLE
Remove self-link from metadata

### DIFF
--- a/kubernetes/schema_metadata.go
+++ b/kubernetes/schema_metadata.go
@@ -40,11 +40,6 @@ func metadataFields(objectName string) map[string]*schema.Schema {
 			Description: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
 			Computed:    true,
 		},
-		"self_link": {
-			Type:        schema.TypeString,
-			Description: fmt.Sprintf("A URL representing this %s.", objectName),
-			Computed:    true,
-		},
 		"uid": {
 			Type:        schema.TypeString,
 			Description: fmt.Sprintf("The unique in time and space value for this %s. More info: http://kubernetes.io/docs/user-guide/identifiers#uids", objectName),

--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -241,7 +241,6 @@ Terraform will perform the following actions:
           + name             = "nginx"
           + namespace        = "nginx"
           + resource_version = (known after apply)
-          + self_link        = (known after apply)
           + uid              = (known after apply)
         }
 
@@ -275,7 +274,6 @@ Terraform will perform the following actions:
                     }
                   + name             = (known after apply)
                   + resource_version = (known after apply)
-                  + self_link        = (known after apply)
                   + uid              = (known after apply)
                 }
 
@@ -622,7 +620,6 @@ Terraform will perform the following actions:
           + generation       = (known after apply)
           + name             = "nginx"
           + resource_version = (known after apply)
-          + self_link        = (known after apply)
           + uid              = (known after apply)
         }
     }
@@ -638,7 +635,6 @@ Terraform will perform the following actions:
           + name             = "nginx"
           + namespace        = "nginx"
           + resource_version = (known after apply)
-          + self_link        = (known after apply)
           + uid              = (known after apply)
         }
 


### PR DESCRIPTION
### Description

Fixes a perpetual diff in some resources.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Remove self-link from metadata to fix perpetual diff in Secret resource
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/1172

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
