### PR TITLE
Document that kubernetes_manifest must be enabled in the provider block.

### DIFF
--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -11,15 +11,11 @@ Represents one Kubernetes resource by supplying a `manifest` attribute. The mani
 
 Once applied, the `object` attribute contains the state of the resource as returned by the Kubernetes API, including all default values.
 
-~> **Prerequisites:** 
+~> A minimum Terraform version of 0.14.8 is required to use this resource.
 
-* This resource requires API access during planning time. This means the cluster has to be accessible at plan time and thus cannot be created in the same apply operation. We recommend only using this resource for custom resources or resources not yet fully supported by the provider.
+~> This resource is currently in beta, and should not be used in production. To use it, you must enable it in the provider block.
 
-* This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out apply operations. A minimum Kubernetes version of 1.16.x is required, but versions 1.17+ are strongly recommended as the SSA implementation in Kubernetes 1.16.x is incomplete and unstable.
-
-* A minimum Terraform version of 0.14.8 is required to use this resource.
-
-* This resource is currently in beta, and should not be used in production. To use it, you must enable it in the provider block.
+How to enable the experiment:
 
 ```hcl
 provider "kubernetes" {
@@ -30,6 +26,14 @@ provider "kubernetes" {
   config_path = "~/.kube/config"
 }
 ```
+
+
+# Before you use this resource
+
+* This resource requires API access during planning time. This means the cluster has to be accessible at plan time and thus cannot be created in the same apply operation. We recommend only using this resource for custom resources or resources not yet fully supported by the provider.
+
+* This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out apply operations. A minimum Kubernetes version of 1.16.x is required, but versions 1.17+ are strongly recommended as the SSA implementation in Kubernetes 1.16.x is incomplete and unstable.
+
 
 ### Example: Create a Kubernetes ConfigMap
 

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -19,6 +19,18 @@ Once applied, the `object` attribute contains the state of the resource as retur
 
 * A minimum Terraform version of 0.14.8 is required to use this resource.
 
+* This resource is currently in beta, and should not be used in production. To use it, you must enable it in the provider block.
+
+```hcl
+provider "kubernetes" {
+  experiments {
+    manifest_resource = true
+  }
+
+  config_path = "~/.kube/config"
+}
+```
+
 ### Example: Create a Kubernetes ConfigMap
 
 ```hcl

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -102,7 +102,6 @@ The `kubernetes_manifest` resource supports the ability to block create and upda
 
 ```hcl
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
 
   manifest = {
     // ...

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -28,7 +28,7 @@ provider "kubernetes" {
 ```
 
 
-# Before you use this resource
+### Before you use this resource
 
 * This resource requires API access during planning time. This means the cluster has to be accessible at plan time and thus cannot be created in the same apply operation. We recommend only using this resource for custom resources or resources not yet fully supported by the provider.
 


### PR DESCRIPTION
### kubernetes_manifest is still experimental

I noticed that the docs don't mention that kubernetes_manfiest must be enabled in the provider block. This PR fixes that, and also removes a reference to the alpha provider.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
