### PR TITLE
Generate Tuple instead of List when elements contain DynamicPseudoType

### DIFF
--- a/manifest/openapi/foundry_v2_test.go
+++ b/manifest/openapi/foundry_v2_test.go
@@ -29,8 +29,8 @@ var objectMetaType = tftypes.Object{
 		"generateName":               tftypes.String,
 		"generation":                 tftypes.Number,
 		"labels":                     tftypes.Map{AttributeType: tftypes.String},
-		"managedFields": tftypes.List{
-			ElementType: tftypes.Object{
+		"managedFields": tftypes.Tuple{
+			ElementTypes: []tftypes.Type{tftypes.Object{
 				AttributeTypes: map[string]tftypes.Type{
 					"apiVersion": tftypes.String,
 					"fieldsType": tftypes.String,
@@ -39,7 +39,7 @@ var objectMetaType = tftypes.Object{
 					"operation":  tftypes.String,
 					"time":       tftypes.String,
 				},
-			},
+			}},
 		},
 		"name":      tftypes.String,
 		"namespace": tftypes.String,
@@ -92,8 +92,8 @@ var samples = testSamples{
 						"ipFamily":                 tftypes.String,
 						"loadBalancerIP":           tftypes.String,
 						"loadBalancerSourceRanges": tftypes.List{ElementType: tftypes.String},
-						"ports": tftypes.List{
-							ElementType: tftypes.Object{
+						"ports": tftypes.Tuple{
+							ElementTypes: []tftypes.Type{tftypes.Object{
 								AttributeTypes: map[string]tftypes.Type{
 									"appProtocol": tftypes.String,
 									"name":        tftypes.String,
@@ -102,7 +102,7 @@ var samples = testSamples{
 									"protocol":    tftypes.String,
 									"targetPort":  tftypes.DynamicPseudoType,
 								},
-							},
+							}},
 						},
 						"publishNotReadyAddresses": tftypes.Bool,
 						"selector":                 tftypes.Map{AttributeType: tftypes.String},

--- a/manifest/openapi/schema_test.go
+++ b/manifest/openapi/schema_test.go
@@ -1,0 +1,90 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestIsTypeFullyKnown(t *testing.T) {
+	type testSample struct {
+		s bool
+		t tftypes.Type
+	}
+
+	type testSamples map[string]testSample
+
+	samples := testSamples{
+		"DynamicPseudoType": {
+			s: false,
+			t: tftypes.DynamicPseudoType,
+		},
+		"String": {
+			s: true,
+			t: tftypes.String,
+		},
+		"StringList": {
+			s: true,
+			t: tftypes.List{ElementType: tftypes.String},
+		},
+		"DynamicPseudoTypeList": {
+			s: false,
+			t: tftypes.List{ElementType: tftypes.DynamicPseudoType},
+		},
+		"DynamicPseudoTypeMap": {
+			s: false,
+			t: tftypes.Map{AttributeType: tftypes.DynamicPseudoType},
+		},
+		"StringMap": {
+			s: true,
+			t: tftypes.Map{AttributeType: tftypes.String},
+		},
+		"Object": {
+			s: true,
+			t: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"foo": tftypes.String,
+					"bar": tftypes.Number,
+				},
+			},
+		},
+		"ObjectDynamic": {
+			s: false,
+			t: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"foo": tftypes.String,
+					"bar": tftypes.DynamicPseudoType,
+				},
+			},
+		},
+		"ListObject": {
+			s: true,
+			t: tftypes.List{ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"foo": tftypes.String,
+					"bar": tftypes.Number,
+				},
+			},
+			},
+		},
+		"ListObjectDynamic": {
+			s: false,
+			t: tftypes.List{ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"foo": tftypes.String,
+					"bar": tftypes.DynamicPseudoType,
+				},
+			},
+			},
+		},
+	}
+
+	for name, v := range samples {
+		t.Run(name,
+			func(t *testing.T) {
+				if isTypeFullyKnown(v.t) != v.s {
+					t.Fatalf("sample %s failed", name)
+				}
+			})
+	}
+}


### PR DESCRIPTION
### Description

This change addresses an issue in the logic that generates the manifest type from OpenAPI definitions.

Before, an attribute specified as an array of elements which contain DynamicPseudoType subitems would be rendered as tftypes.List. This is wrong because the presence of DynamicPseudoType in a List element can cause specific instances of that element in the same list to have divergent actual types.

With this change, we modify the type generator to produce a Tuple rather than a List whenever the presensce of DynamicPseudoType is detected in sub-elements.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1359

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
