### PR TITLE
Fix failing unit test for parseImportID

### DIFF
--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -187,7 +187,12 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 // Example: "apiVersion=v1,kind=Secret,namespace=default,name=default-token-qgm6s"
 //
 func parseImportID(id string) (gvk schema.GroupVersionKind, name string, namespace string, err error) {
-	tokens := map[string]string{"apiVersion": "", "kind": "", "name": "", "namespace": "default"}
+	tokens := map[string]string{
+		"apiVersion": "",
+		"kind":       "",
+		"name":       "",
+		"namespace":  "default", // FIXME we should check if the kind is namespaced or not
+	}
 	var invalidFormat bool = false
 
 	parts := strings.Split(id, ",")

--- a/manifest/provider/import_test.go
+++ b/manifest/provider/import_test.go
@@ -26,7 +26,7 @@ func TestParseImportID(t *testing.T) {
 			ID:        "apiVersion=rbac.authorization.k8s.io/v1,kind=ClusterRole,name=test",
 			GVK:       schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
 			Name:      "test",
-			Namespace: "",
+			Namespace: "default",
 			Err:       nil,
 		},
 		{
@@ -50,15 +50,15 @@ func TestParseImportID(t *testing.T) {
 			t.Fatal(actualErr.Error())
 		}
 		if expected.GVK != actualGvk {
-			t.Log("GVK (actual / wanted):", actualGvk, expected.GVK)
+			t.Logf("GVK did not match. actual: %q  expected: %q.", actualGvk, expected.GVK)
 			t.Fail()
 		}
 		if expected.Name != actualName {
-			t.Log("Name (actual / wanted):", actualName, expected.Name)
+			t.Logf("Name did not match. actual: %q  expected: %q.", actualName, expected.Name)
 			t.Fail()
 		}
 		if expected.Namespace != actualNamespace {
-			t.Log("Namespace (actual / wanted):", actualNamespace, expected.Namespace)
+			t.Logf("Namespace did not match. actual: %q  expected: %q.", actualNamespace, expected.Namespace)
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
### Description

This unit test was failing because parseImportID will set namespace to default if it's not present. We would have to check if the kind was a namespaced resource to figure out if we should omit it or not. AFAIK namespace should just get ignored for non-namespaced resources so this should be fine for now. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
