### PR TITLE
Fix CRD metadata

### DIFF
--- a/manifest/provider/resource.go
+++ b/manifest/provider/resource.go
@@ -129,13 +129,11 @@ func (ps *RawProviderServer) TFTypeFromOpenAPI(ctx context.Context, gvk schema.G
 		if _, ok := atts["kind"]; !ok {
 			atts["kind"] = tftypes.String
 		}
-		if _, ok := atts["metadata"]; !ok {
-			metaType, err := oapi.GetTypeByGVK(openapi.ObjectMetaGVK)
-			if err != nil {
-				return nil, fmt.Errorf("failed to generate tftypes for v1.ObjectMeta: %s", err)
-			}
-			atts["metadata"] = metaType.(tftypes.Object)
+		metaType, err := oapi.GetTypeByGVK(openapi.ObjectMetaGVK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate tftypes for v1.ObjectMeta: %s", err)
 		}
+		atts["metadata"] = metaType.(tftypes.Object)
 
 		tsch = tftypes.Object{AttributeTypes: atts}
 	}

--- a/manifest/test/acceptance/customresourcedefinition_oapi3_metadata_test.go
+++ b/manifest/test/acceptance/customresourcedefinition_oapi3_metadata_test.go
@@ -1,0 +1,176 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestKubernetesManifest_CustomResource_OAPIv3_metadata(t *testing.T) {
+	kind := strings.Title(randString(8))
+	plural := strings.ToLower(kind) + "s"
+	group := "terraform.io"
+	version := "v1"
+	groupVersion := group + "/" + version
+	crd := fmt.Sprintf("%s.%s", plural, group)
+
+	name := strings.ToLower(randName())
+	namespace := "default" //randName()
+
+	tfvars := TFVARS{
+		"name":          name,
+		"namespace":     namespace,
+		"kind":          kind,
+		"plural":        plural,
+		"group":         group,
+		"group_version": groupVersion,
+		"cr_version":    version,
+	}
+
+	step1 := tfhelper.RequireNewWorkingDir(t)
+	step1.SetReattachInfo(reattachInfo)
+	defer func() {
+		step1.RequireDestroy(t)
+		step1.Close()
+		k8shelper.AssertResourceDoesNotExist(t, "apiextensions.k8s.io/v1", "customresourcedefinitions", crd)
+	}()
+
+	// Step 1: Create a structural CRD with a fairly complex schema
+	// (inspired by the Prostgres Operator)
+	tfconfig := loadTerraformConfig(t, "CustomResourceOAPI3-metadata/custom_resource_definition.tf", tfvars)
+	step1.RequireSetConfig(t, string(tfconfig))
+	step1.RequireInit(t)
+	step1.RequireApply(t)
+	k8shelper.AssertResourceExists(t, "apiextensions.k8s.io/v1", "customresourcedefinitions", crd)
+
+	// wait for API to finish ingesting the CRD
+	time.Sleep(5 * time.Second) //lintignore:R018
+
+	reattachInfo2, err := provider.ServeTest(context.Background(), hclog.Default())
+	if err != nil {
+		t.Errorf("Failed to create additional provider instance: %q", err)
+	}
+	step2 := tfhelper.RequireNewWorkingDir(t)
+	step2.SetReattachInfo(reattachInfo2)
+	defer func() {
+		step2.RequireDestroy(t)
+		step2.Close()
+		k8shelper.AssertResourceDoesNotExist(t, groupVersion, kind, name)
+	}()
+
+	// Step 2: create a CR of the type defined by the CRD above
+	tfconfig = loadTerraformConfig(t, "CustomResourceOAPI3-metadata/custom_resource.tf", tfvars)
+	step2.RequireSetConfig(t, string(tfconfig))
+	step2.RequireInit(t)
+	step2.RequireApply(t)
+
+	tfstate := tfstatehelper.NewHelper(step2.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test_cr.object.metadata.name":           name,
+		"kubernetes_manifest.test_cr.object.metadata.namespace":      namespace,
+		"kubernetes_manifest.test_cr.object.spec.teamId":             "test",
+		"kubernetes_manifest.test_cr.object.spec.volume.size":        "1Gi",
+		"kubernetes_manifest.test_cr.object.spec.users.foo_user":     []interface{}{"superuser"},
+		"kubernetes_manifest.test_cr.object.spec.users.bar_user":     []interface{}{},
+		"kubernetes_manifest.test_cr.object.spec.users.mike":         []interface{}{"superuser", "createdb"},
+		"kubernetes_manifest.test_cr.object.spec.numberOfInstances":  json.Number("2"),
+		"kubernetes_manifest.test_cr.object.spec.databases.foo":      "devdb",
+		"kubernetes_manifest.test_cr.object.spec.postgresql.version": "12",
+	})
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.additionalVolumes")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.allowedSourceRanges")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.cluster")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.s3_access_key_id")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.s3_endpoint")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.s3_force_path_style")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.s3_secret_access_key")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.s3_wal_path")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.timestamp")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.clone.uid")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.dockerImage")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.maxDBConnections")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.mode")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.numberOfInstances")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.schema")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.user")
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.connectionPooler.resources")
+
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.dockerImage")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.enableConnectionPooler")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.enableLogicalBackup")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.enableMasterLoadBalancer")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.enableReplicaConnectionPooler")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.enableReplicaLoadBalancer")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.enableShmVolume")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.initContainers")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.init_containers")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.logicalBackupSchedule")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.maintenanceWindows")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.nodeAffinity")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution")
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.initdb")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.loop_wait")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.maximum_lag_on_failover")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.pg_hba")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.retry_timeout")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.slots")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.synchronous_mode")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.synchronous_mode_strict")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.patroni.ttl")
+
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.podAnnotations")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.podPriorityClassName")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.pod_priority_class_name")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.postgresql")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.postgresql.parameters")
+
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.preparedDatabases")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.replicaLoadBalancer")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources")
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources.limits")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources.limits.cpu")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources.limits.memory")
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources.requests")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources.requests.cpu")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.resources.requests.memory")
+
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.schedulerName")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.serviceAnnotations")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.sidecars")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.spiloFSGroup")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.spiloRunAsGroup")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.spiloRunAsUser")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.standby")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.standby.s3_wal_path")
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test_cr.object.spec.tls")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.tls.caFile")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.tls.caSecretName")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.tls.certificateFile")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.tls.privateKeyFile")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.tls.secretName")
+
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.tolerations")
+	tfstate.AssertAttributeEmpty(t, "kubernetes_manifest.test_cr.object.spec.useLoadBalancer")
+
+}

