### PR TITLE
Setting config.WrapTransport directly is not recommended, using config.Wrap() instead

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -318,9 +318,9 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 
 	if logging.IsDebugOrHigher() {
 		log.Printf("[DEBUG] Enabling HTTP requests/responses tracing")
-		cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 			return logging.NewTransport("Kubernetes", rt)
-		}
+		})
 	}
 
 	m := kubeClientsets{

--- a/manifest/provider/clients.go
+++ b/manifest/provider/clients.go
@@ -119,18 +119,18 @@ func (ps *RawProviderServer) getOAPIv2Foundry() (openapi.Foundry, error) {
 }
 
 func loggingTransport(rt http.RoundTripper) http.RoundTripper {
-	return &loggingRountTripper{
+	return &loggingRoundTripper{
 		ot: rt,
 		lt: logging.NewTransport("Kubernetes API", rt),
 	}
 }
 
-type loggingRountTripper struct {
+type loggingRoundTripper struct {
 	ot http.RoundTripper
 	lt http.RoundTripper
 }
 
-func (t *loggingRountTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL.Path == "/openapi/v2" {
 		// don't trace-log the OpenAPI spec document, it's really big
 		return t.ot.RoundTrip(req)
@@ -156,7 +156,8 @@ func (ps *RawProviderServer) checkValidCredentials(ctx context.Context) (diags [
 			diags = append(diags, &tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,
 				Summary:  "Invalid credentials",
-				Detail:   fmt.Sprintf("The credentials configured in the provider block are not accepted by the API server. Error: %s\n\nSet TF_LOG=debug and look for '[InvalidClientConfiguration]' in the log to see actual configuration.", rs.Error().Error()),
+				Detail: fmt.Sprintf("The credentials configured in the provider block are not accepted by the API server. Error: %s\n\nSet TF_LOG=debug and look for '[InvalidClientConfiguration]' in the log to see actual configuration.",
+					rs.Error().Error()),
 			})
 		default:
 			diags = append(diags, &tfprotov5.Diagnostic{

--- a/manifest/provider/configure.go
+++ b/manifest/provider/configure.go
@@ -636,7 +636,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 	}
 
 	if s.logger.IsTrace() {
-		clientConfig.WrapTransport = loggingTransport
+		clientConfig.Wrap(loggingTransport)
 	}
 
 	codec := runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()}

--- a/manifest/test/acceptance/acceptance_test.go
+++ b/manifest/test/acceptance/acceptance_test.go
@@ -27,7 +27,15 @@ var reattachInfo tfexec.ReattachInfo
 
 func TestMain(m *testing.M) {
 	var err error
-	reattachInfo, err = provider.ServeTest(context.TODO(), hclog.Default())
+	logLevel, ok := os.LookupEnv("TF_LOG")
+	if !ok {
+		logLevel = "info"
+	}
+
+	reattachInfo, err = provider.ServeTest(context.TODO(), hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.LevelFromString(logLevel),
+		Output: os.Stderr,
+	}))
 	if err != nil {
 		//lintignore:R009
 		panic(err)


### PR DESCRIPTION
### Description

1. Setting config.WrapTransport directly is not recommended, using config.Wrap() instead. WrapTransport will be changed to an array in a future release
2. Load log level from env in mainifest tests
3. fix a typo

### Acceptance tests
- [✅] Have you added an acceptance test for the functionality being added?
- [✅] Have you run the acceptance tests on this branch?

Output from acceptance testing:
2021/11/09 17:12:57 Testing against Kubernetes API version: v1.21.3
=== RUN   TestKubernetesManifest_ConfigMap
--- PASS: TestKubernetesManifest_ConfigMap (3.23s)
PASS

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
update k8s rest client usage
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
