### PR TITLE
Upgrades Ingress from extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -6,11 +6,10 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	networking "k8s.io/api/networking/v1beta1"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,12 +37,12 @@ func resourceKubernetesIngress() *schema.Resource {
 }
 
 func resourceKubernetesIngressSchemaV1() map[string]*schema.Schema {
-	docHTTPIngressPath := networking.HTTPIngressPath{}.SwaggerDoc()
-	docHTTPIngressRuleValue := networking.HTTPIngressPath{}.SwaggerDoc()
-	docIngress := networking.Ingress{}.SwaggerDoc()
-	docIngressTLS := networking.IngressTLS{}.SwaggerDoc()
-	docIngressRule := networking.IngressRule{}.SwaggerDoc()
-	docIngressSpec := networking.IngressSpec{}.SwaggerDoc()
+	docHTTPIngressPath := v1.HTTPIngressPath{}.SwaggerDoc()
+	docHTTPIngressRuleValue := v1.HTTPIngressPath{}.SwaggerDoc()
+	docIngress := v1.Ingress{}.SwaggerDoc()
+	docIngressTLS := v1.IngressTLS{}.SwaggerDoc()
+	docIngressRule := v1.IngressRule{}.SwaggerDoc()
+	docIngressSpec := v1.IngressSpec{}.SwaggerDoc()
 
 	return map[string]*schema.Schema{
 		"metadata": namespacedMetadataSchema("ingress", true),
@@ -85,9 +84,14 @@ func resourceKubernetesIngressSchemaV1() map[string]*schema.Schema {
 												Elem: &schema.Resource{
 													Schema: map[string]*schema.Schema{
 														"path": {
+															Required:    true,
 															Type:        schema.TypeString,
 															Description: docHTTPIngressPath["path"],
-															Optional:    true,
+														},
+														"path_type": {
+															Required:    true,
+															Type:        schema.TypeString,
+															Description: docHTTPIngressPath["path_type"],
 														},
 														"backend": backendSpecFields(ruleBackedDescription),
 													},
@@ -169,12 +173,12 @@ func resourceKubernetesIngressCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	ing := &v1beta1.Ingress{
+	ing := &v1.Ingress{
 		Spec: expandIngressSpec(d.Get("spec").([]interface{})),
 	}
 	ing.ObjectMeta = metadata
 	log.Printf("[INFO] Creating new ingress: %#v", ing)
-	out, err := conn.ExtensionsV1beta1().Ingresses(metadata.Namespace).Create(ctx, ing, metav1.CreateOptions{})
+	out, err := conn.NetworkingV1().Ingresses(metadata.Namespace).Create(ctx, ing, metav1.CreateOptions{})
 	if err != nil {
 		return diag.Errorf("Failed to create Ingress '%s' because: %s", buildId(ing.ObjectMeta), err)
 	}
@@ -187,7 +191,7 @@ func resourceKubernetesIngressCreate(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] Waiting for load balancer to become ready: %#v", out)
 	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		res, err := conn.ExtensionsV1beta1().Ingresses(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})
+		res, err := conn.NetworkingV1().Ingresses(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})
 		if err != nil {
 			// NOTE it is possible in some HA apiserver setups that are eventually consistent
 			// that we could get a 404 when doing a Get immediately after a Create
@@ -235,7 +239,7 @@ func resourceKubernetesIngressRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Reading ingress %s", name)
-	ing, err := conn.ExtensionsV1beta1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
+	ing, err := conn.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return diag.Errorf("Failed to read Ingress '%s' because: %s", buildId(ing.ObjectMeta), err)
@@ -283,12 +287,12 @@ func resourceKubernetesIngressUpdate(ctx context.Context, d *schema.ResourceData
 		metadata.Namespace = "default"
 	}
 
-	ingress := &v1beta1.Ingress{
+	ingress := &v1.Ingress{
 		ObjectMeta: metadata,
 		Spec:       spec,
 	}
 
-	out, err := conn.ExtensionsV1beta1().Ingresses(namespace).Update(ctx, ingress, metav1.UpdateOptions{})
+	out, err := conn.NetworkingV1().Ingresses(namespace).Update(ctx, ingress, metav1.UpdateOptions{})
 	if err != nil {
 		return diag.Errorf("Failed to update Ingress %s because: %s", buildId(ingress.ObjectMeta), err)
 	}
@@ -309,13 +313,13 @@ func resourceKubernetesIngressDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[INFO] Deleting ingress: %#v", name)
-	err = conn.ExtensionsV1beta1().Ingresses(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	err = conn.NetworkingV1().Ingresses(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		return diag.Errorf("Failed to delete Ingress %s because: %s", d.Id(), err)
 	}
 
 	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		_, err := conn.ExtensionsV1beta1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
+		_, err := conn.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
 				return nil
@@ -348,7 +352,7 @@ func resourceKubernetesIngressExists(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[INFO] Checking ingress %s", name)
-	_, err = conn.ExtensionsV1beta1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
+	_, err = conn.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
 			return false, nil

--- a/kubernetes/schema_backend_spec.go
+++ b/kubernetes/schema_backend_spec.go
@@ -13,16 +13,41 @@ func backendSpecFields(description string) *schema.Schema {
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"service_name": {
-					Type:        schema.TypeString,
+				"service": {
+					Type:        schema.TypeList,
 					Description: "Specifies the name of the referenced service.",
 					Optional:    true,
-				},
-				"service_port": {
-					Type:        schema.TypeString,
-					Description: "Specifies the port of the referenced service.",
-					Computed:    true,
-					Optional:    true,
+					MaxItems:    1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:        schema.TypeString,
+								Description: "Specifies the name of the referenced service.",
+								Optional:    true,
+							},
+							"port": {
+								Type:        schema.TypeList,
+								Description: "Specifies the port of the referenced service.",
+								Computed:    true,
+								Optional:    true,
+								MaxItems:    1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"name": {
+											Type:        schema.TypeString,
+											Description: "Specifies the port name",
+											Optional:    true,
+										},
+										"port_number": {
+											Type:        schema.TypeString,
+											Description: "Specifies the port number",
+											Optional:    true,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -1,14 +1,15 @@
 package kubernetes
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/api/networking/v1"
+	"strconv"
 )
 
 // Flatteners
 
-func flattenIngressRule(in []v1beta1.IngressRule) []interface{} {
+func flattenIngressRule(in []v1.IngressRule) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 	for i, r := range in {
 		m := make(map[string]interface{})
@@ -20,15 +21,24 @@ func flattenIngressRule(in []v1beta1.IngressRule) []interface{} {
 	return att
 }
 
-func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
+func flattenIngressRuleHttp(in *v1.HTTPIngressRuleValue) []interface{} {
 	if in == nil {
 		return []interface{}{}
 	}
 	pathAtts := make([]interface{}, len(in.Paths), len(in.Paths))
 	for i, p := range in.Paths {
+		pathType := ""
+		if *p.PathType == v1.PathTypeExact {
+			pathType = "Exact"
+		} else if *p.PathType == v1.PathTypePrefix {
+			pathType = "Prefix"
+		} else if *p.PathType == v1.PathTypeImplementationSpecific {
+			pathType = "ImplementationSpecific"
+		}
 		path := map[string]interface{}{
-			"path":    p.Path,
-			"backend": flattenIngressBackend(&p.Backend),
+			"path":      p.Path,
+			"path_type": pathType,
+			"backend":   flattenIngressBackend(&p.Backend),
 		}
 		pathAtts[i] = path
 	}
@@ -40,27 +50,40 @@ func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
 	return []interface{}{httpAtt}
 }
 
-func flattenIngressBackend(in *v1beta1.IngressBackend) []interface{} {
+func flattenIngressBackend(in *v1.IngressBackend) []interface{} {
 	att := make([]interface{}, 1, 1)
+	srv := make(map[string]interface{})
+	mAttrs := make([]interface{}, 1, 1)
 
 	m := make(map[string]interface{})
-	m["service_name"] = in.ServiceName
-	m["service_port"] = in.ServicePort.String()
+	m["name"] = in.Service.Name
+	portAtts := make([]interface{}, 1, 1)
+	port := make(map[string]interface{})
+	if in.Service.Port.Name != "" {
+		port["name"] = in.Service.Port.Name
+	}
+	if in.Service.Port.Number != 0 {
+		port["port_number"] = fmt.Sprint(in.Service.Port.Number)
+	}
 
-	att[0] = m
+	portAtts[0] = port
+	m["port"] = portAtts
+	mAttrs[0] = m
+	srv["service"] = mAttrs
+	att[0] = srv
 
 	return att
 }
 
-func flattenIngressSpec(in v1beta1.IngressSpec) []interface{} {
+func flattenIngressSpec(in v1.IngressSpec) []interface{} {
 	att := make(map[string]interface{})
 
 	if in.IngressClassName != nil {
 		att["ingress_class_name"] = in.IngressClassName
 	}
 
-	if in.Backend != nil {
-		att["backend"] = flattenIngressBackend(in.Backend)
+	if in.DefaultBackend != nil {
+		att["backend"] = flattenIngressBackend(in.DefaultBackend)
 	}
 
 	if len(in.Rules) > 0 {
@@ -74,7 +97,7 @@ func flattenIngressSpec(in v1beta1.IngressSpec) []interface{} {
 	return []interface{}{att}
 }
 
-func flattenIngressTLS(in []v1beta1.IngressTLS) []interface{} {
+func flattenIngressTLS(in []v1.IngressTLS) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 
 	for i, v := range in {
@@ -90,15 +113,15 @@ func flattenIngressTLS(in []v1beta1.IngressTLS) []interface{} {
 
 // Expanders
 
-func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
+func expandIngressRule(l []interface{}) []v1.IngressRule {
 	if len(l) == 0 || l[0] == nil {
-		return []v1beta1.IngressRule{}
+		return []v1.IngressRule{}
 	}
-	obj := make([]v1beta1.IngressRule, len(l), len(l))
+	obj := make([]v1.IngressRule, len(l), len(l))
 	for i, n := range l {
 		cfg := n.(map[string]interface{})
 
-		var paths []v1beta1.HTTPIngressPath
+		var paths []v1.HTTPIngressPath
 
 		if httpCfg, ok := cfg["http"]; ok {
 			httpList := httpCfg.([]interface{})
@@ -106,12 +129,14 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 				http := h.(map[string]interface{})
 				if v, ok := http["path"]; ok {
 					pathList := v.([]interface{})
-					paths = make([]v1beta1.HTTPIngressPath, len(pathList), len(pathList))
+					paths = make([]v1.HTTPIngressPath, len(pathList), len(pathList))
 					for i, path := range pathList {
 						p := path.(map[string]interface{})
-						hip := v1beta1.HTTPIngressPath{
-							Path:    p["path"].(string),
-							Backend: *expandIngressBackend(p["backend"].([]interface{})),
+						pathType := v1.PathType(p["path_type"].(string))
+						hip := v1.HTTPIngressPath{
+							Path:     p["path"].(string),
+							PathType: &pathType,
+							Backend:  *expandIngressBackend(p["backend"].([]interface{})),
 						}
 						paths[i] = hip
 					}
@@ -119,10 +144,10 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 			}
 		}
 
-		obj[i] = v1beta1.IngressRule{
+		obj[i] = v1.IngressRule{
 			Host: cfg["host"].(string),
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: &v1beta1.HTTPIngressRuleValue{
+			IngressRuleValue: v1.IngressRuleValue{
+				HTTP: &v1.HTTPIngressRuleValue{
 					Paths: paths,
 				},
 			},
@@ -131,19 +156,19 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 	return obj
 }
 
-func expandIngressSpec(l []interface{}) v1beta1.IngressSpec {
+func expandIngressSpec(l []interface{}) v1.IngressSpec {
 	if len(l) == 0 || l[0] == nil {
-		return v1beta1.IngressSpec{}
+		return v1.IngressSpec{}
 	}
 	in := l[0].(map[string]interface{})
-	obj := v1beta1.IngressSpec{}
+	obj := v1.IngressSpec{}
 
 	if v, ok := in["ingress_class_name"].(string); ok && len(v) > 0 {
 		obj.IngressClassName = &v
 	}
 
 	if v, ok := in["backend"].([]interface{}); ok && len(v) > 0 {
-		obj.Backend = expandIngressBackend(v)
+		obj.DefaultBackend = expandIngressBackend(v)
 	}
 
 	if v, ok := in["rule"].([]interface{}); ok && len(v) > 0 {
@@ -157,33 +182,50 @@ func expandIngressSpec(l []interface{}) v1beta1.IngressSpec {
 	return obj
 }
 
-func expandIngressBackend(l []interface{}) *v1beta1.IngressBackend {
+func expandIngressBackend(l []interface{}) *v1.IngressBackend {
 	if len(l) == 0 || l[0] == nil {
-		return &v1beta1.IngressBackend{}
+		return &v1.IngressBackend{}
 	}
 	in := l[0].(map[string]interface{})
-	obj := &v1beta1.IngressBackend{}
-
-	if v, ok := in["service_name"].(string); ok {
-		obj.ServiceName = v
+	obj := &v1.IngressBackend{
+		Service: &v1.IngressServiceBackend{
+			Port: v1.ServiceBackendPort{},
+		},
 	}
+	services := in["service"].([]interface{})
+	for _, t := range services {
+		service := t.(map[string]interface{})
+		if v, ok := service["name"].(string); ok {
+			obj.Service.Name = v
+		}
 
-	if v, ok := in["service_port"].(string); ok {
-		obj.ServicePort = intstr.Parse(v)
+		ports := service["port"].([]interface{})
+		for _, p := range ports {
+			port := p.(map[string]interface{})
+			if v, ok := port["port_number"].(string); ok {
+				port, _ := strconv.ParseInt(v, 10, 8)
+				obj.Service.Port.Number = int32(port)
+			}
+
+			if v, ok := port["name"].(string); ok {
+				obj.Service.Port.Name = v
+			}
+		}
+
 	}
 
 	return obj
 }
 
-func expandIngressTLS(l []interface{}) []v1beta1.IngressTLS {
+func expandIngressTLS(l []interface{}) []v1.IngressTLS {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tlsList := make([]v1beta1.IngressTLS, len(l), len(l))
+	tlsList := make([]v1.IngressTLS, len(l), len(l))
 	for i, t := range l {
 		in := t.(map[string]interface{})
-		obj := v1beta1.IngressTLS{}
+		obj := v1.IngressTLS{}
 
 		if v, ok := in["hosts"]; ok {
 			obj.Hosts = expandStringSlice(v.([]interface{}))

--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -203,7 +203,7 @@ func expandIngressBackend(l []interface{}) *v1.IngressBackend {
 		for _, p := range ports {
 			port := p.(map[string]interface{})
 			if v, ok := port["port_number"].(string); ok {
-				port, _ := strconv.ParseInt(v, 10, 8)
+				port, _ := strconv.ParseInt(v, 10, 32)
 				obj.Service.Port.Number = int32(port)
 			}
 

--- a/kubernetes/structure_ingress_spec_test.go
+++ b/kubernetes/structure_ingress_spec_test.go
@@ -4,35 +4,40 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/api/networking/v1"
 )
 
 // Test Flatteners
 func TestFlattenIngressRule(t *testing.T) {
-	r := v1beta1.HTTPIngressRuleValue{
-		Paths: []v1beta1.HTTPIngressPath{
+	pathType := v1.PathTypeExact
+	r := v1.HTTPIngressRuleValue{
+		Paths: []v1.HTTPIngressPath{
 			{
-				Path: "/foo/bar",
-				Backend: v1beta1.IngressBackend{
-					ServiceName: "foo",
-					ServicePort: intstr.FromInt(1234),
+				Path:     "/foo/bar",
+				PathType: &pathType,
+				Backend: v1.IngressBackend{
+					Service: &v1.IngressServiceBackend{
+						Name: "foo",
+						Port: v1.ServiceBackendPort{
+							Number: 1234,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	in := []v1beta1.IngressRule{
+	in := []v1.IngressRule{
 		{
 			Host: "the-app-name.staging.live.domain-replaced.tld",
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: (*v1beta1.HTTPIngressRuleValue)(nil),
+			IngressRuleValue: v1.IngressRuleValue{
+				HTTP: (*v1.HTTPIngressRuleValue)(nil),
 			},
 		},
 		{
 			Host: "",
-			IngressRuleValue: v1beta1.IngressRuleValue{
-				HTTP: (*v1beta1.HTTPIngressRuleValue)(&r),
+			IngressRuleValue: v1.IngressRuleValue{
+				HTTP: (*v1.HTTPIngressRuleValue)(&r),
 			},
 		},
 	}
@@ -47,11 +52,20 @@ func TestFlattenIngressRule(t *testing.T) {
 				map[string]interface{}{
 					"path": []interface{}{
 						map[string]interface{}{
-							"path": "/foo/bar",
+							"path":      "/foo/bar",
+							"path_type": "Exact",
 							"backend": []interface{}{
 								map[string]interface{}{
-									"service_name": "foo",
-									"service_port": "1234",
+									"service": []interface{}{
+										map[string]interface{}{
+											"name": "foo",
+											"port": []interface{}{
+												map[string]interface{}{
+													"port_number": "1234",
+												},
+											},
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
### Description
Changes ApiGroup for Ingress from extensions/v1beta1 to networking.k8s.io/v1. Includes breaking schema changes. Includes `PathType` and named ports. Thankful for feedback on how to improve code, especially `flattenIngressBackend` as my go is very rusty.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
#1386 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
