### PR TITLE
Import kubernetes_manifest

### DIFF
--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -21,6 +21,13 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 	// Without the user supplying the GRV there is no way to fully identify the resource when making the Get API call to K8s.
 	// Presumably the Kubernetes API machinery already has a standard for expressing such a group. We should look there first.
 	resp := &tfprotov5.ImportResourceStateResponse{}
+
+	execDiag := s.canExecute()
+	if len(execDiag) > 0 {
+		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
+		return resp, nil
+	}
+
 	gvk, name, namespace, err := parseImportID(req.ID)
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{

--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -140,9 +140,15 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 
 	newState := make(map[string]tftypes.Value)
 	wftype := rt.(tftypes.Object).AttributeTypes["wait_for"]
+	timeoutsType := rt.(tftypes.Object).AttributeTypes["timeouts"]
+	fmType := rt.(tftypes.Object).AttributeTypes["field_manager"]
+
 	newState["manifest"] = tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}, nil)
 	newState["object"] = morph.UnknownToNull(nobj)
 	newState["wait_for"] = tftypes.NewValue(wftype, nil)
+	newState["timeouts"] = tftypes.NewValue(timeoutsType, nil)
+	newState["field_manager"] = tftypes.NewValue(fmType, nil)
+
 	nsVal := tftypes.NewValue(rt, newState)
 
 	impState, err := tfprotov5.NewDynamicValue(nsVal.Type(), nsVal)

--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
@@ -94,12 +93,12 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
-			Summary:  fmt.Sprintf("Failed to get resource %s from API", spew.Sdump(io)),
+			Summary:  fmt.Sprintf("Failed to get resource %+v from API", io),
 			Detail:   err.Error(),
 		})
 		return resp, nil
 	}
-	s.logger.Trace("[ImportResourceState]", "[API Resource]", spew.Sdump(ro))
+	s.logger.Trace("[ImportResourceState]", "[API Resource]", ro)
 
 	objectType, err := s.TFTypeFromOpenAPI(ctx, gvk, false)
 	if err != nil {
@@ -130,7 +129,7 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 		})
 		return resp, nil
 	}
-	s.logger.Trace("[ImportResourceState]", "[tftypes.Value]", spew.Sdump(nobj))
+	s.logger.Trace("[ImportResourceState]", "[tftypes.Value]", nobj)
 
 	newState := make(map[string]tftypes.Value)
 	wftype := rt.(tftypes.Object).AttributeTypes["wait_for"]

