### PR TITLE
Add timeouts block to kubernetes_manifest

### DIFF
--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -15,6 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 )
+
+var defaultCreateTimeout = "10m"
+var defaultUpdateTimeout = "10m"
+var defaultDeleteTimeout = "10m"
 
 // ApplyResourceChange function
 func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest) (*tfprotov5.ApplyResourceChangeResponse, error) {
@@ -162,8 +167,20 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			return resp, nil
 		}
 
+		// figure out the timeout deadline
+		timeouts := s.getTimeouts(plannedStateVal)
+		var timeout time.Duration
+		if applyPriorState.IsNull() {
+			timeout, _ = time.ParseDuration(timeouts["create"])
+		} else {
+			timeout, _ = time.ParseDuration(timeouts["update"])
+		}
+		deadline := time.Now().Add(timeout)
+		ctxDeadline, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
+
 		// Call the Kubernetes API to create the new resource
-		result, err := rs.Patch(ctx, rname, types.ApplyPatchType, jsonManifest, metav1.PatchOptions{FieldManager: "Terraform"})
+		result, err := rs.Patch(ctxDeadline, rname, types.ApplyPatchType, jsonManifest, metav1.PatchOptions{FieldManager: "Terraform"})
 		if err != nil {
 			s.logger.Error("[ApplyResourceChange][Apply]", "API error", dump(err), "API response", dump(result))
 			if status := apierrors.APIStatus(nil); errors.As(err, &status) {
@@ -192,9 +209,24 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 
 		wf, ok := plannedStateVal["wait_for"]
 		if ok {
-			err = s.waitForCompletion(ctx, wf, rs, rname, wt)
+			err = s.waitForCompletion(ctxDeadline, wf, rs, rname, wt)
 			if err != nil {
-				return resp, err
+				if err == context.DeadlineExceeded {
+					resp.Diagnostics = append(resp.Diagnostics,
+						&tfprotov5.Diagnostic{
+							Severity: tfprotov5.DiagnosticSeverityError,
+							Summary:  "Operation timed out",
+							Detail:   "Terraform timed out waiting on the operation to complete",
+						})
+				} else {
+					resp.Diagnostics = append(resp.Diagnostics,
+						&tfprotov5.Diagnostic{
+							Severity: tfprotov5.DiagnosticSeverityError,
+							Summary:  "Error waiting for operation to complete",
+							Detail:   err.Error(),
+						})
+				}
+				return resp, nil
 			}
 		}
 
@@ -253,25 +285,59 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 		if err != nil {
 			return resp, err
 		}
-
 		rnamespace := uo.GetNamespace()
 		rname := uo.GetName()
-
 		if ns {
 			rs = c.Resource(gvr).Namespace(rnamespace)
 		} else {
 			rs = c.Resource(gvr)
 		}
-		err = rs.Delete(ctx, rname, metav1.DeleteOptions{})
+
+		// figure out the timeout deadline
+		timeouts := s.getTimeouts(priorStateVal)
+		timeout, _ := time.ParseDuration(timeouts["delete"])
+		deadline := time.Now().Add(timeout)
+		ctxDeadline, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
+
+		err = rs.Delete(ctxDeadline, rname, metav1.DeleteOptions{})
 		if err != nil {
 			rn := types.NamespacedName{Namespace: rnamespace, Name: rname}.String()
 			resp.Diagnostics = append(resp.Diagnostics,
 				&tfprotov5.Diagnostic{
 					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  fmt.Sprintf("Error deleting resource %s: %s", rn, err),
 					Detail:   err.Error(),
-					Summary:  fmt.Sprintf("DELETE resource %s failed: %s", rn, err),
 				})
 			return resp, nil
+		}
+
+		// wait for delete
+		for {
+			if time.Now().After(deadline) {
+				resp.Diagnostics = append(resp.Diagnostics,
+					&tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  fmt.Sprintf("Timed out when waiting for resource %q to be deleted", rname),
+						Detail:   "Deletion timed out. This can happen when there is a finalizer on a resource. You may need to delete this resource manually with kubectl.",
+					})
+				return resp, nil
+			}
+			_, err := rs.Get(ctxDeadline, rname, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					s.logger.Trace("[ApplyResourceChange][Delete]", "Resource is deleted")
+					break
+				}
+				resp.Diagnostics = append(resp.Diagnostics,
+					&tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Error waiting for deletion.",
+						Detail:   fmt.Sprintf("Error when waiting for resource %q to be deleted: %v", rname, err),
+					})
+				return resp, nil
+			}
+			time.Sleep(1 * time.Second) // lintignore:R018
 		}
 
 		resp.NewState = req.PlannedState
