### PR TITLE
Fix error when adding list-type attributes during update

### DIFF
--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -285,6 +285,13 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 			// at this point, check if there is a default value in the previous state
 			priorAtrVal, restPath, err := tftypes.WalkAttributePath(priorObj, ap)
 			if err != nil {
+				if len(restPath.Steps()) > 0 {
+					// attribute wasn't present, but part of its parent path is.
+					// just stay on course and use the proposed value.
+					return v, nil
+				}
+				// the entire attribute path is was not found - this should not happen
+				// unless the path is totally foreign to the resource type. Return error.
 				return v, ap.NewError(err)
 			}
 			if len(restPath.Steps()) > 0 {

--- a/manifest/test/acceptance/fix_list_attribute_update_test.go
+++ b/manifest/test/acceptance/fix_list_attribute_update_test.go
@@ -1,0 +1,61 @@
+//go:build acceptance
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestKubernetesManifest_FixListAttributeUpdate(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "apps/v1", "deployments", namespace, name)
+	}()
+
+	tfconfig1 := loadTerraformConfig(t, "FixListAttributeUpdate/step1.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig1)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "apps/v1", "deployments", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":                    namespace,
+		"kubernetes_manifest.test.object.metadata.name":                         name,
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.name":  "ping",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.image": "alpine:latest",
+	})
+
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test.object.spec.template.spec.tolerations")
+
+	tfconfig2 := loadTerraformConfig(t, "FixListAttributeUpdate/step2.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig2)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.spec.template.spec.tolerations")
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.spec.template.spec.tolerations.0.effect":   "NoSchedule",
+		"kubernetes_manifest.test.object.spec.template.spec.tolerations.0.key":      "nvidia.com/gpu",
+		"kubernetes_manifest.test.object.spec.template.spec.tolerations.0.operator": "Exists",
+	})
+}

--- a/manifest/test/acceptance/testdata/FixListAttributeUpdate/step1.tf
+++ b/manifest/test/acceptance/testdata/FixListAttributeUpdate/step1.tf
@@ -1,0 +1,39 @@
+# Reported in https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/251
+#
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        "deployment.kubernetes.io/revision" = "1"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          app = "example"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            app = "example"
+          }
+        }
+        spec = {
+          containers = [
+            {
+              image   = "alpine:latest"
+              name    = "ping"
+              command = ["sh", "-c"]
+              args    = ["ping goo.gl"]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/FixListAttributeUpdate/step2.tf
+++ b/manifest/test/acceptance/testdata/FixListAttributeUpdate/step2.tf
@@ -1,0 +1,47 @@
+# Reported in https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/251
+#
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        "deployment.kubernetes.io/revision" = "2"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          app = "example"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            app = "example"
+          }
+        }
+        spec = {
+          containers = [
+            {
+              image   = "alpine:latest"
+              name    = "ping"
+              command = ["sh", "-c"]
+              args    = ["ping goo.gl"]
+            }
+          ]
+          # causes planning to fail if added after the resource exists
+          tolerations = [
+            {
+              effect   = "NoSchedule"
+              key      = "nvidia.com/gpu"
+              operator = "Exists"
+            },
+          ]
+        }
+      }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/FixListAttributeUpdate/variables.tf
+++ b/manifest/test/acceptance/testdata/FixListAttributeUpdate/variables.tf
@@ -1,0 +1,7 @@
+variable "name" {
+  default = "test-fix-list-update"
+}
+
+variable "namespace" {
+  default = "namespace"
+}


### PR DESCRIPTION
### Description
Resolves issues like the ones described in:
* https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/251
* https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/185
* https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/232#issuecomment-862876220

Before this change, when a list-type attribute was previously nil because of not being set, adding a new value for this attribute and trying to update the manifest would fail with a "...step cannot be applied to this value" error.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* Fix updating list attributes (https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/251)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
