### PR TITLE
Fixing structure to match with the new networking.k8s.io/v1 Ingress

### DIFF
--- a/kubernetes/data_source_kubernetes_ingress.go
+++ b/kubernetes/data_source_kubernetes_ingress.go
@@ -57,6 +57,11 @@ func dataSourceKubernetesIngress() *schema.Resource {
 																Computed:    true,
 															},
 															"backend": backendSpecFields(ruleBackedDescription),
+															"path_type": {
+																Type:        schema.TypeString,
+																Description: docHTTPIngressPath["pathType"],
+																Computed:    true,
+															},
 														},
 													},
 												},

--- a/kubernetes/data_source_kubernetes_ingress_test.go
+++ b/kubernetes/data_source_kubernetes_ingress_test.go
@@ -24,15 +24,15 @@ func TestAccKubernetesDataSourceIngress_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_ingress.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service_name", "app1"),
-					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service_port", "443"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service.0.name", "app1"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.backend.0.service.0.port.0.number", "443"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.host", "server.domain.com"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.path", "/.*"),
 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service_name", "app2"),
-					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service_port", "80"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.name", "app2"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.port.0.number", "80"),
 				),
 			},
 			{
@@ -45,15 +45,15 @@ func TestAccKubernetesDataSourceIngress_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.kubernetes_ingress.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.backend.#", "1"),
-					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.backend.0.service_name", "app1"),
-					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.backend.0.service_port", "443"),
+					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.backend.0.service.0.name", "app1"),
+					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.backend.0.service.0.port.0.number", "443"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.#", "1"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.host", "server.domain.com"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.#", "1"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.path", "/.*"),
 					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.#", "1"),
-					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service_name", "app2"),
-					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service_port", "80"),
+					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.name", "app2"),
+					resource.TestCheckResourceAttr("data.kubernetes_ingress.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.port.0.number", "80"),
 				),
 			},
 		},
@@ -96,18 +96,27 @@ func testAccKubernetesDataSourceIngressConfig_basic(name string) string {
   }
   spec {
     backend {
-      service_name = "app1"
-      service_port = 443
+      service {
+        name = "app1"
+        port {
+          number = 443
+        }      
+      }
     }
     rule {
       host = "server.domain.com"
       http {
         path {
           backend {
-            service_name = "app2"
-            service_port = 80
+            service {
+              name = "app2"
+              port {
+                number = 80
+              }            
+            }
           }
           path = "/.*"
+          path_type = "ImplementationSpecific"
         }
       }
     }
@@ -178,9 +187,14 @@ resource "kubernetes_ingress" "test" {
         path {
           path = "/*"
           backend {
-            service_name = kubernetes_service.test.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.test.metadata.0.name
+              port {
+                number = 80
+              }            
+            }
           }
+          path_type = "ImplementationSpecific"
         }
       }
     }

