### PR TITLE
Fix a bunch of typos: s/kubrenetes/kubernetes/g

### DIFF
--- a/website/docs/guides/alpha-manifest-migration-guide.markdown
+++ b/website/docs/guides/alpha-manifest-migration-guide.markdown
@@ -106,11 +106,11 @@ Run the following command in the directory where the `terraform.tfstate` file is
 terraform state replace-provider hashicorp/kubernetes-alpha hashicorp/kubernetes
 ```
 
-## Mixing 'kubrenetes_manifest' with other 'kubernetes_*' resources
+## Mixing 'kubernetes_manifest' with other 'kubernetes_*' resources
 
-In case you plan on adding `kubrenetes_manifest` resources to your existing configuration which contains other resources of the Kubernetes provider there are some important aspects to be aware of.
+In case you plan on adding `kubernetes_manifest` resources to your existing configuration which contains other resources of the Kubernetes provider there are some important aspects to be aware of.
 
-If your present configuration for the Kubernetes provider also creates the Kubernetes cluster using Terraform resources in the same `apply` operation (against best-practice recommendations), this will no longer work when adding `kubrenetes_manifest` resources. The reason behind this is that `kubrenetes_manifest` require access to the API during planning, at which point the cluster resource would not have yet been created.
+If your present configuration for the Kubernetes provider also creates the Kubernetes cluster using Terraform resources in the same `apply` operation (against best-practice recommendations), this will no longer work when adding `kubernetes_manifest` resources. The reason behind this is that `kubernetes_manifest` require access to the API during planning, at which point the cluster resource would not have yet been created.
 
 As a solution, choose one of the following options:
 


### PR DESCRIPTION
### Description

The documentation contains a bunch of typos, where "Kubernetes" has been misspelled.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