--- a/manifest/test/acceptance/testdata/CustomResourceOAPI3-metadata/custom_resource.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceOAPI3-metadata/custom_resource.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_manifest" "test_cr" {
+
+  manifest = {
+    apiVersion = "${var.group}/${var.cr_version}"
+    kind       = var.kind
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      teamId = "test"
+      volume = {
+        size = "1Gi"
+      }
+      numberOfInstances = 2
+      users = {
+        mike = [
+          "superuser",
+          "createdb"
+        ]
+        foo_user = [
+          "superuser"
+        ]
+        bar_user = []
+      }
+      databases = {
+        foo = "devdb"
+      }
+      postgresql = {
+        version = "12"
+      }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/CustomResourceOAPI3-metadata/custom_resource_definition.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceOAPI3-metadata/custom_resource_definition.tf
@@ -1,0 +1,797 @@
+resource "kubernetes_manifest" "test_crd" {
+
+  manifest = {
+    "apiVersion" = "apiextensions.k8s.io/v1"
+    "kind"       = "CustomResourceDefinition"
+    "metadata" = {
+      "name" = "${var.plural}.${var.group}"
+    }
+    "spec" = {
+      "group" = var.group
+      "names" = {
+        "categories" = [
+          "all",
+        ]
+        "kind"     = var.kind
+        "listKind" = "${var.kind}List"
+        "plural"   = var.plural
+        "singular" = lower(var.kind)
+      }
+      "scope" = "Namespaced"
+      "versions" = [
+        {
+          "additionalPrinterColumns" = [
+            {
+              "description" = "Team responsible for Postgres cluster"
+              "jsonPath"    = ".spec.teamId"
+              "name"        = "Team"
+              "type"        = "string"
+            },
+            {
+              "description" = "PostgreSQL version"
+              "jsonPath"    = ".spec.postgresql.version"
+              "name"        = "Version"
+              "type"        = "string"
+            },
+            {
+              "description" = "Number of Pods per Postgres cluster"
+              "jsonPath"    = ".spec.numberOfInstances"
+              "name"        = "Pods"
+              "type"        = "integer"
+            },
+            {
+              "description" = "Size of the bound volume"
+              "jsonPath"    = ".spec.volume.size"
+              "name"        = "Volume"
+              "type"        = "string"
+            },
+            {
+              "description" = "Requested CPU for Postgres containers"
+              "jsonPath"    = ".spec.resources.requests.cpu"
+              "name"        = "CPU-Request"
+              "type"        = "string"
+            },
+            {
+              "description" = "Requested memory for Postgres containers"
+              "jsonPath"    = ".spec.resources.requests.memory"
+              "name"        = "Memory-Request"
+              "type"        = "string"
+            },
+            {
+              "jsonPath" = ".metadata.creationTimestamp"
+              "name"     = "Age"
+              "type"     = "date"
+            },
+            {
+              "description" = "Current sync status of postgresql resource"
+              "jsonPath"    = ".status.PostgresClusterStatus"
+              "name"        = "Status"
+              "type"        = "string"
+            },
+          ]
+          "name" = var.cr_version
+          "schema" = {
+            "openAPIV3Schema" = {
+              "properties" = {
+                "apiVersion" = {
+                  "enum" = [
+                    "${var.group}/${var.cr_version}",
+                  ]
+                  "type" = "string"
+                }
+                "kind" = {
+                  "enum" = [
+                    var.kind,
+                  ]
+                  "type" = "string"
+                }
+                "metadata" = {
+                  "type" = "object"
+                }
+                "spec" = {
+                  "properties" = {
+                    "additionalVolumes" = {
+                      "items" = {
+                        "properties" = {
+                          "mountPath" = {
+                            "type" = "string"
+                          }
+                          "name" = {
+                            "type" = "string"
+                          }
+                          "subPath" = {
+                            "type" = "string"
+                          }
+                          "targetContainers" = {
+                            "items" = {
+                              "type" = "string"
+                            }
+                            "nullable" = true
+                            "type"     = "array"
+                          }
+                          "volumeSource" = {
+                            "type"                                 = "object"
+                            "x-kubernetes-preserve-unknown-fields" = true
+                          }
+                        }
+                        "required" = [
+                          "name",
+                          "mountPath",
+                          "volumeSource",
+                        ]
+                        "type" = "object"
+                      }
+                      "type" = "array"
+                    }
+                    "allowedSourceRanges" = {
+                      "items" = {
+                        "pattern" = "^(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\/(\\d|[1-2]\\d|3[0-2])$"
+                        "type"    = "string"
+                      }
+                      "nullable" = true
+                      "type"     = "array"
+                    }
+                    "clone" = {
+                      "properties" = {
+                        "cluster" = {
+                          "type" = "string"
+                        }
+                        "s3_access_key_id" = {
+                          "type" = "string"
+                        }
+                        "s3_endpoint" = {
+                          "type" = "string"
+                        }
+                        "s3_force_path_style" = {
+                          "type" = "boolean"
+                        }
+                        "s3_secret_access_key" = {
+                          "type" = "string"
+                        }
+                        "s3_wal_path" = {
+                          "type" = "string"
+                        }
+                        "timestamp" = {
+                          "pattern" = "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$"
+                          "type"    = "string"
+                        }
+                        "uid" = {
+                          "format" = "uuid"
+                          "type"   = "string"
+                        }
+                      }
+                      "required" = [
+                        "cluster",
+                      ]
+                      "type" = "object"
+                    }
+                    "connectionPooler" = {
+                      "properties" = {
+                        "dockerImage" = {
+                          "type" = "string"
+                        }
+                        "maxDBConnections" = {
+                          "type" = "integer"
+                        }
+                        "mode" = {
+                          "enum" = [
+                            "session",
+                            "transaction",
+                          ]
+                          "type" = "string"
+                        }
+                        "numberOfInstances" = {
+                          "minimum" = 2
+                          "type"    = "integer"
+                        }
+                        "resources" = {
+                          "properties" = {
+                            "limits" = {
+                              "properties" = {
+                                "cpu" = {
+                                  "pattern" = "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                                  "type"    = "string"
+                                }
+                                "memory" = {
+                                  "pattern" = "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                                  "type"    = "string"
+                                }
+                              }
+                              "required" = [
+                                "cpu",
+                                "memory",
+                              ]
+                              "type" = "object"
+                            }
+                            "requests" = {
+                              "properties" = {
+                                "cpu" = {
+                                  "pattern" = "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                                  "type"    = "string"
+                                }
+                                "memory" = {
+                                  "pattern" = "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                                  "type"    = "string"
+                                }
+                              }
+                              "required" = [
+                                "cpu",
+                                "memory",
+                              ]
+                              "type" = "object"
+                            }
+                          }
+                          "required" = [
+                            "requests",
+                            "limits",
+                          ]
+                          "type" = "object"
+                        }
+                        "schema" = {
+                          "type" = "string"
+                        }
+                        "user" = {
+                          "type" = "string"
+                        }
+                      }
+                      "type" = "object"
+                    }
+                    "databases" = {
+                      "additionalProperties" = {
+                        "type" = "string"
+                      }
+                      "type" = "object"
+                    }
+                    "dockerImage" = {
+                      "type" = "string"
+                    }
+                    "enableConnectionPooler" = {
+                      "type" = "boolean"
+                    }
+                    "enableLogicalBackup" = {
+                      "type" = "boolean"
+                    }
+                    "enableMasterLoadBalancer" = {
+                      "type" = "boolean"
+                    }
+                    "enableReplicaConnectionPooler" = {
+                      "type" = "boolean"
+                    }
+                    "enableReplicaLoadBalancer" = {
+                      "type" = "boolean"
+                    }
+                    "enableShmVolume" = {
+                      "type" = "boolean"
+                    }
+                    "initContainers" = {
+                      "items" = {
+                        "type"                                 = "object"
+                        "x-kubernetes-preserve-unknown-fields" = true
+                      }
+                      "nullable" = true
+                      "type"     = "array"
+                    }
+                    "init_containers" = {
+                      "items" = {
+                        "type"                                 = "object"
+                        "x-kubernetes-preserve-unknown-fields" = true
+                      }
+                      "nullable" = true
+                      "type"     = "array"
+                    }
+                    "logicalBackupSchedule" = {
+                      "pattern" = "^(\\d+|\\*)(/\\d+)?(\\s+(\\d+|\\*)(/\\d+)?){4}$"
+                      "type"    = "string"
+                    }
+                    "maintenanceWindows" = {
+                      "items" = {
+                        "pattern" = "^\\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))\\ *$"
+                        "type"    = "string"
+                      }
+                      "type" = "array"
+                    }
+                    "nodeAffinity" = {
+                      "properties" = {
+                        "preferredDuringSchedulingIgnoredDuringExecution" = {
+                          "items" = {
+                            "properties" = {
+                              "preference" = {
+                                "properties" = {
+                                  "matchExpressions" = {
+                                    "items" = {
+                                      "properties" = {
+                                        "key" = {
+                                          "type" = "string"
+                                        }
+                                        "operator" = {
+                                          "type" = "string"
+                                        }
+                                        "values" = {
+                                          "items" = {
+                                            "type" = "string"
+                                          }
+                                          "type" = "array"
+                                        }
+                                      }
+                                      "required" = [
+                                        "key",
+                                        "operator",
+                                      ]
+                                      "type" = "object"
+                                    }
+                                    "type" = "array"
+                                  }
+                                  "matchFields" = {
+                                    "items" = {
+                                      "properties" = {
+                                        "key" = {
+                                          "type" = "string"
+                                        }
+                                        "operator" = {
+                                          "type" = "string"
+                                        }
+                                        "values" = {
+                                          "items" = {
+                                            "type" = "string"
+                                          }
+                                          "type" = "array"
+                                        }
+                                      }
+                                      "required" = [
+                                        "key",
+                                        "operator",
+                                      ]
+                                      "type" = "object"
+                                    }
+                                    "type" = "array"
+                                  }
+                                }
+                                "type" = "object"
+                              }
+                              "weight" = {
+                                "format" = "int32"
+                                "type"   = "integer"
+                              }
+                            }
+                            "required" = [
+                              "weight",
+                              "preference",
+                            ]
+                            "type" = "object"
+                          }
+                          "type" = "array"
+                        }
+                        "requiredDuringSchedulingIgnoredDuringExecution" = {
+                          "properties" = {
+                            "nodeSelectorTerms" = {
+                              "items" = {
+                                "properties" = {
+                                  "matchExpressions" = {
+                                    "items" = {
+                                      "properties" = {
+                                        "key" = {
+                                          "type" = "string"
+                                        }
+                                        "operator" = {
+                                          "type" = "string"
+                                        }
+                                        "values" = {
+                                          "items" = {
+                                            "type" = "string"
+                                          }
+                                          "type" = "array"
+                                        }
+                                      }
+                                      "required" = [
+                                        "key",
+                                        "operator",
+                                      ]
+                                      "type" = "object"
+                                    }
+                                    "type" = "array"
+                                  }
+                                  "matchFields" = {
+                                    "items" = {
+                                      "properties" = {
+                                        "key" = {
+                                          "type" = "string"
+                                        }
+                                        "operator" = {
+                                          "type" = "string"
+                                        }
+                                        "values" = {
+                                          "items" = {
+                                            "type" = "string"
+                                          }
+                                          "type" = "array"
+                                        }
+                                      }
+                                      "required" = [
+                                        "key",
+                                        "operator",
+                                      ]
+                                      "type" = "object"
+                                    }
+                                    "type" = "array"
+                                  }
+                                }
+                                "type" = "object"
+                              }
+                              "type" = "array"
+                            }
+                          }
+                          "required" = [
+                            "nodeSelectorTerms",
+                          ]
+                          "type" = "object"
+                        }
+                      }
+                      "type" = "object"
+                    }
+                    "numberOfInstances" = {
+                      "minimum" = 0
+                      "type"    = "integer"
+                    }
+                    "patroni" = {
+                      "properties" = {
+                        "initdb" = {
+                          "additionalProperties" = {
+                            "type" = "string"
+                          }
+                          "type" = "object"
+                        }
+                        "loop_wait" = {
+                          "type" = "integer"
+                        }
+                        "maximum_lag_on_failover" = {
+                          "type" = "integer"
+                        }
+                        "pg_hba" = {
+                          "items" = {
+                            "type" = "string"
+                          }
+                          "type" = "array"
+                        }
+                        "retry_timeout" = {
+                          "type" = "integer"
+                        }
+                        "slots" = {
+                          "additionalProperties" = {
+                            "additionalProperties" = {
+                              "type" = "string"
+                            }
+                            "type" = "object"
+                          }
+                          "type" = "object"
+                        }
+                        "synchronous_mode" = {
+                          "type" = "boolean"
+                        }
+                        "synchronous_mode_strict" = {
+                          "type" = "boolean"
+                        }
+                        "ttl" = {
+                          "type" = "integer"
+                        }
+                      }
+                      "type" = "object"
+                    }
+                    "podAnnotations" = {
+                      "additionalProperties" = {
+                        "type" = "string"
+                      }
+                      "type" = "object"
+                    }
+                    "podPriorityClassName" = {
+                      "type" = "string"
+                    }
+                    "pod_priority_class_name" = {
+                      "type" = "string"
+                    }
+                    "postgresql" = {
+                      "properties" = {
+                        "parameters" = {
+                          "additionalProperties" = {
+                            "type" = "string"
+                          }
+                          "type" = "object"
+                        }
+                        "version" = {
+                          "enum" = [
+                            "9.3",
+                            "9.4",
+                            "9.5",
+                            "9.6",
+                            "10",
+                            "11",
+                            "12",
+                            "13",
+                          ]
+                          "type" = "string"
+                        }
+                      }
+                      "required" = [
+                        "version",
+                      ]
+                      "type" = "object"
+                    }
+                    "preparedDatabases" = {
+                      "additionalProperties" = {
+                        "properties" = {
+                          "defaultUsers" = {
+                            "type" = "boolean"
+                          }
+                          "extensions" = {
+                            "additionalProperties" = {
+                              "type" = "string"
+                            }
+                            "type" = "object"
+                          }
+                          "schemas" = {
+                            "additionalProperties" = {
+                              "properties" = {
+                                "defaultRoles" = {
+                                  "type" = "boolean"
+                                }
+                                "defaultUsers" = {
+                                  "type" = "boolean"
+                                }
+                              }
+                              "type" = "object"
+                            }
+                            "type" = "object"
+                          }
+                        }
+                        "type" = "object"
+                      }
+                      "type" = "object"
+                    }
+                    "replicaLoadBalancer" = {
+                      "type" = "boolean"
+                    }
+                    "resources" = {
+                      "properties" = {
+                        "limits" = {
+                          "properties" = {
+                            "cpu" = {
+                              "pattern" = "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                              "type"    = "string"
+                            }
+                            "memory" = {
+                              "pattern" = "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                              "type"    = "string"
+                            }
+                          }
+                          "required" = [
+                            "cpu",
+                            "memory",
+                          ]
+                          "type" = "object"
+                        }
+                        "requests" = {
+                          "properties" = {
+                            "cpu" = {
+                              "pattern" = "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                              "type"    = "string"
+                            }
+                            "memory" = {
+                              "pattern" = "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                              "type"    = "string"
+                            }
+                          }
+                          "required" = [
+                            "cpu",
+                            "memory",
+                          ]
+                          "type" = "object"
+                        }
+                      }
+                      "required" = [
+                        "requests",
+                        "limits",
+                      ]
+                      "type" = "object"
+                    }
+                    "schedulerName" = {
+                      "type" = "string"
+                    }
+                    "serviceAnnotations" = {
+                      "additionalProperties" = {
+                        "type" = "string"
+                      }
+                      "type" = "object"
+                    }
+                    "sidecars" = {
+                      "items" = {
+                        "type"                                 = "object"
+                        "x-kubernetes-preserve-unknown-fields" = true
+                      }
+                      "nullable" = true
+                      "type"     = "array"
+                    }
+                    "spiloFSGroup" = {
+                      "type" = "integer"
+                    }
+                    "spiloRunAsGroup" = {
+                      "type" = "integer"
+                    }
+                    "spiloRunAsUser" = {
+                      "type" = "integer"
+                    }
+                    "standby" = {
+                      "properties" = {
+                        "s3_wal_path" = {
+                          "type" = "string"
+                        }
+                      }
+                      "required" = [
+                        "s3_wal_path",
+                      ]
+                      "type" = "object"
+                    }
+                    "teamId" = {
+                      "type" = "string"
+                    }
+                    "tls" = {
+                      "properties" = {
+                        "caFile" = {
+                          "type" = "string"
+                        }
+                        "caSecretName" = {
+                          "type" = "string"
+                        }
+                        "certificateFile" = {
+                          "type" = "string"
+                        }
+                        "privateKeyFile" = {
+                          "type" = "string"
+                        }
+                        "secretName" = {
+                          "type" = "string"
+                        }
+                      }
+                      "required" = [
+                        "secretName",
+                      ]
+                      "type" = "object"
+                    }
+                    "tolerations" = {
+                      "items" = {
+                        "properties" = {
+                          "effect" = {
+                            "enum" = [
+                              "NoExecute",
+                              "NoSchedule",
+                              "PreferNoSchedule",
+                            ]
+                            "type" = "string"
+                          }
+                          "key" = {
+                            "type" = "string"
+                          }
+                          "operator" = {
+                            "enum" = [
+                              "Equal",
+                              "Exists",
+                            ]
+                            "type" = "string"
+                          }
+                          "tolerationSeconds" = {
+                            "type" = "integer"
+                          }
+                          "value" = {
+                            "type" = "string"
+                          }
+                        }
+                        "required" = [
+                          "key",
+                          "operator",
+                          "effect",
+                        ]
+                        "type" = "object"
+                      }
+                      "type" = "array"
+                    }
+                    "useLoadBalancer" = {
+                      "type" = "boolean"
+                    }
+                    "users" = {
+                      "additionalProperties" = {
+                        "description" = "Role flags specified here must not contradict each other"
+                        "items" = {
+                          "enum" = [
+                            "bypassrls",
+                            "BYPASSRLS",
+                            "nobypassrls",
+                            "NOBYPASSRLS",
+                            "createdb",
+                            "CREATEDB",
+                            "nocreatedb",
+                            "NOCREATEDB",
+                            "createrole",
+                            "CREATEROLE",
+                            "nocreaterole",
+                            "NOCREATEROLE",
+                            "inherit",
+                            "INHERIT",
+                            "noinherit",
+                            "NOINHERIT",
+                            "login",
+                            "LOGIN",
+                            "nologin",
+                            "NOLOGIN",
+                            "replication",
+                            "REPLICATION",
+                            "noreplication",
+                            "NOREPLICATION",
+                            "superuser",
+                            "SUPERUSER",
+                            "nosuperuser",
+                            "NOSUPERUSER",
+                          ]
+                          "type" = "string"
+                        }
+                        "nullable" = true
+                        "type"     = "array"
+                      }
+                      "type" = "object"
+                    }
+                    "volume" = {
+                      "properties" = {
+                        "iops" = {
+                          "type" = "integer"
+                        }
+                        "size" = {
+                          "pattern" = "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                          "type"    = "string"
+                        }
+                        "storageClass" = {
+                          "type" = "string"
+                        }
+                        "subPath" = {
+                          "type" = "string"
+                        }
+                        "throughput" = {
+                          "type" = "integer"
+                        }
+                      }
+                      "required" = [
+                        "size",
+                      ]
+                      "type" = "object"
+                    }
+                  }
+                  "required" = [
+                    "numberOfInstances",
+                    "teamId",
+                    "postgresql",
+                    "volume",
+                  ]
+                  "type" = "object"
+                }
+                "status" = {
+                  "additionalProperties" = {
+                    "type" = "string"
+                  }
+                  "type" = "object"
+                }
+              }
+              "required" = [
+                "kind",
+                "apiVersion",
+                "spec",
+              ]
+              "type"                                 = "object"
+              "x-kubernetes-preserve-unknown-fields" = true
+            }
+          }
+          "served"  = true
+          "storage" = true
+          "subresources" = {
+            "status" = {}
+          }
+        },
+      ]
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/CustomResourceOAPI3-metadata/variables.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceOAPI3-metadata/variables.tf
@@ -1,0 +1,31 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "kind" {
+  type = string
+}
+
+variable "group" {
+  type = string
+}
+variable "cr_version" {
+  type = string
+}
+
+variable "plural" {
+  type = string
+}


### PR DESCRIPTION
### Description

With this change, the `kubernetes_manifest` resource will always generate the complete standard type for the "metadata" attribute of the Custom Resource even when the `openAPIV3Schema` attribute of it's CRD defines an partial or empty metadata attribute. 

Fixes issues described in #1418 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
2021/10/06 19:00:14 Testing against Kubernetes API version: v1.22.2
=== RUN   TestKubernetesManifest_CustomResource_OAPIv3_metadata
--- PASS: TestKubernetesManifest_CustomResource_OAPIv3_metadata (9.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