--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/payload"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ImportResourceState function
+func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprotov5.ImportResourceStateRequest) (*tfprotov5.ImportResourceStateResponse, error) {
+	// Terraform only gives us the schema name of the resource and an ID string, as passed by the user on the command line.
+	// The ID should be a combination of a Kubernetes GVK and a namespace/name type of resource identifier.
+	// Without the user supplying the GRV there is no way to fully identify the resource when making the Get API call to K8s.
+	// Presumably the Kubernetes API machinery already has a standard for expressing such a group. We should look there first.
+	resp := &tfprotov5.ImportResourceStateResponse{}
+	gvk, name, namespace, err := parseImportID(req.ID)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to parse import ID",
+			Detail:   err.Error(),
+		})
+	}
+	s.logger.Trace("[ImportResourceState]", "[ID]", gvk, name, namespace)
+	rt, err := GetResourceType(req.TypeName)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to determine resource type",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	rm, err := s.getRestMapper()
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to get RESTMapper client",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	client, err := s.getDynamicClient()
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "failed to get Dynamic client",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	ns, err := IsResourceNamespaced(gvk, rm)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to get namespacing requirement from RESTMapper",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	io := unstructured.Unstructured{}
+	io.SetKind(gvk.Kind)
+	io.SetAPIVersion(gvk.GroupVersion().String())
+	io.SetName(name)
+	io.SetNamespace(namespace)
+
+	gvr, err := GVRFromUnstructured(&io, rm)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to get GVR from GVK via RESTMapper",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	rcl := client.Resource(gvr)
+
+	var ro *unstructured.Unstructured
+	if ns {
+		ro, err = rcl.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	} else {
+		ro, err = rcl.Get(ctx, name, metav1.GetOptions{})
+	}
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  fmt.Sprintf("Failed to get resource %s from API", spew.Sdump(io)),
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	s.logger.Trace("[ImportResourceState]", "[API Resource]", spew.Sdump(ro))
+
+	objectType, err := s.TFTypeFromOpenAPI(ctx, gvk, false)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  fmt.Sprintf("Failed to determine resource type from GVK: %s", gvk),
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	fo := RemoveServerSideFields(ro.UnstructuredContent())
+	nobj, err := payload.ToTFValue(fo, objectType, tftypes.NewAttributePath())
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to convert unstructured to tftypes.Value",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	nobj, err = morph.DeepUnknown(objectType, nobj, tftypes.NewAttributePath())
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to backfill unknown values during import",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	s.logger.Trace("[ImportResourceState]", "[tftypes.Value]", spew.Sdump(nobj))
+
+	newState := make(map[string]tftypes.Value)
+	wftype := rt.(tftypes.Object).AttributeTypes["wait_for"]
+	newState["manifest"] = tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}, nil)
+	newState["object"] = morph.UnknownToNull(nobj)
+	newState["wait_for"] = tftypes.NewValue(wftype, nil)
+	nsVal := tftypes.NewValue(rt, newState)
+
+	impState, err := tfprotov5.NewDynamicValue(nsVal.Type(), nsVal)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to construct dynamic value for imported state",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	resp.ImportedResources = append(resp.ImportedResources, &tfprotov5.ImportedResource{
+		TypeName: req.TypeName,
+		State:    &impState,
+	})
+	return resp, nil
+}
+
+// parseImportID processes the resource ID string passed by the user to the "terraform import" command
+// and extracts the values for GVK, name and (optionally) namespace of the target resource as required
+// during the import process.
+//
+// The expected format for the import resource ID is:
+//
+// "<apiGroup/><apiVersion>#<Kind>#<namespace>#<name>"
+//
+// where 'namespace' is only required for resources that expect a namespace.
+//
+// Note the '#' separator between the elements of the ID string.
+//
+// Example: "v1#Secret#default#default-token-qgm6s"
+//
+func parseImportID(id string) (gvk schema.GroupVersionKind, name string, namespace string, err error) {
+	parts := strings.Split(id, "#")
+	if len(parts) < 3 || len(parts) > 4 {
+		err = fmt.Errorf("invalid format for import ID [%s]", id)
+		return
+	}
+	gvk = schema.FromAPIVersionAndKind(parts[0], parts[1])
+	if len(parts) == 4 {
+		namespace = parts[2]
+		name = parts[3]
+	} else {
+		name = parts[2]
+	}
+	return
+}

--- a/manifest/provider/import_test.go
+++ b/manifest/provider/import_test.go
@@ -41,24 +41,24 @@ func TestParseImportID(t *testing.T) {
 			Err: fmt.Errorf("invalid format for import ID [%s]\nExpected format is: apiVersion=<value>,kind=<value>,name=<value>[,namespace=<value>]", "foobar"),
 		},
 	}
