### PR TITLE
Test configs for kubernetes_manifest reference old alpha provider

### DIFF
--- a/manifest/provider/plugin.go
+++ b/manifest/provider/plugin.go
@@ -14,7 +14,7 @@ import (
 	tf5server "github.com/hashicorp/terraform-plugin-go/tfprotov5/server"
 )
 
-var providerName = "registry.terraform.io/hashicorp/kubernetes-alpha"
+var providerName = "registry.terraform.io/hashicorp/kubernetes"
 
 // Serve is the default entrypoint for the provider.
 func Serve(ctx context.Context, logger hclog.Logger) error {

--- a/manifest/test/acceptance/testdata/ConfigMap/configmap.tf
+++ b/manifest/test/acceptance/testdata/ConfigMap/configmap.tf
@@ -1,8 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "v1"

--- a/manifest/test/acceptance/testdata/ConfigMap/configmap_modified.tf
+++ b/manifest/test/acceptance/testdata/ConfigMap/configmap_modified.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "ConfigMap"

--- a/manifest/test/acceptance/testdata/CronJob/cronjob.tf
+++ b/manifest/test/acceptance/testdata/CronJob/cronjob.tf
@@ -1,8 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "batch/v1beta1"
@@ -24,7 +20,7 @@ resource "kubernetes_manifest" "test" {
                   image = "busybox"
                   name  = "busybox"
                   command = [
-                    "sleep", 
+                    "sleep",
                     "30"
                   ]
                 }

--- a/manifest/test/acceptance/testdata/CustomResource/custom_resource.tf
+++ b/manifest/test/acceptance/testdata/CustomResource/custom_resource.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = var.group_version

--- a/manifest/test/acceptance/testdata/CustomResource/terraform.tfvars
+++ b/manifest/test/acceptance/testdata/CustomResource/terraform.tfvars
@@ -1,4 +1,4 @@
-name = "testcr"
-namespace = "default"
+name          = "testcr"
+namespace     = "default"
 group_version = "terraform.io/v1"
-kind = "Jqgmbnpb"
+kind          = "Jqgmbnpb"

--- a/manifest/test/acceptance/testdata/CustomResourceDefinition/customresourcedefinition.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceDefinition/customresourcedefinition.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "apiextensions.k8s.io/v1"

--- a/manifest/test/acceptance/testdata/CustomResourceOAPI3/custom_resource.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceOAPI3/custom_resource.tf
@@ -1,5 +1,4 @@
 resource "kubernetes_manifest" "test_cr" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "${var.group}/${var.cr_version}"

--- a/manifest/test/acceptance/testdata/CustomResourceOAPI3/custom_resource_definition.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceOAPI3/custom_resource_definition.tf
@@ -1,5 +1,4 @@
 resource "kubernetes_manifest" "test_crd" {
-  provider = kubernetes-alpha
 
   manifest = {
     "apiVersion" = "apiextensions.k8s.io/v1"

--- a/manifest/test/acceptance/testdata/DaemonSet/daemonset.tf
+++ b/manifest/test/acceptance/testdata/DaemonSet/daemonset.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "apps/v1"

--- a/manifest/test/acceptance/testdata/Deployment/deployment.tf
+++ b/manifest/test/acceptance/testdata/Deployment/deployment.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "apps/v1"

--- a/manifest/test/acceptance/testdata/HPA/hpa.tf
+++ b/manifest/test/acceptance/testdata/HPA/hpa.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "autoscaling/v2beta2"
@@ -17,13 +14,13 @@ resource "kubernetes_manifest" "test" {
         kind       = "Deployment"
         name       = "nginx"
       }
-      
+
       maxReplicas = 10
       minReplicas = 1
 
       metrics = [
         {
-          type     = "Resource"
+          type = "Resource"
           resource = {
             name = "cpu"
             target = {

--- a/manifest/test/acceptance/testdata/HPA/hpa_modified.tf
+++ b/manifest/test/acceptance/testdata/HPA/hpa_modified.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "autoscaling/v2beta2"
@@ -17,13 +14,13 @@ resource "kubernetes_manifest" "test" {
         kind       = "Deployment"
         name       = "nginx"
       }
-      
+
       maxReplicas = 20
       minReplicas = 1
 
       metrics = [
         {
-          type     = "Resource"
+          type = "Resource"
           resource = {
             name = "cpu"
             target = {

--- a/manifest/test/acceptance/testdata/Job/job.tf
+++ b/manifest/test/acceptance/testdata/Job/job.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "batch/v1"
@@ -21,7 +18,7 @@ resource "kubernetes_manifest" "test" {
               image = "busybox"
               name  = "busybox"
               command = [
-                "sleep", 
+                "sleep",
                 "30"
               ]
             }

--- a/manifest/test/acceptance/testdata/Namespace/namespace.tf
+++ b/manifest/test/acceptance/testdata/Namespace/namespace.tf
@@ -1,14 +1,10 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "v1"
     kind       = "Namespace"
     metadata = {
-      name      = var.name
+      name = var.name
     }
   }
 }

--- a/manifest/test/acceptance/testdata/Namespace/namespace_modified.tf
+++ b/manifest/test/acceptance/testdata/Namespace/namespace_modified.tf
@@ -1,14 +1,11 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "v1"
     kind       = "Namespace"
     metadata = {
-      name      = var.name
+      name = var.name
       labels = {
         test = "test"
       }

--- a/manifest/test/acceptance/testdata/NonStructuredCustomResource/custom_resource.tf
+++ b/manifest/test/acceptance/testdata/NonStructuredCustomResource/custom_resource.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = var.group_version

--- a/manifest/test/acceptance/testdata/NonStructuredCustomResource/variables.tf
+++ b/manifest/test/acceptance/testdata/NonStructuredCustomResource/variables.tf
@@ -24,5 +24,5 @@ variable "kind" {
 }
 
 variable "testdata" {
-  type = "string"
+  type = string
 }

--- a/manifest/test/acceptance/testdata/NonStructuredCustomResourceDefinition/customresourcedefinition.tf
+++ b/manifest/test/acceptance/testdata/NonStructuredCustomResourceDefinition/customresourcedefinition.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "apiextensions.k8s.io/v1beta1"
@@ -12,7 +9,7 @@ resource "kubernetes_manifest" "test" {
     }
     spec = {
       preserveUnknownFields = true
-      group = var.group
+      group                 = var.group
       names = {
         kind   = var.kind
         plural = var.plural

--- a/manifest/test/acceptance/testdata/Secret/secret.tf
+++ b/manifest/test/acceptance/testdata/Secret/secret.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "v1"

--- a/manifest/test/acceptance/testdata/StatefulSet/statefulset.tf
+++ b/manifest/test/acceptance/testdata/StatefulSet/statefulset.tf
@@ -1,8 +1,4 @@
-provider "kubernetes-alpha" {
-}
 resource "kubernetes_manifest" "test_svc" {
-  provider = kubernetes-alpha
-
   manifest = {
     "apiVersion" = "v1"
     "kind"       = "Service"
@@ -29,8 +25,6 @@ resource "kubernetes_manifest" "test_svc" {
   }
 }
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     "apiVersion" = "apps/v1"
     "kind"       = "StatefulSet"

--- a/manifest/test/acceptance/testdata/StatefulSet/statefulset.tf
+++ b/manifest/test/acceptance/testdata/StatefulSet/statefulset.tf
@@ -1,25 +1,24 @@
-provider kubernetes-alpha {
+provider "kubernetes-alpha" {
 }
-
-resource kubernetes_manifest test_svc {
+resource "kubernetes_manifest" "test_svc" {
   provider = kubernetes-alpha
 
   manifest = {
     "apiVersion" = "v1"
-    "kind" = "Service"
+    "kind"       = "Service"
     "metadata" = {
       "labels" = {
         "app" = "nginx"
       }
-      "name" = var.name
+      "name"      = var.name
       "namespace" = var.namespace
     }
     "spec" = {
       "clusterIP" = "None"
       "ports" = [
         {
-          "name" = "web"
-          "port" = 80
+          "name"     = "web"
+          "port"     = 80
           "protocol" = "TCP"
         },
       ]
@@ -29,15 +28,14 @@ resource kubernetes_manifest test_svc {
     }
   }
 }
-
-resource kubernetes_manifest test {
+resource "kubernetes_manifest" "test" {
   provider = kubernetes-alpha
 
   manifest = {
     "apiVersion" = "apps/v1"
-    "kind" = "StatefulSet"
+    "kind"       = "StatefulSet"
     "metadata" = {
-      "name" = var.name
+      "name"      = var.name
       "namespace" = var.namespace
     }
     "spec" = {
@@ -58,18 +56,18 @@ resource kubernetes_manifest test {
           "containers" = [
             {
               "image" = "nginx:1"
-              "name" = "nginx"
+              "name"  = "nginx"
               "ports" = [
                 {
                   "containerPort" = 80
-                  "name" = "web"
-                  "protocol" = "TCP"
+                  "name"          = "web"
+                  "protocol"      = "TCP"
                 },
               ]
               "volumeMounts" = [
                 {
                   "mountPath" = "/usr/share/nginx/html"
-                  "name" = "www"
+                  "name"      = "www"
                 },
               ]
             },

--- a/manifest/test/acceptance/testdata/WaitFor/wait_for_fields_pod.tf
+++ b/manifest/test/acceptance/testdata/WaitFor/wait_for_fields_pod.tf
@@ -1,8 +1,5 @@
-provider "kubernetes-alpha" {
-}
 
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "v1"


### PR DESCRIPTION
Tests for `kubernetes_manifest` should now use the kubernetes provider.

+ bonus a `terraform fmt`

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
