### PR TITLE
Add support for certificates/v1 API

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -216,7 +216,8 @@ func Provider() *schema.Provider {
 			"kubernetes_horizontal_pod_autoscaler": resourceKubernetesHorizontalPodAutoscaler(),
 
 			// certificates
-			"kubernetes_certificate_signing_request": resourceKubernetesCertificateSigningRequest(),
+			"kubernetes_certificate_signing_request":    resourceKubernetesCertificateSigningRequest(),
+			"kubernetes_certificate_signing_request_v1": resourceKubernetesCertificateSigningRequestV1(),
 
 			// rbac
 			"kubernetes_role":                 resourceKubernetesRole(),

--- a/kubernetes/resource_kubernetes_certificate_signing_request_test.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_test.go
@@ -17,7 +17,10 @@ func TestAccKubernetesCertificateSigningRequest_basic(t *testing.T) {
 	usages := []string{"client auth"}
 	signerName := "kubernetes.io/legacy-unknown"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.22.0")
+		},
 		IDRefreshName:     "kubernetes_certificate_signing_request.test",
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesCertificateSigningRequestDestroy,
@@ -33,7 +36,10 @@ func TestAccKubernetesCertificateSigningRequest_basic(t *testing.T) {
 func TestAccKubernetesCertificateSigningRequest_generateName(t *testing.T) {
 	generateName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.22.0")
+		},
 		IDRefreshName:     "kubernetes_certificate_signing_request.test",
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesCertificateSigningRequestDestroy,

--- a/kubernetes/resource_kubernetes_certificate_signing_request_v1.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_v1.go
@@ -1,0 +1,189 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	certificates "k8s.io/api/certificates/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func resourceKubernetesCertificateSigningRequestV1() *schema.Resource {
+	apiDoc := certificates.CertificateSigningRequest{}.SwaggerDoc()
+	apiDocSpec := certificates.CertificateSigningRequestSpec{}.SwaggerDoc()
+	apiDocStatus := certificates.CertificateSigningRequestStatus{}.SwaggerDoc()
+
+	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will not work on clusters using Kubernetes version 1.22 and above.\n" +
+			"Please switch to the `kubernetes_certificate_signing_request_v1` resource on clusters using v1.22 and above.",
+		CreateContext: resourceKubernetesCertificateSigningRequestV1Create,
+		ReadContext:   resourceKubernetesCertificateSigningRequestV1Read,
+		DeleteContext: resourceKubernetesCertificateSigningRequestV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"auto_approve": {
+				Type:        schema.TypeBool,
+				Description: "Automatically approve the CertificateSigningRequest",
+				Optional:    true,
+				ForceNew:    true,
+				Default:     true,
+			},
+			"certificate": {
+				Type:        schema.TypeString,
+				Description: apiDocStatus["certificate"],
+				Computed:    true,
+			},
+			"metadata": metadataSchemaForceNew(metadataSchema("certificate signing request", true)),
+			"spec": {
+				ForceNew:    true,
+				Type:        schema.TypeList,
+				Description: apiDoc[""],
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"request": {
+							Type:        schema.TypeString,
+							Description: apiDocSpec["request"],
+							Required:    true,
+							ForceNew:    true,
+						},
+						"signer_name": {
+							Type:        schema.TypeString,
+							Description: apiDocSpec["signerName"],
+							Required:    true,
+							ForceNew:    true,
+						},
+						"usages": {
+							Type:        schema.TypeSet,
+							Description: apiDocSpec["usages"],
+							Set:         schema.HashString,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+const TerraformAutoApproveReason = "TerraformAutoApprove"
+const TerraformAutoApproveMessage = "This CertificateSigningRequest was auto-approved by Terraform"
+
+func resourceKubernetesCertificateSigningRequestV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec, err := expandCertificateSigningRequestV1Spec(d.Get("spec").([]interface{}))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	csr := certificates.CertificateSigningRequest{
+		ObjectMeta: metadata,
+		Spec:       *spec,
+	}
+	log.Printf("[INFO] Creating new certificate signing request: %#v", csr)
+	newCSR, err := conn.CertificatesV1().CertificateSigningRequests().Create(ctx, &csr, metav1.CreateOptions{})
+	if err != nil {
+		return diag.Errorf("Failed to create certificate signing request: %s", err)
+	}
+
+	// Get the name, since it might have been randomly generated during create.
+	csrName := newCSR.ObjectMeta.Name
+
+	// Delete the remote CSR resource when this function exits, or when errors are encountered.
+	defer conn.CertificatesV1().CertificateSigningRequests().Delete(ctx, csrName, metav1.DeleteOptions{})
+
+	if d.Get("auto_approve").(bool) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			pendingCSR, getErr := conn.CertificatesV1().CertificateSigningRequests().Get(
+				ctx, csrName, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			approval := certificates.CertificateSigningRequestCondition{
+				Status:  v1.ConditionTrue,
+				Type:    certificates.CertificateApproved,
+				Reason:  TerraformAutoApproveReason,
+				Message: TerraformAutoApproveMessage,
+			}
+			pendingCSR.Status.Certificate = []byte{}
+			pendingCSR.Status.Conditions = append(pendingCSR.Status.Conditions, approval)
+			_, err := conn.CertificatesV1().CertificateSigningRequests().UpdateApproval(
+				ctx, csrName, pendingCSR, metav1.UpdateOptions{})
+			return err
+		})
+		if retryErr != nil {
+			return diag.Errorf("CSR auto-approve update failed: %v", retryErr)
+		}
+		log.Printf("[DEBUG] Auto approve succeeded")
+	}
+
+	log.Printf("[DEBUG] Waiting for certificate to be issued")
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		out, err := conn.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("[ERROR] Received error: %v", err)
+			return resource.NonRetryableError(err)
+		}
+
+		// Check to see if a certificate has been issued, and update status accordingly,
+		// since 'Issued' is not a state ever populated in the Status Conditions.
+		for _, condition := range out.Status.Conditions {
+			log.Printf("[DEBUG] Found Status.Condition.Type: %v", condition.Type)
+			if condition.Type == certificates.CertificateApproved &&
+				len(out.Status.Certificate) > 0 {
+				log.Printf("[DEBUG] Found non-empty Certificate field in Status")
+				return nil
+
+			}
+		}
+		log.Printf("[DEBUG] CertificateSigningRequest %s status received: %#v", csrName, out.Status)
+		return resource.RetryableError(fmt.Errorf(
+			"Waiting for certificate to be issued"))
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	log.Printf("[INFO] Certificate issued for request: %s", csrName)
+
+	issued, err := conn.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(csrName)
+	d.Set("certificate", string(issued.Status.Certificate))
+
+	return resourceKubernetesCertificateSigningRequestV1Read(ctx, d, meta)
+}
+
+// resourceKubernetesCertificateSigningRequestV1Read does not return any data, because Read functions exist to
+// sync the local state with the remote state. Since this data is local-only, there is nothing to read.
+func resourceKubernetesCertificateSigningRequestV1Read(ctx context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+func resourceKubernetesCertificateSigningRequestV1Delete(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	d.SetId("")
+	return diag.Diagnostics{}
+}

--- a/kubernetes/resource_kubernetes_certificate_signing_request_v1_test.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_v1_test.go
@@ -1,0 +1,146 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAccKubernetesCertificateSigningRequestV1_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	usages := []string{"client auth"}
+	signerName := "kubernetes.io/kube-apiserver-client"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.22.0")
+		},
+		IDRefreshName:     "kubernetes_certificate_signing_request_v1.test",
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesCertificateSigningRequestV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCertificateSigningRequestV1Config_basic(name, signerName, usages, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCertificateSigningRequestV1Valid,
+					resource.TestCheckResourceAttrSet("kubernetes_certificate_signing_request_v1.test", "certificate"),
+					resource.TestCheckResourceAttr("kubernetes_certificate_signing_request_v1.test", "spec.0.signer_name", signerName),
+					resource.TestCheckResourceAttr("kubernetes_certificate_signing_request_v1.test", "spec.0.usages.0", usages[0]),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesCertificateSigningRequestV1_generateName(t *testing.T) {
+	generateName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.22.0")
+		},
+		IDRefreshName:     "kubernetes_certificate_signing_request_v1.test",
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesCertificateSigningRequestV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCertificateSigningRequestV1Config_generateName(generateName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCertificateSigningRequestV1Valid,
+					resource.TestCheckResourceAttrSet("kubernetes_certificate_signing_request_v1.test", "certificate"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckKubernetesCertificateSigningRequestV1Valid checks to see that the locally-stored certificate
+// contains a valid PEM preamble. It also checks that the CSR resource has been deleted from Kubernetes, since
+// the CSR is only supposed to exist momentarily as the certificate is generated. (CSR resources are ephemeral
+// in Kubernetes and therefore are only used temporarily).
+func testAccCheckKubernetesCertificateSigningRequestV1Valid(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "kubernetes_certificate_signing_request_v1" {
+			if !strings.HasPrefix(rs.Primary.Attributes["certificate"], "-----BEGIN CERTIFICATE----") {
+				return fmt.Errorf("certificate is missing cert PEM preamble from resource: %s", rs.Primary.ID)
+			}
+		}
+	}
+	return testAccCheckKubernetesCertificateSigningRequestV1RemoteResourceDeleted(s)
+}
+
+func testAccCheckKubernetesCertificateSigningRequestV1RemoteResourceDeleted(s *terraform.State) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kubernetes_certificate_signing_request_v1" {
+			continue
+		}
+		out, err := conn.CertificatesV1().CertificateSigningRequests().Get(ctx, rs.Primary.ID, metav1.GetOptions{})
+		if err == nil {
+			if out.Name == rs.Primary.ID {
+				return fmt.Errorf("CertificateSigningRequest still exists in Kubernetes: %s", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckKubernetesCertificateSigningRequestV1Destroy(s *terraform.State) error {
+	return testAccCheckKubernetesCertificateSigningRequestV1RemoteResourceDeleted(s)
+}
+
+func testAccKubernetesCertificateSigningRequestV1Config_basic(name, signerName string, usages []string, autoApprove bool) string {
+	return fmt.Sprintf(`resource "kubernetes_certificate_signing_request_v1" "test" {
+  metadata {
+    name = %q
+  }
+  auto_approve = %t
+  spec {
+    request     = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
+YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
+ImigHcF787djpF2QDbz3oQ3QsM/I7ftdjB/HHlG2a5YpqjzT0KAAMAoGCCqGSM49
+BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
+DpNPvh30e0Js8/DYn2YUfu/pQU19
+-----END CERTIFICATE REQUEST-----
+EOT
+    signer_name = %q
+    usages      = %q
+  }
+}
+`, name, autoApprove, signerName, usages)
+}
+
+func testAccKubernetesCertificateSigningRequestV1Config_generateName(generateName string) string {
+	return fmt.Sprintf(`resource "kubernetes_certificate_signing_request_v1" "test" {
+  metadata {
+    generate_name = %q
+  }
+  auto_approve = true
+  spec {
+    request     = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
+YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
+ImigHcF787djpF2QDbz3oQ3QsM/I7ftdjB/HHlG2a5YpqjzT0KAAMAoGCCqGSM49
+BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
+DpNPvh30e0Js8/DYn2YUfu/pQU19
+-----END CERTIFICATE REQUEST-----
+EOT
+    signer_name = "kubernetes.io/kube-apiserver-client"
+    usages      = ["client auth"]
+  }
+}
+`, generateName)
+}

--- a/kubernetes/structures_certificate_signing_request_v1.go
+++ b/kubernetes/structures_certificate_signing_request_v1.go
@@ -1,0 +1,31 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	certificates "k8s.io/api/certificates/v1"
+)
+
+func expandCertificateSigningRequestV1Spec(csr []interface{}) (*certificates.CertificateSigningRequestSpec, error) {
+	obj := &certificates.CertificateSigningRequestSpec{}
+	if len(csr) == 0 || csr[0] == nil {
+		return obj, nil
+	}
+	in := csr[0].(map[string]interface{})
+	obj.Request = []byte(in["request"].(string))
+	if v, ok := in["usages"].(*schema.Set); ok && v.Len() > 0 {
+		obj.Usages = expandCertificateSigningRequestV1Usages(v.List())
+	}
+	if v, ok := in["signer_name"].(string); ok && v != "" {
+		obj.SignerName = v
+	}
+	return obj, nil
+}
+
+func expandCertificateSigningRequestV1Usages(s []interface{}) []certificates.KeyUsage {
+	out := make([]certificates.KeyUsage, len(s), len(s))
+	for i, v := range s {
+		out[i] = certificates.KeyUsage(v.(string))
+	}
+	return out
+}

--- a/website/docs/r/certificate_signing_request_v1.html.markdown
+++ b/website/docs/r/certificate_signing_request_v1.html.markdown
@@ -1,0 +1,106 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_certificate_signing_request_v1"
+description: |-
+  Use this resource to generate TLS certificates using Kubernetes.
+---
+
+# kubernetes_certificate_signing_request_v1
+
+Use this resource to generate TLS certificates using Kubernetes.
+
+This is a *logical resource*, so it contributes only to the current Terraform state and does not persist any external managed resources.
+
+This resource enables automation of [X.509](https://www.itu.int/rec/T-REC-X.509) credential provisioning (including TLS/SSL certificates). It does this by creating a CertificateSigningRequest using the Kubernetes API, which generates a certificate from the Certificate Authority (CA) configured in the Kubernetes cluster. The CSR can be approved automatically by Terraform, or it can be approved by a custom controller running in Kubernetes. See [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for all available options pertaining to CertificateSigningRequests.
+
+## Example Usage
+
+```hcl
+resource "kubernetes_certificate_signing_request_v1" "example" {
+  metadata {
+    name = "example"
+  }
+  spec {
+    usages      = ["client auth", "server auth"]
+    signer_name = "kubernetes.io/kube-apiserver-client"
+
+    request = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
+YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
+ImigHcF787djpF2QDbz3oQ3QsM/I7ftdjB/HHlG2a5YpqjzT0KAAMAoGCCqGSM49
+BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
+DpNPvh30e0Js8/DYn2YUfu/pQU19
+-----END CERTIFICATE REQUEST-----
+EOT
+  }
+
+  auto_approve = true
+}
+
+
+resource "kubernetes_secret" "example" {
+  metadata {
+    name = "example"
+  }
+  data = {
+    "tls.crt" = kubernetes_certificate_signing_request_v1.example.certificate
+    "tls.key" = tls_private_key.example.private_key_pem # key used to generate Certificate Request
+  }
+  type = "kubernetes.io/tls"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auto_approve` - (Optional) Automatically approve the CertificateSigningRequest. Defaults to 'true'.
+* `metadata` - (Required) Standard certificate signing request's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+* `spec` - (Required) Spec defines the specification of the desired behavior of the deployment. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the certificate signing request that may be used to store arbitrary metadata.
+
+~> By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the certificate signing request. May match selectors of replication controllers and services.
+
+~> By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+
+* `name` - (Optional) Name of the certificate signing request, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+#### Attributes
+
+* `certificate` - The signed certificate PEM data.
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this certificate signing request that can be used by clients to determine when certificate signing request has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
+* `uid` - The unique in time and space value for this certificate signing request. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+### `spec`
+
+#### Arguments
+
+* `request` - (Required) Base64-encoded PKCS#10 CSR data.
+* `signer_name` - (Required) Indicates the requested signer, and is a qualified name. See https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers
+* `usages` - (Required) Specifies a set of usage contexts the key will be valid for. See https://godoc.org/k8s.io/api/certificates/v1#KeyUsage
+
+## Generating a New Certificate
+
+Since the certificate is a logical resource that lives only in the Terraform state,
+it will persist until it is explicitly destroyed by the user.
+
+In order to force the generation of a new certificate within an existing state, the
+certificate instance can be "tainted":
+
+```
+terraform taint kubernetes_certificate_signing_request_v1.example
+```
+
+A new certificate will then be generated on the next ``terraform apply``.


### PR DESCRIPTION
### Description

This PR adds support for the certificates/v1 API by adding a new `kubernetes_certificate_signing_request_v1` resource. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccKubernetesCertificateSigningRequestV1_basic
--- PASS: TestAccKubernetesCertificateSigningRequestV1_basic (3.34s)
=== RUN   TestAccKubernetesCertificateSigningRequestV1_generateName
--- PASS: TestAccKubernetesCertificateSigningRequestV1_generateName (3.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	7.706s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for certificates/v1 API 
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
