### PR TITLE
Check env and exec blocks are fully known

### DIFF
--- a/manifest/provider/configure.go
+++ b/manifest/provider/configure.go
@@ -556,7 +556,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				}
 				execCfg.Command = cmd
 			}
-			if !execObj["args"].IsNull() && execObj["args"].IsKnown() {
+			if !execObj["args"].IsNull() && execObj["args"].IsFullyKnown() {
 				var xcmdArgs []tftypes.Value
 				err = execObj["args"].As(&xcmdArgs)
 				if err != nil {
@@ -584,7 +584,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 					execCfg.Args = append(execCfg.Args, v)
 				}
 			}
-			if !execObj["env"].IsNull() && execObj["env"].IsKnown() {
+			if !execObj["env"].IsNull() && execObj["env"].IsFullyKnown() {
 				var xcmdEnvs map[string]tftypes.Value
 				err = execObj["env"].As(&xcmdEnvs)
 				if err != nil {


### PR DESCRIPTION
### Description

Fixes #1464 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix manifest configuration to use IsFullyKnown() on exec and env blocks 
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
