### PR TITLE
fix kubernetes_job "No waiting" example usage

### DIFF
--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -34,6 +34,7 @@ resource "kubernetes_job" "demo" {
     }
     backoff_limit = 4
   }
+  wait_for_completion = false
 }
 ```
 


### PR DESCRIPTION
`kubernetes_job`'s [`wait_for_completion`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job#wait_for_completion) defaults to `true`. In order to create a `kubernetes_job` without waiting, we have to explicitly set `wait_for_completion` to `false`.