-	for _, s := range samples {
-		gotGvk, gotName, gotNamespace, gotErr := parseImportID(s.ID)
-		if gotErr != nil {
-			if gotErr.Error() == s.Err.Error() {
+	for _, expected := range samples {
+		actualGvk, actualName, actualNamespace, actualErr := parseImportID(expected.ID)
+		if actualErr != nil {
+			if actualErr.Error() == expected.Err.Error() {
 				continue
 			}
-			t.Fatal(gotErr.Error())
+			t.Fatal(actualErr.Error())
 		}
-		if s.GVK != gotGvk {
-			t.Log("GVK (got / wanted):", gotGvk, s.GVK)
+		if expected.GVK != actualGvk {
+			t.Log("GVK (actual / wanted):", actualGvk, expected.GVK)
 			t.Fail()
 		}
-		if s.Name != gotName {
-			t.Log("Name (got / wanted):", gotName, s.Name)
+		if expected.Name != actualName {
+			t.Log("Name (actual / wanted):", actualName, expected.Name)
 			t.Fail()
 		}
-		if s.Namespace != gotNamespace {
-			t.Log("Namespace (got / wanted):", gotNamespace, s.Namespace)
+		if expected.Namespace != actualNamespace {
+			t.Log("Namespace (actual / wanted):", actualNamespace, expected.Namespace)
 			t.Fail()
 		}
 	}

--- a/manifest/provider/import_test.go
+++ b/manifest/provider/import_test.go
@@ -16,21 +16,21 @@ func TestParseImportID(t *testing.T) {
 		Err       error
 	}{
 		{
-			ID:        "v1#ConfigMap#default#test",
+			ID:        "apiVersion=v1,kind=ConfigMap,namespace=default,name=test",
 			GVK:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 			Name:      "test",
 			Namespace: "default",
 			Err:       nil,
 		},
 		{
-			ID:        "rbac.authorization.k8s.io/v1#ClusterRole#test",
+			ID:        "apiVersion=rbac.authorization.k8s.io/v1,kind=ClusterRole,name=test",
 			GVK:       schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
 			Name:      "test",
 			Namespace: "",
 			Err:       nil,
 		},
 		{
-			ID:        "apps/v1#Deployment#foo#bar",
+			ID:        "apiVersion=apps/v1,kind=Deployment,namespace=foo,name=bar",
 			GVK:       schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 			Name:      "bar",
 			Namespace: "foo",
@@ -38,7 +38,7 @@ func TestParseImportID(t *testing.T) {
 		},
 		{
 			ID:  "foobar",
-			Err: fmt.Errorf("invalid format for import ID [%s]", "foobar"),
+			Err: fmt.Errorf("invalid format for import ID [%s]\nExpected format is: apiVersion=<value>,kind=<value>,name=<value>[,namespace=<value>]", "foobar"),
 		},
 	}
 	for _, s := range samples {

--- a/manifest/provider/import_test.go
+++ b/manifest/provider/import_test.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestParseImportID(t *testing.T) {
+	samples := []struct {
+		ID        string
+		GVK       schema.GroupVersionKind
+		Name      string
+		Namespace string
+		Err       error
+	}{
+		{
+			ID:        "v1#ConfigMap#default#test",
+			GVK:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			Name:      "test",
+			Namespace: "default",
+			Err:       nil,
+		},
+		{
+			ID:        "rbac.authorization.k8s.io/v1#ClusterRole#test",
+			GVK:       schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+			Name:      "test",
+			Namespace: "",
+			Err:       nil,
+		},
+		{
+			ID:        "apps/v1#Deployment#foo#bar",
+			GVK:       schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Name:      "bar",
+			Namespace: "foo",
+			Err:       nil,
+		},
+		{
+			ID:  "foobar",
+			Err: fmt.Errorf("invalid format for import ID [%s]", "foobar"),
+		},
+	}
+	for _, s := range samples {
+		gotGvk, gotName, gotNamespace, gotErr := parseImportID(s.ID)
+		if gotErr != nil {
+			if gotErr.Error() == s.Err.Error() {
+				continue
+			}
+			t.Fatal(gotErr.Error())
+		}
+		if s.GVK != gotGvk {
+			t.Log("GVK (got / wanted):", gotGvk, s.GVK)
+			t.Fail()
+		}
+		if s.Name != gotName {
+			t.Log("Name (got / wanted):", gotName, s.Name)
+			t.Fail()
+		}
+		if s.Namespace != gotNamespace {
+			t.Log("Namespace (got / wanted):", gotNamespace, s.Namespace)
+			t.Fail()
+		}
+	}
+}

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -85,15 +85,6 @@ func (s *RawProviderServer) UpgradeResourceState(ctx context.Context, req *tfpro
 	return resp, nil
 }
 
-// ImportResourceState function
-func (*RawProviderServer) ImportResourceState(ctx context.Context, req *tfprotov5.ImportResourceStateRequest) (*tfprotov5.ImportResourceStateResponse, error) {
-	// Terraform only gives us the schema name of the resource and an ID string, as passed by the user on the command line.
-	// The ID should be a combination of a Kubernetes GRV and a namespace/name type of resource identifier.
-	// Without the user supplying the GRV there is no way to fully identify the resource when making the Get API call to K8s.
-	// Presumably the Kubernetes API machinery already has a standard for expressing such a group. We should look there first.
-	return nil, status.Errorf(codes.Unimplemented, "method ImportResourceState not implemented")
-}
-
 // ReadDataSource function
 func (s *RawProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
 	s.logger.Trace("[ReadDataSource][Request]\n%s\n", dump(*req))

--- a/manifest/test/acceptance/configmap_test.go
+++ b/manifest/test/acceptance/configmap_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -23,7 +24,7 @@ func TestKubernetesManifest_ConfigMap(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/cronjob_test.go
+++ b/manifest/test/acceptance/cronjob_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -21,7 +22,7 @@ func TestKubernetesManifest_CronJob(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/daemonset_test.go
+++ b/manifest/test/acceptance/daemonset_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -21,7 +22,7 @@ func TestKubernetesManifest_DaemonSet(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/deployment_test.go
+++ b/manifest/test/acceptance/deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -22,7 +23,7 @@ func TestKubernetesManifest_Deployment(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/exists_test.go
+++ b/manifest/test/acceptance/exists_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -5,6 +6,8 @@ package acceptance
 import (
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 )
 
 func TestKubernetesManifest_alreadyExists(t *testing.T) {
@@ -21,7 +24,7 @@ func TestKubernetesManifest_alreadyExists(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/fieldmanager_test.go
+++ b/manifest/test/acceptance/fieldmanager_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -6,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -22,7 +24,7 @@ func TestKubernetesManifest_fieldManager(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	// 1. Create the resource
 	tfvars := TFVARS{

--- a/manifest/test/acceptance/hpa_test.go
+++ b/manifest/test/acceptance/hpa_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -22,7 +23,7 @@ func TestKubernetesManifest_HPA(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/import_test.go
+++ b/manifest/test/acceptance/import_test.go
@@ -1,0 +1,65 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestKubernetesManifest_Import(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+
+	k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+
+	k8shelper.CreateConfigMap(t, name, namespace,
+		map[string]interface{}{
+			"foo": "bar",
+		})
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Import/import.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+
+	importId := strings.Join([]string{"v1", "ConfigMap", namespace, name}, "#")
+
+	tf.RequireImport(t, "kubernetes_manifest.test", importId)
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.data.foo":           "bar",
+	})
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.data.fizz")
+
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.data.foo":           "bar",
+		"kubernetes_manifest.test.object.data.fizz":          "buzz",
+	})
+}

--- a/manifest/test/acceptance/import_test.go
+++ b/manifest/test/acceptance/import_test.go
@@ -1,9 +1,10 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
 
 import (
-	"strings"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
@@ -40,7 +41,7 @@ func TestKubernetesManifest_Import(t *testing.T) {
 	tf.RequireSetConfig(t, tfconfig)
 	tf.RequireInit(t)
 
-	importId := strings.Join([]string{"v1", "ConfigMap", namespace, name}, "#")
+	importId := fmt.Sprintf("apiVersion=%s,kind=%s,namespace=%s,name=%s", "v1", "ConfigMap", namespace, name)
 
 	tf.RequireImport(t, "kubernetes_manifest.test", importId)
 	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)

--- a/manifest/test/acceptance/job_test.go
+++ b/manifest/test/acceptance/job_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -21,7 +22,7 @@ func TestKubernetesManifest_Job(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/secret_test.go
+++ b/manifest/test/acceptance/secret_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -21,7 +22,7 @@ func TestKubernetesManifest_Secret(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/statefulset_test.go
+++ b/manifest/test/acceptance/statefulset_test.go
@@ -5,6 +5,7 @@ package acceptance
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -21,7 +22,7 @@ func TestKubernetesManifest_StatefulSet(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/testdata/Import/import.tf
+++ b/manifest/test/acceptance/testdata/Import/import.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    data = {
+      foo = "bar"
+      fizz = "buzz"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Import/variables.tf
+++ b/manifest/test/acceptance/testdata/Import/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/manifest/test/acceptance/wait_for_test.go
+++ b/manifest/test/acceptance/wait_for_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
@@ -27,7 +28,7 @@ func TestKubernetesManifest_WaitForFields_Pod(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/helper/kubernetes/kubernetes_helper.go
+++ b/manifest/test/helper/kubernetes/kubernetes_helper.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package kubernetes
@@ -81,7 +82,7 @@ func (k *Helper) CreateNamespace(t *testing.T, name string) {
 	}
 }
 
-// CreateNamespace creates a new namespace
+// CreateConfigMap creates a new ConfigMap
 func (k *Helper) CreateConfigMap(t *testing.T, name string, namespace string, data map[string]interface{}) {
 	t.Helper()
 
@@ -103,7 +104,7 @@ func (k *Helper) CreateConfigMap(t *testing.T, name string, namespace string, da
 	}
 }
 
-// DeleteResource deletes a namespace
+// DeleteResource deletes a resource referred to by the name and GVK
 func (k *Helper) DeleteResource(t *testing.T, name string, gvr schema.GroupVersionResource) {
 	t.Helper()
 
@@ -113,7 +114,7 @@ func (k *Helper) DeleteResource(t *testing.T, name string, gvr schema.GroupVersi
 	}
 }
 
-// DeleteResource deletes a namespace
+// DeleteResource deletes a namespaced resource referred to by the name and GVK
 func (k *Helper) DeleteNamespacedResource(t *testing.T, name string, namespace string, gvr schema.GroupVersionResource) {
 	t.Helper()
 

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -111,7 +111,7 @@ kubectl get secrets sample -o yaml | tfk8s --strip -o sample.tf
 ### Import the resource state from the cluster
 
 ```
-terraform import kubernetes_manifest.secret_sample "v1#Secret#default#sample"
+terraform import kubernetes_manifest.secret_sample "apiVersion=v1,kind=Secret,namespace=default,name=sample"
 ```
 
 Note the import ID as the last argument to the import command. This ID points Terraform at which Kubernetes object to read when importing.

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -97,6 +97,22 @@ resource "kubernetes_manifest" "test-crd" {
   }
 }
 ```
+## Importing existing Kubernetes resources as `kubernetes_manifest`
+
+Objects already present in a Kubernetes cluster can be imported into Terraform to be managed as `kubernetes_manifest` resources. Follow these steps to import a resource:
+
+### Extract the resource from Kubernetes and transform it into Terraform configuration.
+```
+kubectl get secrets sample -o yaml | tfk8s --strip -o sample.tf
+```
+### Import the resource state from the cluster.
+
+```
+terraform import kubernetes_manifest.secret_sample "v1#Secret#default#sample"
+```
+
+Note the import ID as the last argument to the import command. This ID points Terraform at which Kubernetes object to read when importing.
+It should be constructed with the following syntax: `"<apiVersion>#<Kind>#<metadata.namespace>#<metadata.name>"`
 
 ## Using `wait_for` to block create and update calls
 

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -97,15 +97,18 @@ resource "kubernetes_manifest" "test-crd" {
   }
 }
 ```
+
 ## Importing existing Kubernetes resources as `kubernetes_manifest`
 
 Objects already present in a Kubernetes cluster can be imported into Terraform to be managed as `kubernetes_manifest` resources. Follow these steps to import a resource:
 
-### Extract the resource from Kubernetes and transform it into Terraform configuration.
+### Extract the resource from Kubernetes and transform it into Terraform configuration
+
 ```
 kubectl get secrets sample -o yaml | tfk8s --strip -o sample.tf
 ```
-### Import the resource state from the cluster.
+
+### Import the resource state from the cluster
 
 ```
 terraform import kubernetes_manifest.secret_sample "v1#Secret#default#sample"


### PR DESCRIPTION
### Description

This change introduces the ability to import `kubernetes_manifest` resources.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
[import-manifest][~/work/terraform-provider-kubernetes/manifest]$ make testacc TESTARGS="-test.run 'TestKubernetesManifest_Import'"

go test -count=1 -tags acceptance "./test/acceptance" -v -test.run 'TestKubernetesManifest_Import' -timeout 120m
2021/08/03 14:04:49 Testing against Kubernetes API version: v1.21.2
=== RUN   TestKubernetesManifest_Import
--- PASS: TestKubernetesManifest_Import (1.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance	1.766s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
* Support for importing kubernetes_manifest resources.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
