### PR TITLE
Add field_manager to kubernetes_manifest

### DIFF
--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -82,6 +82,39 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 							},
 						},
 					},
+					{
+						TypeName: "field_manager",
+						Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+						MinItems: 0,
+						MaxItems: 1,
+						Block: &tfprotov5.SchemaBlock{
+							Description: "Configure field manager options.",
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:            "name",
+									Type:            tftypes.String,
+									Required:        false,
+									Optional:        true,
+									Computed:        false,
+									Sensitive:       false,
+									Description:     "The name to use for the field manager when creating and updating the resource.",
+									DescriptionKind: 0,
+									Deprecated:      false,
+								},
+								{
+									Name:            "force_conflicts",
+									Type:            tftypes.Bool,
+									Required:        false,
+									Optional:        true,
+									Computed:        false,
+									Sensitive:       false,
+									Description:     "Force changes against conflicts.",
+									DescriptionKind: 0,
+									Deprecated:      false,
+								},
+							},
+						},
+					},
 				},
 				Attributes: []*tfprotov5.SchemaAttribute{
 					{

--- a/manifest/test/acceptance/fieldmanager_test.go
+++ b/manifest/test/acceptance/fieldmanager_test.go
@@ -1,0 +1,91 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"strings"
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestKubernetesManifest_fieldManager(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	// 1. Create the resource
+	tfvars := TFVARS{
+		"namespace":     namespace,
+		"name":          name,
+		"field_manager": "tftest",
+		"force":         false,
+		"data":          "bar",
+	}
+	tfconfig := loadTerraformConfig(t, "FieldManager/field_manager.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":       namespace,
+		"kubernetes_manifest.test.object.metadata.name":            name,
+		"kubernetes_manifest.test.object.data.foo":                 "bar",
+		"kubernetes_manifest.test.field_manager.0.name":            "tftest",
+		"kubernetes_manifest.test.field_manager.0.force_conflicts": false,
+	})
+
+	// 2. Try to change the resource with a new field manager name, should give a conflict
+	tfvars = TFVARS{
+		"namespace":     namespace,
+		"name":          name,
+		"field_manager": "tftest-newmanager",
+		"force":         false,
+		"data":          "foobar",
+	}
+	tfconfig = loadTerraformConfig(t, "FieldManager/field_manager.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	err := tf.Apply() // this should fail
+	if err == nil || !strings.Contains(err.Error(), "There was a field manager conflict when trying to apply the manifest") {
+		t.Log(err.Error())
+		t.Fatal("Expected terraform apply to cause a field manager conflict")
+	}
+
+	// 3. Try again with force_conflicts set to true, should succeed
+	tfvars = TFVARS{
+		"namespace":     namespace,
+		"name":          name,
+		"field_manager": "tftest-newmanager",
+		"force":         true,
+		"data":          "foobar",
+	}
+	tfconfig = loadTerraformConfig(t, "FieldManager/field_manager.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":       namespace,
+		"kubernetes_manifest.test.object.metadata.name":            name,
+		"kubernetes_manifest.test.object.data.foo":                 "foobar",
+		"kubernetes_manifest.test.field_manager.0.name":            "tftest-newmanager",
+		"kubernetes_manifest.test.field_manager.0.force_conflicts": true,
+	})
+}

--- a/manifest/test/acceptance/testdata/FieldManager/field_manager.tf
+++ b/manifest/test/acceptance/testdata/FieldManager/field_manager.tf
@@ -1,0 +1,18 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    data = {
+      foo = var.data
+    }
+  }
+
+  field_manager {
+    name = var.field_manager
+    force_conflicts = var.force
+  }
+}

--- a/manifest/test/acceptance/testdata/FieldManager/variables.tf
+++ b/manifest/test/acceptance/testdata/FieldManager/variables.tf
@@ -1,0 +1,28 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "field_manager" {
+  type = string
+}
+
+variable "force" {
+  type = bool
+}
+
+variable "data" {
+  type = string
+}

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -126,17 +126,6 @@ resource "kubernetes_manifest" "test" {
       "status.readyReplicas" = "2"
     }
   }
-}
-```
-
-## Configuring timeouts
-
-resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
-  manifest = {
-    // ...
-  }
 
   timeouts {
     create = "10m"
@@ -144,6 +133,32 @@ resource "kubernetes_manifest" "test" {
     delete = "30s"
   }
 }
+```
+
+## Configuring `field_manager`
+
+The `kubernetes_manifest` exposes configuration of the field manager through the optional `field_manager` block.
+
+```hcl
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    // ...
+  }
+
+  field_manager {
+    fields = {
+      # set the name of the field manager
+      name = "myteam"
+
+      # force field manager conflicts to be overridden
+      force_conflicts = true
+    }
+  }
+}
+
+```
 
 ## Argument Reference
 
@@ -152,12 +167,20 @@ The following arguments are supported:
 - `manifest` (Required) An object Kubernetes manifest describing the desired state of the resource in HCL format.
 - `object` (Optional) The resulting resource state, as returned by the API server after applying the desired state from `manifest`.
 - `wait_for` (Optional) An object which allows you configure the provider to wait for certain conditions to be met. See below for schema. 
+- `field_manager` (Optional) Configure field manager options. See below.
 
 ### `wait_for`
 
 #### Arguments
 
 - **fields** (Required) A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use `*` for any value. 
+
+### `field_manager`
+
+#### Arguments
+
+- **name** (Optional) The name of the field manager to use when applying the resource. Defaults to `Terraform`.
+- **force_conflicts** (Optional) Forcibly override any field manager conflicts when applying the resource. Defaults to `false`.
 
 ### `timeouts`
 


### PR DESCRIPTION
### Description

This PR adds support for configuring the field manager to the `kubernetes_manifest` resource. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
KUBE_CONFIG_PATH=~/.kube/config TESTARGS="-run TestKubernetesManifest_fieldManager" make testacc                                        field-manager ◼
go test -count=1 -tags acceptance "./test/acceptance" -v -run TestKubernetesManifest_fieldManager -timeout 120m
2021/07/22 17:40:08 Testing against Kubernetes API version: v1.20.2
=== RUN   TestKubernetesManifest_fieldManager
W0722 17:40:09.224703   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:09.247338   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:09.261181   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:09.282239   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:09.880762   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:09.904783   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:10.225091   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
2021-07-22T17:40:10.424-0400 [ERROR] [ApplyResourceChange][Apply]:
  API error=
  | (*errors.StatusError)(0xc0006b86e0)(Apply failed with 1 conflict: conflict with "tftest": .data.foo)

  API response=
  | (*unstructured.Unstructured)(<nil>)

W0722 17:40:10.823739   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:11.223761   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:11.622042   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0722 17:40:12.223309   39852 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
--- PASS: TestKubernetesManifest_fieldManager (3.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance	4.900s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add field_manager block to kubernetes_manifest
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
