### PR TITLE
Update Github Token in stale issue task

### DIFF
--- a/.github/workflows/prune_stale_issues.yml
+++ b/.github/workflows/prune_stale_issues.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/stale@v1.1.0
       with:
-        repo-token: ${{ secrets.k8s_github_actions }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been open 365 days with no activity. If this issue is reproducible with the latest version of the provider and with Terraform 0.12/0.13, please comment. Otherwise this issue will be closed in 30 days.'
         days-before-stale: 365
         days-before-close: 30


### PR DESCRIPTION
### Description
Updates the Github token in the issue pruner to secrets.GITHUB_TOKEN, which is the preferred token for these actions.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
