### PR TITLE
Replace heredoc with jsonencode in docs

### DIFF
--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -59,15 +59,13 @@ resource "kubernetes_secret" "example" {
   }
 
   data = {
-    ".dockerconfigjson" = <<DOCKER
-{
-  "auths": {
-    "${var.registry_server}": {
-      "auth": "${base64encode("${var.registry_username}:${var.registry_password}")}"
-    }
-  }
-}
-DOCKER
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "${var.registry_server}": {
+          "auth": "${base64encode("${var.registry_username}:${var.registry_password}")}"
+        }
+      }
+    })
   }
 
   type = "kubernetes.io/dockerconfigjson"


### PR DESCRIPTION
### Description

> Don't use "heredoc" strings to generate JSON or YAML.
> Instead, use the jsonencode function or the yamlencode function so
> that Terraform can be responsible for guaranteeing valid JSON or YAML
> syntax.

👉 https://www.terraform.io/docs/language/expressions/strings.html#generating-json-or-yaml

Useful command for viewing this commit:

    git show --color-words='.'


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