@@ -281,4 +347,30 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 	s.OAPIFoundry = nil // this needs to be optimized to refresh only when CRDs are applied (or maybe other schema altering resources too?)
 
 	return resp, nil
+}
+
+func (s *RawProviderServer) getTimeouts(v map[string]tftypes.Value) map[string]string {
+	timeouts := map[string]string{
+		"create": defaultCreateTimeout,
+		"update": defaultUpdateTimeout,
+		"delete": defaultDeleteTimeout,
+	}
+	if !v["timeouts"].IsNull() && v["timeouts"].IsKnown() {
+		var timeoutsBlock []tftypes.Value
+		v["timeouts"].As(&timeoutsBlock)
+		if len(timeoutsBlock) > 0 {
+			var t map[string]tftypes.Value
+			timeoutsBlock[0].As(&t)
+			var s string
+			for _, k := range []string{"create", "update", "delete"} {
+				if vv, ok := t[k]; ok && !vv.IsNull() {
+					vv.As(&s)
+					if s != "" {
+						timeouts[k] = s
+					}
+				}
+			}
+		}
+	}
+	return timeouts
 }

--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -53,6 +53,36 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 		"kubernetes_manifest": {
 			Version: 1,
 			Block: &tfprotov5.SchemaBlock{
+				BlockTypes: []*tfprotov5.SchemaNestedBlock{
+					{
+						TypeName: "timeouts",
+						Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+						MinItems: 0,
+						MaxItems: 1,
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:        "create",
+									Type:        tftypes.String,
+									Description: "Timeout for the create operation.",
+									Optional:    true,
+								},
+								{
+									Name:        "update",
+									Type:        tftypes.String,
+									Description: "Timeout for the update operation.",
+									Optional:    true,
+								},
+								{
+									Name:        "delete",
+									Type:        tftypes.String,
+									Description: "Timeout for the delete operation.",
+									Optional:    true,
+								},
+							},
+						},
+					},
+				},
 				Attributes: []*tfprotov5.SchemaAttribute{
 					{
 						Name:        "manifest",

--- a/manifest/provider/waiter.go
+++ b/manifest/provider/waiter.go
@@ -182,7 +182,7 @@ func (w *FieldWaiter) Wait(ctx context.Context) error {
 			return err
 		}
 
-              // TODO: implement with exponential back-off.
+		// TODO: implement with exponential back-off.
 		time.Sleep(1 * time.Second) // lintignore:R018
 	}
 }

--- a/manifest/provider/waiter.go
+++ b/manifest/provider/waiter.go
@@ -182,6 +182,7 @@ func (w *FieldWaiter) Wait(ctx context.Context) error {
 			return err
 		}
 
+              // TODO: implement with exponential back-off.
 		time.Sleep(1 * time.Second) // lintignore:R018
 	}
 }

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -127,8 +127,23 @@ resource "kubernetes_manifest" "test" {
     }
   }
 }
-
 ```
+
+## Configuring timeouts
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    // ...
+  }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "30s"
+  }
+}
 
 ## Argument Reference
 
@@ -143,3 +158,7 @@ The following arguments are supported:
 #### Arguments
 
 - **fields** (Required) A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use `*` for any value. 
+
+### `timeouts`
+
+See [Operation Timeouts](https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts)


### PR DESCRIPTION
I decided just to redo this feature, based on my previous PRs in the alpha repo, to be an implementation of the `timeouts` block as described here: https://www.terraform.io/docs/extend/resources/retries-and-customizable-timeouts.html

The main thing that's different than the old PRs is that I've used a context with a deadline rather than having the waiter support a timeout parameter. 

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for timeouts block to `kubernetes_manifest` resource
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes-alpha/pull/238
https://github.com/hashicorp/terraform-provider-kubernetes-alpha/pull/237


<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