--- a/kubernetes/schema_backend_spec.go
+++ b/kubernetes/schema_backend_spec.go
@@ -13,16 +13,39 @@ func backendSpecFields(description string) *schema.Schema {
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"service_name": {
-					Type:        schema.TypeString,
-					Description: "Specifies the name of the referenced service.",
-					Optional:    true,
-				},
-				"service_port": {
-					Type:        schema.TypeString,
-					Description: "Specifies the port of the referenced service.",
-					Computed:    true,
-					Optional:    true,
+				"service": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:        schema.TypeString,
+								Description: "Specifies the name of the referenced service.",
+								Required:    true,
+							},
+							"port": {
+								Type:        schema.TypeList,
+								Description: "Specifies the port of the referenced service.",
+								MaxItems:    1,
+								Required:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"number": {
+											Type:        schema.TypeInt,
+											Description: "Specifies the numerical port of the referenced service.",
+											Optional:    true,
+										},
+										"name": {
+											Type:        schema.TypeInt,
+											Description: "Specifies the name of the port of the referenced service.",
+											Optional:    true,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -2,13 +2,12 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	v1 "k8s.io/api/networking/v1"
 )
 
 // Flatteners
 
-func flattenIngressRule(in []v1beta1.IngressRule) []interface{} {
+func flattenIngressRule(in []v1.IngressRule) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 	for i, r := range in {
 		m := make(map[string]interface{})
@@ -20,15 +19,16 @@ func flattenIngressRule(in []v1beta1.IngressRule) []interface{} {
 	return att
 }
 
-func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
+func flattenIngressRuleHttp(in *v1.HTTPIngressRuleValue) []interface{} {
 	if in == nil {
 		return []interface{}{}
 	}
 	pathAtts := make([]interface{}, len(in.Paths), len(in.Paths))
 	for i, p := range in.Paths {
 		path := map[string]interface{}{
-			"path":    p.Path,
-			"backend": flattenIngressBackend(&p.Backend),
+			"path":      p.Path,
+			"backend":   flattenIngressBackend(&p.Backend),
+			"path_type": string(*p.PathType),
 		}
 		pathAtts[i] = path
 	}
@@ -40,27 +40,44 @@ func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
 	return []interface{}{httpAtt}
 }
 
-func flattenIngressBackend(in *v1beta1.IngressBackend) []interface{} {
+func flattenIngressBackend(in *v1.IngressBackend) []interface{} {
 	att := make([]interface{}, 1, 1)
 
+	p := make(map[string]interface{})
+	if in.Service.Port.Number != 0 {
+		p["number"] = in.Service.Port.Number
+	}
+	if in.Service.Port.Name != "" {
+		p["name"] = in.Service.Port.Name
+	}
+
+	patt := make([]interface{}, 1, 1)
+	patt[0] = p
+
+	s := make(map[string]interface{})
+	s["port"] = patt
+	s["name"] = in.Service.Name
+
+	satt := make([]interface{}, 1, 1)
+	satt[0] = s
+
 	m := make(map[string]interface{})
-	m["service_name"] = in.ServiceName
-	m["service_port"] = in.ServicePort.String()
+	m["service"] = satt
 
 	att[0] = m
 
 	return att
 }
 
-func flattenIngressSpec(in v1beta1.IngressSpec) []interface{} {
+func flattenIngressSpec(in v1.IngressSpec) []interface{} {
 	att := make(map[string]interface{})
 
 	if in.IngressClassName != nil {
 		att["ingress_class_name"] = in.IngressClassName
 	}
 
-	if in.Backend != nil {
-		att["backend"] = flattenIngressBackend(in.Backend)
+	if in.DefaultBackend != nil {
+		att["backend"] = flattenIngressBackend(in.DefaultBackend)
 	}
 
 	if len(in.Rules) > 0 {
@@ -74,7 +91,7 @@ func flattenIngressSpec(in v1beta1.IngressSpec) []interface{} {
 	return []interface{}{att}
 }
 
-func flattenIngressTLS(in []v1beta1.IngressTLS) []interface{} {
+func flattenIngressTLS(in []v1.IngressTLS) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 
 	for i, v := range in {
@@ -90,15 +107,15 @@ func flattenIngressTLS(in []v1beta1.IngressTLS) []interface{} {
 
 // Expanders
 
-func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
+func expandIngressRule(l []interface{}) []v1.IngressRule {
 	if len(l) == 0 || l[0] == nil {
-		return []v1beta1.IngressRule{}
+		return []v1.IngressRule{}
 	}
-	obj := make([]v1beta1.IngressRule, len(l), len(l))
+	obj := make([]v1.IngressRule, len(l), len(l))
 	for i, n := range l {
 		cfg := n.(map[string]interface{})
 
-		var paths []v1beta1.HTTPIngressPath
+		var paths []v1.HTTPIngressPath
 
 		if httpCfg, ok := cfg["http"]; ok {
 			httpList := httpCfg.([]interface{})
@@ -106,12 +123,14 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 				http := h.(map[string]interface{})
 				if v, ok := http["path"]; ok {
 					pathList := v.([]interface{})
-					paths = make([]v1beta1.HTTPIngressPath, len(pathList), len(pathList))
+					paths = make([]v1.HTTPIngressPath, len(pathList), len(pathList))
 					for i, path := range pathList {
 						p := path.(map[string]interface{})
-						hip := v1beta1.HTTPIngressPath{
-							Path:    p["path"].(string),
-							Backend: *expandIngressBackend(p["backend"].([]interface{})),
+						pathType := v1.PathType(p["path_type"].(string))
+						hip := v1.HTTPIngressPath{
+							Path:     p["path"].(string),
+							Backend:  *expandIngressBackend(p["backend"].([]interface{})),
+							PathType: &pathType,
 						}
 						paths[i] = hip
 					}
@@ -119,10 +138,10 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 			}
 		}
 
-		obj[i] = v1beta1.IngressRule{
+		obj[i] = v1.IngressRule{
 			Host: cfg["host"].(string),
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: &v1beta1.HTTPIngressRuleValue{
+			IngressRuleValue: v1.IngressRuleValue{
+				HTTP: &v1.HTTPIngressRuleValue{
 					Paths: paths,
 				},
 			},
@@ -131,19 +150,19 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 	return obj
 }
 
-func expandIngressSpec(l []interface{}) v1beta1.IngressSpec {
+func expandIngressSpec(l []interface{}) v1.IngressSpec {
 	if len(l) == 0 || l[0] == nil {
-		return v1beta1.IngressSpec{}
+		return v1.IngressSpec{}
 	}
 	in := l[0].(map[string]interface{})
-	obj := v1beta1.IngressSpec{}
+	obj := v1.IngressSpec{}
 
 	if v, ok := in["ingress_class_name"].(string); ok && len(v) > 0 {
 		obj.IngressClassName = &v
 	}
 
 	if v, ok := in["backend"].([]interface{}); ok && len(v) > 0 {
-		obj.Backend = expandIngressBackend(v)
+		obj.DefaultBackend = expandIngressBackend(v)
 	}
 
 	if v, ok := in["rule"].([]interface{}); ok && len(v) > 0 {
@@ -157,33 +176,49 @@ func expandIngressSpec(l []interface{}) v1beta1.IngressSpec {
 	return obj
 }
 
-func expandIngressBackend(l []interface{}) *v1beta1.IngressBackend {
+func expandIngressBackend(l []interface{}) *v1.IngressBackend {
 	if len(l) == 0 || l[0] == nil {
-		return &v1beta1.IngressBackend{}
+		return &v1.IngressBackend{}
 	}
 	in := l[0].(map[string]interface{})
-	obj := &v1beta1.IngressBackend{}
+	obj := &v1.IngressBackend{}
 
-	if v, ok := in["service_name"].(string); ok {
-		obj.ServiceName = v
+	l, ok := in["service"].([]interface{})
+	if !ok || len(l) == 0 || l[0] == nil {
+		return &v1.IngressBackend{}
+	}
+	in = l[0].(map[string]interface{})
+	obj.Service = &v1.IngressServiceBackend{}
+
+	if v, ok := in["name"].(string); ok {
+		obj.Service.Name = v
 	}
 
-	if v, ok := in["service_port"].(string); ok {
-		obj.ServicePort = intstr.Parse(v)
+	l, ok = in["port"].([]interface{})
+	if !ok || len(l) == 0 || l[0] == nil {
+		return obj
+	}
+	in = l[0].(map[string]interface{})
+
+	if v, ok := in["number"].(int); ok {
+		obj.Service.Port.Number = int32(v)
+	}
+	if v, ok := in["name"].(string); ok {
+		obj.Service.Port.Name = v
 	}
 
 	return obj
 }
 
-func expandIngressTLS(l []interface{}) []v1beta1.IngressTLS {
+func expandIngressTLS(l []interface{}) []v1.IngressTLS {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tlsList := make([]v1beta1.IngressTLS, len(l), len(l))
+	tlsList := make([]v1.IngressTLS, len(l), len(l))
 	for i, t := range l {
 		in := t.(map[string]interface{})
-		obj := v1beta1.IngressTLS{}
+		obj := v1.IngressTLS{}
 
 		if v, ok := in["hosts"]; ok {
 			obj.Hosts = expandStringSlice(v.([]interface{}))

--- a/kubernetes/structure_ingress_spec_test.go
+++ b/kubernetes/structure_ingress_spec_test.go
@@ -1,38 +1,43 @@
 package kubernetes
 
 import (
+	v1 "k8s.io/api/networking/v1"
 	"reflect"
 	"testing"
-
-	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Test Flatteners
 func TestFlattenIngressRule(t *testing.T) {
-	r := v1beta1.HTTPIngressRuleValue{
-		Paths: []v1beta1.HTTPIngressPath{
+	pathType := v1.PathTypeImplementationSpecific
+
+	r := v1.HTTPIngressRuleValue{
+		Paths: []v1.HTTPIngressPath{
 			{
 				Path: "/foo/bar",
-				Backend: v1beta1.IngressBackend{
-					ServiceName: "foo",
-					ServicePort: intstr.FromInt(1234),
+				Backend: v1.IngressBackend{
+					Service: &v1.IngressServiceBackend{
+						Name: "foo",
+						Port: v1.ServiceBackendPort{
+							Number: 1234,
+						},
+					},
 				},
+				PathType: &pathType,
 			},
 		},
 	}
 
-	in := []v1beta1.IngressRule{
+	in := []v1.IngressRule{
 		{
 			Host: "the-app-name.staging.live.domain-replaced.tld",
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: (*v1beta1.HTTPIngressRuleValue)(nil),
+			IngressRuleValue: v1.IngressRuleValue{
+				HTTP: (*v1.HTTPIngressRuleValue)(nil),
 			},
 		},
 		{
 			Host: "",
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: (*v1beta1.HTTPIngressRuleValue)(&r),
+			IngressRuleValue: v1.IngressRuleValue{
+				HTTP: (*v1.HTTPIngressRuleValue)(&r),
 			},
 		},
 	}
@@ -50,10 +55,19 @@ func TestFlattenIngressRule(t *testing.T) {
 							"path": "/foo/bar",
 							"backend": []interface{}{
 								map[string]interface{}{
-									"service_name": "foo",
-									"service_port": "1234",
+									"service": []interface{}{
+										map[string]interface{}{
+											"name": "foo",
+											"port": []interface{}{
+												map[string]interface{}{
+													"number": int32(1234),
+												},
+											},
+										},
+									},
 								},
 							},
+							"path_type": "ImplementationSpecific",
 						},
 					},
 				},

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -192,8 +192,21 @@ The following arguments are supported:
 
 #### Arguments
 
-* `service_name` - (Optional) Specifies the name of the referenced service.
-* `service_port` - (Optional) Specifies the port of the referenced service.
+* `service` - (Optional) Specifies the referenced service.
+
+### `service`
+
+#### Arguments
+
+* `name` - (Required) Specifies the name of the referenced service
+* `port` - (Required) Specifies the port name or number of the referenced service
+
+### `port`
+
+#### Arguments
+
+* `number` - (Optional) Specifies the port number of the referenced service
+* `name` - (Optional) Specifies the port name of the referenced service.
 
 ### `rule`
 
@@ -211,6 +224,7 @@ The following arguments are supported:
 
 * `path` - (Required)  A string or an extended POSIX regular expression as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
 * `backend` - (Required) Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+* `path_type` - (Optional) PathType determines the interpretation of the Path matching. PathType can be one of the following values: `ImplementationSpecific`, `Prefix`, and `Exact`. Default value is `ImplementationSpecific`.
 
 ### `tls`
 


### PR DESCRIPTION
### Description

- Change service_name/service_port to service.name/service.port.number
- Correct tests due to the changes


<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=-run=TestAccKubernetes\(DataSource\)?Ingress_.*'
=== RUN   TestAccKubernetesDataSourceIngress_basic
--- PASS: TestAccKubernetesDataSourceIngress_basic (3.48s)
=== RUN   TestAccKubernetesDataSourceIngress_regression
    provider_test.go:280: The Kubernetes endpoint must come from EKS for this test to run - skipping
--- SKIP: TestAccKubernetesDataSourceIngress_regression (0.00s)
=== RUN   TestAccKubernetesIngress_basic
--- PASS: TestAccKubernetesIngress_basic (3.85s)
=== RUN   TestAccKubernetesIngress_TLS
--- PASS: TestAccKubernetesIngress_TLS (3.93s)
=== RUN   TestAccKubernetesIngress_InternalKey
--- PASS: TestAccKubernetesIngress_InternalKey (5.58s)
=== RUN   TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud
    provider_test.go:252: The Kubernetes endpoint must come from GKE for this test to run - skipping
--- SKIP: TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud (0.00s)
=== RUN   TestAccKubernetesIngress_stateUpgradeV0_loadBalancerIngress
    provider_test.go:280: The Kubernetes endpoint must come from EKS for this test to run - skipping
--- SKIP: TestAccKubernetesIngress_stateUpgradeV0_loadBalancerIngress (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   16.892s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix kubernetes_ingress resource to utilize the new networking.k8s.io/v1 Ingress resource (and added features)
```

### References
#1386
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
