### PR TITLE
Add build matrix for multiple k8s versions

### DIFF
--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -15,10 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        kubernetes_version:
+          # NOTE exact sha for image is required for kind
+          - v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          - v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+          # FIXME this is disabled for now as there is a regression in v1.19.11
+          # and there is no image available for the latest v1.19.x
+          # - v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
         terraform_version:
-          - "0.14.10"
-          - "0.15.5"
-          - "1.0.3"
+          - 1.0.8
+          - 0.15.5
+          - 0.14.11
     steps:
       - uses: actions/checkout@v2
       - name: Read go-version
@@ -32,7 +39,8 @@ jobs:
           go-version: ${{ steps.go-version.outputs.content }}
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.11.1"
+          version: v0.11.1
+          image: kindest/node:${{ matrix.kubernetes_version }}
       - name: Build annotations webhook
         run: |
           docker build --rm -t tf-k8s-acc-webhook ./manifest/test/acceptance/testdata/ComputedFields/webhook/

--- a/manifest/test/acceptance/wait_for_test.go
+++ b/manifest/test/acceptance/wait_for_test.go
@@ -3,7 +3,6 @@
 package acceptance
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -12,10 +11,6 @@ import (
 )
 
 func TestKubernetesManifest_WaitForFields_Pod(t *testing.T) {
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		t.Skip("skipping this test for now as it is broken inside GitHub actions") // FIXME
-	}
-
 	name := randName()
 	namespace := randName()
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] ~Have you added an acceptance test for the functionality being added?~
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
