### PR TITLE
Allow setting job's parallelism to zero

### DIFF
--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -70,7 +70,7 @@ func jobSpecFields(specUpdatable bool) map[string]*schema.Schema {
 			Optional:     true,
 			ForceNew:     false,
 			Default:      1,
-			ValidateFunc: validatePositiveInteger,
+			ValidateFunc: validateNonNegativeInteger,
 			Description:  "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
 		},
 		// This field is immutable in Jobs.

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -82,7 +82,7 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 		obj.ManualSelector = ptrToBool(v.(bool))
 	}
 
-	if v, ok := in["parallelism"].(int); ok && v > 0 {
+	if v, ok := in["parallelism"].(int); ok && v >= 0 {
 		obj.Parallelism = ptrToInt32(int32(v))
 	}
 


### PR DESCRIPTION

### Description

Hi there 👋 , 

in this PR we allow setting zero value for job's parallelism which should [be allowed](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism) in Kubernetes.
With these changes, the user should be able to run a paused job. For example: 

```
resource "kubernetes_job" "test" {
  metadata {
    name = "test"
  }
  spec {
    parallelism             = 0
    template {
      metadata {}
      spec {
        container {
          name    = "hello"
          image   = "busybox"
          command = ["sleep", "30"]
        }
      }
    }
  }
  wait_for_completion = false
}
```
should create a job without duration:

```
NAME              COMPLETIONS   DURATION   AG
test              0/1                      8s
```


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.


For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

This PR addresses the issue https://github.com/hashicorp/terraform-provider-kubernetes/issues/1313.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
