### PR TITLE
Docs for ingress_class_name in kubernetes_ingress

### DIFF
--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -186,6 +186,7 @@ The following arguments are supported:
 * `backend` - (Optional) Backend defines the referenced service endpoint to which the traffic will be forwarded. See `backend` block attributes below.
 * `rule` - (Optional) A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend. See `rule` block attributes below.
 * `tls` - (Optional) TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI. See `tls` block attributes below.
+* `ingress_class_name` - (Optional) The ingress class name references an IngressClass resource that contains additional configuration including the name of the controller that should implement the class.
 
 ### `backend`
 


### PR DESCRIPTION
### Description

Docs update for the ingress resource

### Acceptance tests
- [x] ~~Have you added an acceptance test for the functionality being added?~~
- [x] ~~Have you run the acceptance tests on this branch?~~

Output from acceptance testing:

```
Docs, not tested
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Add docs for ingressClassName as field in Ingress manifest
```

### References
https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
