### PR TITLE
Some fixes post v2.4.0

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -146,7 +146,7 @@ func Provider() *schema.Provider {
 							Type:     schema.TypeBool,
 							Optional: true,
 							DefaultFunc: func() (interface{}, error) {
-								if v := os.Getenv("TF_X_KUBERNETES_MANIFEST"); v != "" {
+								if v := os.Getenv("TF_X_KUBERNETES_MANIFEST_RESOURCE"); v != "" {
 									vv, err := strconv.ParseBool(v)
 									if err != nil {
 										return false, err

--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -19,6 +19,13 @@ import (
 // ApplyResourceChange function
 func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest) (*tfprotov5.ApplyResourceChangeResponse, error) {
 	resp := &tfprotov5.ApplyResourceChangeResponse{}
+
+	execDiag := s.canExecute()
+	if len(execDiag) > 0 {
+		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
+		return resp, nil
+	}
+
 	rt, err := GetResourceType(req.TypeName)
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{

--- a/manifest/provider/configure.go
+++ b/manifest/provider/configure.go
@@ -642,7 +642,7 @@ func (s *RawProviderServer) canExecute() (resp []*tfprotov5.Diagnostic) {
 		resp = append(resp, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
 			Summary:  "Incompatible terraform version",
-			Detail:   fmt.Sprintf("This provider requires Terraform %s or above", minTFVersion),
+			Detail:   fmt.Sprintf("The `kubernetes_manifest` resource requires Terraform %s or above", minTFVersion),
 		})
 	}
 	return

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -77,12 +77,9 @@ func (s *RawProviderServer) dryRun(ctx context.Context, obj tftypes.Value) error
 func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
 	resp := &tfprotov5.PlanResourceChangeResponse{}
 
-	if !s.providerEnabled {
-		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-			Severity: tfprotov5.DiagnosticSeverityError,
-			Summary:  "Experimental feature not enabled.",
-			Detail:   "The `kubernetes_manifest` resource is an experimental feature and must be explicitly enabled in the provider configuration block.",
-		})
+	execDiag := s.canExecute()
+	if len(execDiag) > 0 {
+		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
 		return resp, nil
 	}
 

--- a/manifest/provider/read.go
+++ b/manifest/provider/read.go
@@ -16,6 +16,13 @@ import (
 // ReadResource function
 func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfprotov5.ReadResourceRequest) (*tfprotov5.ReadResourceResponse, error) {
 	resp := &tfprotov5.ReadResourceResponse{}
+
+	execDiag := s.canExecute()
+	if len(execDiag) > 0 {
+		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
+		return resp, nil
+	}
+
 	var resState map[string]tftypes.Value
 	var err error
 	rt, err := GetResourceType(req.TypeName)

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -34,6 +34,7 @@ type RawProviderServer struct {
 	OAPIFoundry     openapi.Foundry
 
 	providerEnabled bool
+	hostTFVersion   string
 }
 
 func dump(v interface{}) hclog.Format {

--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -100,7 +100,7 @@ provider "kubernetes" {
 }
 ```
 
-For short-lived authentication tokens, like those found in EKS, which [expire in 15 minutes](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#controlling-access-to-eks-clusters), an exec-based credential plugin can be used to ensure the token is always up to date:
+For short-lived authentication tokens, like those found in EKS, which [expire in 15 minutes](https://aws.github.io/aws-eks-best-practices/security/docs/iam#controlling-access-to-eks-clusters), an exec-based credential plugin can be used to ensure the token is always up to date:
 
 ```hcl
 data "aws_eks_cluster" "example" {

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -11,8 +11,13 @@ Represents one Kubernetes resource by supplying a `manifest` attribute. The mani
 
 Once applied, the `object` attribute contains the state of the resource as returned by the Kubernetes API, including all default values.
 
-~> **NOTE:** This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out plan and apply operations. This means the cluster has to be accessible at plan time. We recommend only using this resource for custom resources or resources not yet fully supported by the provider. 
+~> **Prerequisites:** 
 
+* This resource requires API access during planning time. This means the cluster has to be accessible at plan time and thus cannot be created in the same apply operation. We recommend only using this resource for custom resources or resources not yet fully supported by the provider.
+
+* This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out apply operations. A minimum Kubernetes version of 1.16.x is required, but versions 1.17+ are strongly recommended as the SSA implementation in Kubernetes 1.16.x is incomplete and unstable.
+
+* A minimum Terraform version of 1.14.8 is required to use this resource.
 
 ### Example: Create a Kubernetes ConfigMap
 

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -17,7 +17,7 @@ Once applied, the `object` attribute contains the state of the resource as retur
 
 * This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out apply operations. A minimum Kubernetes version of 1.16.x is required, but versions 1.17+ are strongly recommended as the SSA implementation in Kubernetes 1.16.x is incomplete and unstable.
 
-* A minimum Terraform version of 1.14.8 is required to use this resource.
+* A minimum Terraform version of 0.14.8 is required to use this resource.
 
 ### Example: Create a Kubernetes ConfigMap
 


### PR DESCRIPTION
### Description

This change addresses some issues that made their way into release v2.4.0:

* delays checking the minimum version of Terraform in the manifest resource until after ConfigureProvider
* documents the minimum Terraform version for manifest resources
* aligns environment variable names used to set the feature gate flag for kubernetes_manifest
* fixes a dead link in the documentation

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* restores compatibility with Terraform versions lower than 0.14.8 (#1341)
```

### References

Fixes #1341 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
