### PR TITLE
Check that resource exists before trying to create

### DIFF
--- a/manifest/test/acceptance/exists_test.go
+++ b/manifest/test/acceptance/exists_test.go
@@ -1,0 +1,54 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKubernetesManifest_alreadyExists(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t,
+			"v1", "configmaps", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "alreadyExists/configmap.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t,
+		"v1", "configmaps", namespace, name)
+
+	// Make a new working dir and apply again
+	tf2 := tfhelper.RequireNewWorkingDir(t)
+	tf2.SetReattachInfo(reattachInfo)
+	tfconfigModified := loadTerraformConfig(t, "alreadyExists/configmap.tf", tfvars)
+	tf2.RequireSetConfig(t, tfconfigModified)
+	err := tf2.Apply()
+
+	if err == nil {
+		t.Fatal("Creating a resource that already exists should cause an error")
+	}
+
+	errMsg := "Error: Cannot create resource that already exists"
+	if err != nil && !strings.Contains(err.Error(), errMsg) {
+		t.Errorf("Expected error to contain %q. Actual error:", errMsg)
+		t.Log(err)
+	}
+}

--- a/manifest/test/acceptance/testdata/alreadyExists/configmap.tf
+++ b/manifest/test/acceptance/testdata/alreadyExists/configmap.tf
@@ -1,0 +1,14 @@
+
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    data = {
+      TEST = "test"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/alreadyExists/variables.tf
+++ b/manifest/test/acceptance/testdata/alreadyExists/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Check that a resource does not exist before creating
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
