### PR TITLE
Kubernetes service docs

### DIFF
--- a/kubernetes/data_source_kubernetes_service.go
+++ b/kubernetes/data_source_kubernetes_service.go
@@ -16,7 +16,7 @@ func dataSourceKubernetesService() *schema.Resource {
 			"metadata": namespacedMetadataSchema("service", false),
 			"spec": {
 				Type:        schema.TypeList,
-				Description: "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+				Description: "Spec defines the behavior of a service. See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status for more information",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -7,7 +7,9 @@ description: |-
 
 # kubernetes_service
 
-A Service is an abstraction which defines a logical set of pods and a policy by which to access them - sometimes called a micro-service.
+A Service is an abstraction which defines a logical set of pods and a policy by
+which to access them - sometimes called a micro-service.
+
 This data source allows you to pull data about such service.
 
 ## Example Usage
@@ -32,73 +34,209 @@ resource "aws_route53_record" "example" {
 
 The following arguments are supported:
 
-* `metadata` - (Required) Standard service's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+* `metadata` - (Required) Standard service's metadata. For more information see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+.
+
+This argument is a block with the following arguments:
+
+* `name` - Name of the service, must be unique. Cannot be updated. For more
+information see [this reference](http://kubernetes.io/docs/user-guide/identifiers#names).
+* `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
 
 ## Attributes
 
-* `spec` - Spec defines the behavior of a service. [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
+Besides the arguments provided, you can fetch the following list of attributes.
 
-## Nested Blocks
+### spec
+
+`spec` defines the behavior of a service. For more information see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
+
+`spec` itself is a list of maps:
+
+```hcl
+spec = [
+  {
+    cluster_ip                  = "172.20.99.5"
+    external_ips                = []
+    external_name               = ""
+    external_traffic_policy     = ""
+    health_check_node_port      = 0
+    load_balancer_ip            = ""
+    load_balancer_source_ranges = []
+    port = [
+      {
+        name        = "web"
+        node_port   = 0
+        port        = 9090
+        protocol    = "TCP"
+        target_port = "9090"
+      },
+    ]
+    publish_not_ready_addresses = false
+    selector = {
+      "app"        = "prometheus"
+      "prometheus" = "kube-prometheus-stack-prometheus"
+    }
+    session_affinity = "None"
+    type             = "ClusterIP"
+  }
+]
+```
+
+Each map has the following structure:
+
+* `cluster_ip` - The IP address of the service. It is usually assigned randomly
+by the master. If an address is specified manually and is not in use by others,
+it will be allocated to the service; otherwise, creation of the service will
+fail. `None` can be specified for headless services when proxying is not
+required. Ignored if type is `ExternalName`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies).
+* `external_ips` - A list of IP addresses for which nodes in the cluster will
+also accept traffic for this service. These IPs are not managed by Kubernetes.
+The user is responsible for ensuring that traffic arrives at a node with this
+IP.  A common example is external load-balancers that are not part of the
+Kubernetes system.
+* `external_name` - The external reference that `kubedns` or equivalent will
+return as a CNAME record for this service. No proxying will be involved. Must be
+a valid DNS name and requires `type` to be `ExternalName`.
+* `external_traffic_policy` - (Optional) Denotes if this Service desires to
+route external traffic to node-local or cluster-wide endpoints. `Local`
+preserves the client source IP and avoids a second hop for `LoadBalancer` and
+`Nodeport` type services, but risks potentially imbalanced traffic spreading.
+`Cluster` obscures the client source IP and may cause a second hop to another
+node, but should have good overall load-spreading. For more information see
+[this reference](https://kubernetes.io/docs/tutorials/services/source-ip/).
+* `load_balancer_ip` - Only applies to `type = LoadBalancer`. `LoadBalancer`
+will get created with the IP specified in this field. This feature depends on
+whether the underlying cloud provider supports specifying this field when a load
+balancer is created. This field will be ignored if the cloud-provider does not
+support the feature.
+* `load_balancer_source_ranges` - If specified and supported by the platform,
+this will restrict traffic through the cloud-provider load-balancer will be
+restricted to the specified client IPs. This field will be ignored if the
+cloud provider does not support the feature. For more information see
+[this reference](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
+* `port` - The list of ports that are exposed by this service. For more
+information see [this reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
+* `selector` - Route service traffic to pods with label keys and values matching
+this selector. Only applies to types `ClusterIP`, `NodePort`, and
+`LoadBalancer`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#overview).
+* `session_affinity` - Used to maintain session affinity. Supports `ClientIP`
+and `None`. Defaults to `None`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies).
+* `type` - Determines how the service is exposed. Defaults to `ClusterIP`. Valid
+options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`.
+`ExternalName` maps to the specified `external_name`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#overview).
+
+Since `port` is a data structure itself, it is detailed in the next section as well.
+
+#### port
+
+* `name` - The name of this port within the service. All ports within the
+service must have unique names. Optional if only one `ServicePort` is defined on
+this service.
+* `node_port` - The port on each node on which this service is exposed when
+`type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If
+specified, it will be allocated to the service if unused or else creation of the
+service will fail. Default is to auto-allocate a port if the `type` of this
+service requires one. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#type--nodeport).
+* `port` - The port that will be exposed by this service.
+* `protocol` - The IP protocol for this port. Supports `TCP` and `UDP`. Default
+is `TCP`.
+* `target_port` - Number or name of the port to access on the pods targeted by
+the service. Number must be in the range 1 to 65535. This field is ignored for
+services with `cluster_ip = "None"`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#defining-a-service).
 
 ### `metadata`
 
-#### Arguments
+`metadata` is metadata that all persisted resources must have, which includes
+all objects users must create.. For more information, see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata).
 
-* `name` - Name of the service, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
+`metadata` itself is a list of maps:
 
-#### Attributes
+```hcl
+metadata = [
+  {
+    "annotations" = tomap({
+      "meta.helm.sh/release-name"      = "kube-prometheus-stack"
+      "meta.helm.sh/release-namespace" = "observability"
+    })
+    "generation" = 0
+    "labels" = tomap({
+      "app"          = "kube-prometheus-stack-prometheus"
+      "chart"        = "kube-prometheus-stack-16.0.1"
+      "heritage"     = "Helm"
+      "release"      = "kube-prometheus-stack"
+      "self-monitor" = "true"
+    })
+    "name"             = "kube-prometheus-stack-prometheus"
+    "namespace"        = "observability"
+    "resource_version" = "5285082"
+    "self_link"        = ""
+    "uid"              = "f3e28348-7f14-4f01-b32b-5e558ed6a132"
+  },
+]
+```
 
-* `annotations` - (Optional) An unstructured key value map stored with the service that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
-* `generation` - A sequence number representing a specific generation of the desired state.
-* `resource_version` - An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
-* `uid` - The unique in time and space value for this service. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+Each map has the following structure:
 
-### `port`
-
-#### Attributes
-
-* `name` - The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
-* `node_port` - The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#type--nodeport)
-* `port` - The port that will be exposed by this service.
-* `protocol` - The IP protocol for this port. Supports `TCP` and `UDP`. Default is `TCP`.
-* `target_port` - Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = "None"`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#defining-a-service)
-
-### `spec`
-
-#### Attributes
-
-* `cluster_ip` - The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
-* `external_ips` - A list of IP addresses for which nodes in the cluster will also accept traffic for this service. These IPs are not managed by Kubernetes. The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
-* `external_name` - The external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires `type` to be `ExternalName`.
-* `external_traffic_policy` - (Optional) Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. `Local` preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. `Cluster` obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading. For more info: https://kubernetes.io/docs/tutorials/services/source-ip/
-* `load_balancer_ip` - Only applies to `type = LoadBalancer`. LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying this field when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
-* `load_balancer_source_ranges` - If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. For more info see [Kubernetes reference](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
-* `port` - The list of ports that are exposed by this service. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
-* `selector` - Route service traffic to pods with label keys and values matching this selector. Only applies to types `ClusterIP`, `NodePort`, and `LoadBalancer`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#overview)
-* `session_affinity` - Used to maintain session affinity. Supports `ClientIP` and `None`. Defaults to `None`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
-* `type` - Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#overview)
-
-
-## Attributes
-
-* `status` - Status is a list containing the most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `annotations` - (Optional) An unstructured key value map stored with the
+service that may be used to store arbitrary metadata. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/annotations).
+* `labels` - (Optional) Map of string keys and values that can be used to
+organize and categorize (scope and select) the service. May match selectors of
+replication controllers and services. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/labels).
+* `generation` - A sequence number representing a specific generation of the
+desired state.
+* `resource_version` - An opaque value that represents the internal version of
+this service that can be used by clients to determine when service has changed.
+For more information see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency).
+* `uid` - The unique in time and space value for this service. For more
+information see
+[this reference](http://kubernetes.io/docs/user-guide/identifiers#uids).
 
 ### `status`
-#### Attributes
 
-* `load_balancer` - a list containing the current status of the load-balancer, if one is present.
+`status` is a list containing the most recently observed status of
+the service. Populated by the system. Read-only. More information see
+[this reference](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
-### `load_balancer`
-#### Attributes
+`status` itself is a list of maps:
 
-* `ingress` - a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+```hcl
+status = [
+  {
+    "load_balancer" = [
+      {
+        "ingress" = []
+      }
+    ]
+  }
+]
+```
 
-### `ingress`
-#### Attributes
+Each map has the following structure:
 
-* `ip` -  IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers).
-* `hostname` - Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers).
+* `load_balancer` - a list (of maps) containing the current status of the
+load-balancer, if one is present.
 
+Then each map might have the following structure:
 
+* `ingress` - a list (of maps) containing ingress points for the load-balancer.
+Traffic intended for the service should be sent to these ingress points.
+
+Then each map might have the following structure:
+
+* `ip` -  IP is set for load-balancer ingress points that are IP based
+(typically GCE or OpenStack load-balancers).
+* `hostname` - Hostname is set for load-balancer ingress points that are DNS
+based (typically AWS load-balancers).

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -7,8 +7,8 @@ description: |-
 
 # kubernetes_service
 
-A Service is an abstraction which defines a logical set of pods and a policy by which to access them - sometimes called a micro-service.
-
+A Service is an abstraction which defines a logical set of pods and a policy by
+which to access them - sometimes called a micro-service.
 
 ## Example Usage
 
@@ -50,7 +50,7 @@ resource "kubernetes_pod" "example" {
 
 ## Example using AWS load balancer
 
-```
+```hcl
 variable "cluster_name" {
   type = string
 }
@@ -83,7 +83,7 @@ resource "kubernetes_service" "example" {
   }
   spec {
     port {
-      port = 8080
+      port        = 8080
       target_port = 80
     }
     type = "LoadBalancer"
@@ -113,98 +113,241 @@ output "load_balancer_info" {
 }
 ```
 
-
-
 ## Argument Reference
 
 The following arguments are supported:
 
-* `metadata` - (Required) Standard service's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
-* `spec` - (Required) Spec defines the behavior of a service. [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
-* `wait_for_load_balancer` - (Optional) Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created. Defaults to `true`.
+* `metadata` - (Required) Standard service's metadata. For more information see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata).
+* `spec` - (Required) Spec defines the behavior of a service. For more
+information see [this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
+* `wait_for_load_balancer` - (Optional) Terraform will wait for the load
+balancer to have at least 1 endpoint before considering the resource created.
+Defaults to `true`.
+* `timeouts` - provides the
+[Timeouts](/docs/language/resources/syntax.html#operation-timeouts)
+configuration options.
 
-## Nested Blocks
+### `metadata` arguments
 
-### `metadata`
+* `annotations` - (Optional) An unstructured key value map stored with the
+service that may be used to store arbitrary metadata.
 
-#### Arguments
+~> By default, the provider ignores any annotations whose key names are in the
+[Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints).
+This is necessary because such annotations can be mutated by server-side
+components and consequently cause a perpetual diff in the Terraform `plan`
+output. If you explicitly specify any such annotations in the configuration
+template then Terraform will consider these as normal resource attributes and
+manage them as expected (while still avoiding the perpetual diff problem). For
+more information info see
+[this reference](http://kubernetes.io/docs/user-guide/annotations).
 
-* `annotations` - (Optional) An unstructured key value map stored with the service that may be used to store arbitrary metadata.
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique
+name ONLY IF the `name` field has not been provided. This value will also be
+combined with a unique suffix. For more information see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency).
+* `labels` - (Optional) Map of string keys and values that can be used to
+organize and categorize (scope and select) the service. May match selectors of
+replication controllers and services.
 
-~> By default, the provider ignores any annotations whose key names are in the [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints). This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+~> By default, the provider ignores any labels whose key names are in the
+[Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints).
+This is necessary because such labels can be mutated by server-side components
+and consequently cause a perpetual diff in the Terraform `plan` output. If you
+explicitly specify any such labels in the configuration template then Terraform
+will consider these as normal resource attributes and manage them as expected
+(while still avoiding the perpetual diff problem). For more information see
+[this reference](http://kubernetes.io/docs/user-guide/labels).
 
-* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. 
+* `name` - (Optional) Name of the service, must be unique. Cannot be updated.
+For more info see
+[this reference](http://kubernetes.io/docs/user-guide/identifiers#names).
+* `namespace` - (Optional) Defines the space within which name of the
+service must be unique.
 
-~> By default, the provider ignores any labels whose key names are in the [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints). This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+### `spec` arguments
 
-* `name` - (Optional) Name of the service, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
+* `cluster_ip` - The IP address of the service. It is usually assigned randomly
+by the master. If an address is specified manually and is not in use by others,
+it will be allocated to the service; otherwise, creation of the service will
+fail. `None` can be specified for headless services when proxying is not
+required. Ignored if type is `ExternalName`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies).
+* `external_ips` - A list of IP addresses for which nodes in the cluster will
+also accept traffic for this service. These IPs are not managed by Kubernetes.
+The user is responsible for ensuring that traffic arrives at a node with this
+IP.  A common example is external load-balancers that are not part of the
+Kubernetes system.
+* `external_name` - The external reference that `kubedns` or equivalent will
+return as a CNAME record for this service. No proxying will be involved. Must be
+a valid DNS name and requires `type` to be `ExternalName`.
+* `external_traffic_policy` - (Optional) Denotes if this Service desires to
+route external traffic to node-local or cluster-wide endpoints. `Local`
+preserves the client source IP and avoids a second hop for `LoadBalancer` and
+`Nodeport` type services, but risks potentially imbalanced traffic spreading.
+`Cluster` obscures the client source IP and may cause a second hop to another
+node, but should have good overall load-spreading. For more information see
+[this reference](https://kubernetes.io/docs/tutorials/services/source-ip/).
+* `load_balancer_ip` - Only applies to `type = LoadBalancer`. `LoadBalancer`
+will get created with the IP specified in this field. This feature depends on
+whether the underlying cloud provider supports specifying this field when a load
+balancer is created. This field will be ignored if the cloud-provider does not
+support the feature.
+* `load_balancer_source_ranges` - If specified and supported by the platform,
+this will restrict traffic through the cloud-provider load-balancer will be
+restricted to the specified client IPs. This field will be ignored if the
+cloud provider does not support the feature. For more information see
+[this reference](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
+* `publish_not_ready_addresses` - (Optional) When set to true, indicates that
+DNS implementations must publish the `notReadyAddresses` of subsets for the
+Endpoints associated with the Service. The default value is `false`. The primary
+use case for setting this field is to use a StatefulSet's Headless Service to
+propagate `SRV` records for its Pods without respect to their readiness for
+purpose of peer discovery.
+* `selector` - (Optional) Route service traffic to pods with label keys and
+values matching this selector. Only applies to types `ClusterIP`, `NodePort`,
+and `LoadBalancer`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#overview).
+* `session_affinity` - (Optional) Used to maintain session affinity. Supports
+`ClientIP` and `None`. Defaults to `None`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies).
+* `type` - (Optional) Determines how the service is exposed. Defaults to
+`ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and
+`LoadBalancer`. `ExternalName` maps to the specified `external_name`. For more
+information see
+[this reference](http://kubernetes.io/docs/user-guide/services#overview).
+* `health_check_node_port` - (Optional) Specifies the Healthcheck NodePort for
+the service. Only effects when type is set to `LoadBalancer` and
+`external_traffic_policy` is set to `Local`.
+* `port` - The list of ports that are exposed by this service. For more
+information see
+[this reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies).
 
-#### Attributes
+Since `port` is block itself, each one of the available properties are detailed
+below:
 
-
-* `generation` - A sequence number representing a specific generation of the desired state.
-* `resource_version` - An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
-* `uid` - The unique in time and space value for this service. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
-
-### `spec`
-
-#### Arguments
-
-* `cluster_ip` - (Optional) The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
-* `external_ips` - (Optional) A list of IP addresses for which nodes in the cluster will also accept traffic for this service. These IPs are not managed by Kubernetes. The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
-* `external_name` - (Optional) The external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires `type` to be `ExternalName`.
-* `external_traffic_policy` - (Optional) Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. `Local` preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. `Cluster` obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading. For more info: https://kubernetes.io/docs/tutorials/services/source-ip/
-* `load_balancer_ip` - (Optional) Only applies to `type = LoadBalancer`. LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying this field when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
-* `load_balancer_source_ranges` - (Optional) If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. For more info see [Kubernetes reference](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
-* `port` - (Required) The list of ports that are exposed by this service. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
-* `publish_not_ready_addresses` - (Optional) When set to true, indicates that DNS implementations must publish the `notReadyAddresses` of subsets for the Endpoints associated with the Service. The default value is `false`. The primary use case for setting this field is to use a StatefulSet's Headless Service to propagate `SRV` records for its Pods without respect to their readiness for purpose of peer discovery.
-* `selector` - (Optional) Route service traffic to pods with label keys and values matching this selector. Only applies to types `ClusterIP`, `NodePort`, and `LoadBalancer`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#overview)
-* `session_affinity` - (Optional) Used to maintain session affinity. Supports `ClientIP` and `None`. Defaults to `None`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies)
-* `type` - (Optional) Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#overview)
-* `health_check_node_port` - (Optional) Specifies the Healthcheck NodePort for the service. Only effects when type is set to `LoadBalancer` and external_traffic_policy is set to `Local`.
-
-### `port`
-
-#### Arguments
-
-* `name` - (Optional) The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
-* `node_port` - (Optional) The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#type--nodeport)
+* `name` - (Optional) The name of this port within the service. All ports within
+the service must have unique names. Optional if only one `ServicePort` is
+defined on this service.
+* `node_port` - (Optional) The port on each node on which this service is
+exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the
+system. If specified, it will be allocated to the service if unused or else
+creation of the service will fail. Default is to auto-allocate a port if the
+`type` of this service requires one. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#type--nodeport).
 * `port` - (Required) The port that will be exposed by this service.
-* `protocol` - (Optional) The IP protocol for this port. Supports `TCP` and `UDP`. Default is `TCP`.
-* `target_port` - (Optional) Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = "None"`. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#defining-a-service)
+* `protocol` - (Optional) The IP protocol for this port. Supports `TCP` and
+`UDP`. Default is `TCP`.
+* `target_port` - (Optional) Number or name of the port to access on the pods
+targeted by the service. Number must be in the range 1 to 65535. This field is
+ignored for services with `cluster_ip = "None"`. For more information see
+[this reference](http://kubernetes.io/docs/user-guide/services#defining-a-service).
 
 ## Attributes
 
-* `status` - Status is a list containing the most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+Besides the arguments provided, you can fetch the following list of attributes.
 
-### `status`
-#### Attributes
+### `metadata`
 
-* `load_balancer` - a list containing the current status of the load-balancer, if one is present.
+* `generation`: a sequence number representing a specific generation of the
+desired state.
+* `resource_version`: an opaque value that represents the internal version of
+this service that can be used by clients to determine when service has changed.
+For more information see
+[this reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency).
+* `uid`: the unique in time and space value for this service. For more
+information see
+[this reference](http://kubernetes.io/docs/user-guide/identifiers#uids).
+* `self_link`: a URL representing this object. Populated by the system.
+Read-only.
+* `status`: a list containing the most recently observed status of
+the service. Populated by the system. Read-only. For more information see
+[this reference](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
-### `load_balancer`
-#### Attributes
+And since `status` itself is a list of maps, each one will have the following
+structure:
 
-* `ingress` - a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+* `load_balancer`: a list (of maps) containing the current status of the
+load-balancer, if one is present.
 
-### `ingress`
-#### Attributes
+Then each map might have the following structure:
 
-* `ip` -  IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers).
-* `hostname` - Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers).
+* `ingress`: a list (of maps) containing ingress points for the load-balancer.
+Traffic intended for the service should be sent to these ingress points.
 
-### Timeouts
+Then each map might have the following structure:
 
-`kubernetes_service` provides the following
-[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+* `ip`: IP is set for load-balancer ingress points that are IP based
+(typically GCE or OpenStack load-balancers).
+* `hostname`: Hostname is set for load-balancer ingress points that are DNS
+based (typically AWS load-balancers).
 
-- `create` - Default `10 minutes`
+As a reference, here is a complete example of a `kubernetes_service`
+information:
+
+```hcl
+example = {
+  "id" = "observability/example"
+  "metadata" = [
+    {
+      "annotations"      = tomap(null) /* of string */
+      "generate_name"    = ""
+      "generation"       = 0
+      "labels"           = tomap(null) /* of string */
+      "name"             = "example"
+      "namespace"        = "observability"
+      "resource_version" = "9944172"
+      "self_link"        = ""
+      "uid"              = "1456d1b1-ea66-4837-827a-5756acef60d7"
+    },
+  ]
+  "spec" = [
+    {
+      "cluster_ip"                  = "172.20.156.16"
+      "external_ips"                = []
+      "external_name"               = ""
+      "external_traffic_policy"     = "Cluster"
+      "health_check_node_port"      = 0
+      "load_balancer_ip"            = ""
+      "load_balancer_source_ranges" = []
+      "port" = [
+        {
+          "name"        = ""
+          "node_port"   = 30466
+          "port"        = 8080
+          "protocol"    = "TCP"
+          "target_port" = "80"
+        },
+      ]
+      "publish_not_ready_addresses" = false
+      "selector"                    = {}
+      "session_affinity"            = "None"
+      "type"                        = "LoadBalancer"
+    },
+  ]
+  "status" = [
+    {
+      "load_balancer" = [
+        {
+          "ingress" = [
+            {
+              "hostname" = "a1456d1b1ea664837827a5756acef60d-1786071345.us-east-2.elb.amazonaws.com"
+              "ip"       = ""
+            },
+          ]
+        },
+      ]
+    },
+  ]
+  "timeouts"               = {}
+  "wait_for_load_balancer" = true
+}
+```
 
 ## Import
 
-Service can be imported using its namespace and name, e.g.
+Service can be imported using it's `namespace` and `name`, e.g.
 
 ```
 $ terraform import kubernetes_service.example default/terraform-name


### PR DESCRIPTION
### Description

This PR updates the documentation for both resource and data source of `kubernetes_service`.

Also includes a small fix to `kubernetes/data_source_kubernetes_service.go`.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from testing:

```
$ make website-lint
go install github.com/client9/misspell/cmd/misspell@v0.3.4
go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.26.0
go install github.com/bflad/tfproviderdocs@v0.9.1
go install github.com/katbyte/terrafmt@v0.3.0
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0
==> Checking website against linters...
==> Running markdownlint-cli using DOCKER='/usr/bin/docker', DOCKER_RUN_OPTS='' and DOCKER_VOLUME_OPTS='rw'
==> Running terrafmt diff...
==> Statically compiling provider for tfproviderdocs...
==> Getting provider schema for tfproviderdocs...

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
==> Running tfproviderdocs...
==> Checking for broken links...
==> Checking Markdown links...

FILE: website/docs/r/job.html.markdown

FILE: website/docs/r/horizontal_pod_autoscaler.html.markdown

FILE: website/docs/r/secret.html.markdown

FILE: website/docs/r/stateful_set.html.markdown

FILE: website/docs/r/service.html.markdown

FILE: website/docs/r/csi_driver.html.markdown

FILE: website/docs/r/endpoints.html.markdown

FILE: website/docs/r/priority_class.markdown

FILE: website/docs/r/certificate_signing_request.html.markdown

FILE: website/docs/r/api_service.html.markdown

FILE: website/docs/r/pod_disruption_budget.html.markdown

FILE: website/docs/r/limit_range.html.markdown

FILE: website/docs/r/replication_controller.html.markdown

FILE: website/docs/r/role_binding.html.markdown

FILE: website/docs/r/validating_webhook_configuration.html.markdown

FILE: website/docs/r/deployment.html.markdown

FILE: website/docs/r/network_policy.html.markdown

FILE: website/docs/r/cron_job.html.markdown

FILE: website/docs/r/mutating_webhook_configuration.html.markdown

FILE: website/docs/r/storage_class.html.markdown

FILE: website/docs/r/resource_quota.html.markdown

FILE: website/docs/r/service_account.html.markdown

FILE: website/docs/r/namespace.html.markdown

FILE: website/docs/r/ingress.html.markdown

FILE: website/docs/r/persistent_volume.html.markdown

FILE: website/docs/r/persistent_volume_claim.html.markdown

FILE: website/docs/r/pod.html.markdown

FILE: website/docs/r/config_map.html.markdown

FILE: website/docs/r/default_service_account.html.markdown

FILE: website/docs/r/cluster_role_binding.html.markdown

FILE: website/docs/r/cluster_role.html.markdown

FILE: website/docs/r/role.html.markdown

FILE: website/docs/r/pod_security_policy.html.markdown

FILE: website/docs/r/daemonset.html.markdown

FILE: website/docs/guides/v2-upgrade-guide.markdown

FILE: website/docs/guides/getting-started.html.markdown

FILE: website/docs/d/all_namespaces.html.markdown

FILE: website/docs/d/secret.html.markdown

FILE: website/docs/d/service.html.markdown

FILE: website/docs/d/storage_class.html.markdown

FILE: website/docs/d/service_account.html.markdown

FILE: website/docs/d/namespace.html.markdown

FILE: website/docs/d/ingress.html.markdown

FILE: website/docs/d/persistent_volume_claim.html.markdown

FILE: website/docs/d/pod.html.markdown

FILE: website/docs/d/config_map.html.markdown

FILE: website/docs/index.html.markdown
==================> MARKDOWN LINK CHECK SUCCESS <==================

[✔] All links are good!

===================================================================
$ make test
==> Checking that code complies with gofmt requirements...
go test "/home/semantix/Projects/tmp/terraform-provider-kubernetes/kubernetes" || exit 1
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	0.144s
echo "/home/semantix/Projects/tmp/terraform-provider-kubernetes/kubernetes" | \
	xargs -t -n4 go test  -timeout=30s -parallel=4
go test '-timeout=30s' '-parallel=4' /home/semantix/Projects/tmp/terraform-provider-kubernetes/kubernetes 
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	0.148s
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Updated documentation for `kubernetes_service` (resource and data source).
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/1051

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
