### PR TITLE
Service tests

### DIFF
--- a/manifest/test/acceptance/service_cluster_ip_test.go
+++ b/manifest/test/acceptance/service_cluster_ip_test.go
@@ -1,0 +1,76 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"encoding/json"
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+// This test case tests a Service but also is a demonstration of some the assert functions
+// available in the test helper
+func TestKubernetesManifest_Service_ClusterIP(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "services", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Service_ClusterIP/service.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "services", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":      namespace,
+		"kubernetes_manifest.test.object.metadata.name":           name,
+		"kubernetes_manifest.test.object.spec.ports.0.name":       "http",
+		"kubernetes_manifest.test.object.spec.ports.0.port":       json.Number("80"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort": json.Number("8080"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":   "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":       "test",
+		"kubernetes_manifest.test.object.spec.type":               "ClusterIP",
+	})
+
+	tfconfigModified := loadTerraformConfig(t, "Service_ClusterIP/service_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":        namespace,
+		"kubernetes_manifest.test.object.metadata.name":             name,
+		"kubernetes_manifest.test.object.metadata.annotations.test": "1",
+		"kubernetes_manifest.test.object.metadata.labels.test":      "2",
+		"kubernetes_manifest.test.object.spec.ports.0.name":         "https",
+		"kubernetes_manifest.test.object.spec.ports.0.port":         json.Number("443"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort":   json.Number("8443"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":     "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":         "test",
+		"kubernetes_manifest.test.object.spec.type":                 "ClusterIP",
+	})
+
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.labels", 1)
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.annotations", 1)
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+}

--- a/manifest/test/acceptance/service_cluster_ip_test.go
+++ b/manifest/test/acceptance/service_cluster_ip_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -6,7 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
 // This test case tests a Service but also is a demonstration of some the assert functions
@@ -24,7 +26,7 @@ func TestKubernetesManifest_Service_ClusterIP(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/service_external_name_test.go
+++ b/manifest/test/acceptance/service_external_name_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -5,7 +6,8 @@ package acceptance
 import (
 	"testing"
 
-	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
 // This test case tests a Service but also is a demonstration of some the assert functions
@@ -23,7 +25,7 @@ func TestKubernetesManifest_Service_ExternalName(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/service_external_name_test.go
+++ b/manifest/test/acceptance/service_external_name_test.go
@@ -1,0 +1,72 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+// This test case tests a Service but also is a demonstration of some the assert functions
+// available in the test helper
+func TestKubernetesManifest_Service_ExternalName(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "services", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Service_ExternalName/service.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "services", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.spec.selector.app":  "test",
+		"kubernetes_manifest.test.object.spec.type":          "ExternalName",
+		"kubernetes_manifest.test.object.spec.externalName":  "terraform.kubernetes.test.com",
+	})
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.object.spec.ports.0")
+
+	tfconfigModified := loadTerraformConfig(t, "Service_ExternalName/service_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":        namespace,
+		"kubernetes_manifest.test.object.metadata.name":             name,
+		"kubernetes_manifest.test.object.metadata.annotations.test": "1",
+		"kubernetes_manifest.test.object.metadata.labels.test":      "2",
+		"kubernetes_manifest.test.object.spec.selector.app":         "test",
+		"kubernetes_manifest.test.object.spec.type":                 "ExternalName",
+		"kubernetes_manifest.test.object.spec.externalName":         "kubernetes-alpha.terraform.test.com",
+	})
+
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.labels", 1)
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.annotations", 1)
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+
+}

--- a/manifest/test/acceptance/service_load_balancer_test.go
+++ b/manifest/test/acceptance/service_load_balancer_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -6,7 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
 // This test case tests a Service but also is a demonstration of some the assert functions
@@ -24,7 +26,7 @@ func TestKubernetesManifest_Service_LoadBalancer(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/service_load_balancer_test.go
+++ b/manifest/test/acceptance/service_load_balancer_test.go
@@ -1,0 +1,76 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"encoding/json"
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+// This test case tests a Service but also is a demonstration of some the assert functions
+// available in the test helper
+func TestKubernetesManifest_Service_LoadBalancer(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "services", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Service_LoadBalancer/service.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "services", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":      namespace,
+		"kubernetes_manifest.test.object.metadata.name":           name,
+		"kubernetes_manifest.test.object.spec.ports.0.name":       "http",
+		"kubernetes_manifest.test.object.spec.ports.0.port":       json.Number("80"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort": json.Number("8080"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":   "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":       "test",
+		"kubernetes_manifest.test.object.spec.type":               "LoadBalancer",
+	})
+
+	tfconfigModified := loadTerraformConfig(t, "Service_LoadBalancer/service_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":        namespace,
+		"kubernetes_manifest.test.object.metadata.name":             name,
+		"kubernetes_manifest.test.object.metadata.annotations.test": "1",
+		"kubernetes_manifest.test.object.metadata.labels.test":      "2",
+		"kubernetes_manifest.test.object.spec.ports.0.name":         "https",
+		"kubernetes_manifest.test.object.spec.ports.0.port":         json.Number("443"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort":   json.Number("8443"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":     "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":         "test",
+		"kubernetes_manifest.test.object.spec.type":                 "LoadBalancer",
+	})
+
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.labels", 1)
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.annotations", 1)
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+}

--- a/manifest/test/acceptance/service_node_port_test.go
+++ b/manifest/test/acceptance/service_node_port_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -6,7 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
 // This test case tests a Service but also is a demonstration of some the assert functions
@@ -24,7 +26,7 @@ func TestKubernetesManifest_Service_NodePort(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/service_node_port_test.go
+++ b/manifest/test/acceptance/service_node_port_test.go
@@ -1,0 +1,79 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"encoding/json"
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+// This test case tests a Service but also is a demonstration of some the assert functions
+// available in the test helper
+func TestKubernetesManifest_Service_NodePort(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "services", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Service_NodePort/service.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "services", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":      namespace,
+		"kubernetes_manifest.test.object.metadata.name":           name,
+		"kubernetes_manifest.test.object.spec.ports.0.name":       "http",
+		"kubernetes_manifest.test.object.spec.ports.0.port":       json.Number("80"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort": json.Number("8080"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":   "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":       "test",
+		"kubernetes_manifest.test.object.spec.type":               "NodePort",
+	})
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.spec.ports.0.nodePort")
+
+	tfconfigModified := loadTerraformConfig(t, "Service_NodePort/service_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":        namespace,
+		"kubernetes_manifest.test.object.metadata.name":             name,
+		"kubernetes_manifest.test.object.metadata.annotations.test": "1",
+		"kubernetes_manifest.test.object.metadata.labels.test":      "2",
+		"kubernetes_manifest.test.object.spec.ports.0.name":         "https",
+		"kubernetes_manifest.test.object.spec.ports.0.port":         json.Number("443"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort":   json.Number("8443"),
+		"kubernetes_manifest.test.object.spec.ports.0.nodePort":     json.Number("32767"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":     "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":         "test",
+		"kubernetes_manifest.test.object.spec.type":                 "NodePort",
+	})
+
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.labels", 1)
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.annotations", 1)
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+}

--- a/manifest/test/acceptance/service_test.go
+++ b/manifest/test/acceptance/service_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -6,7 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
 // This test case tests a Service but also is a demonstration of some the assert functions
@@ -24,7 +26,7 @@ func TestKubernetesManifest_Service(t *testing.T) {
 	}()
 
 	k8shelper.CreateNamespace(t, namespace)
-	defer k8shelper.DeleteNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
 
 	tfvars := TFVARS{
 		"namespace": namespace,

--- a/manifest/test/acceptance/service_test.go
+++ b/manifest/test/acceptance/service_test.go
@@ -1,0 +1,76 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"encoding/json"
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+// This test case tests a Service but also is a demonstration of some the assert functions
+// available in the test helper
+func TestKubernetesManifest_Service(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "services", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Service/service.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "services", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":      namespace,
+		"kubernetes_manifest.test.object.metadata.name":           name,
+		"kubernetes_manifest.test.object.spec.ports.0.name":       "http",
+		"kubernetes_manifest.test.object.spec.ports.0.port":       json.Number("80"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort": json.Number("8080"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":   "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":       "test",
+		"kubernetes_manifest.test.object.spec.type":               "ClusterIP",
+	})
+
+	tfconfigModified := loadTerraformConfig(t, "Service/service_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":        namespace,
+		"kubernetes_manifest.test.object.metadata.name":             name,
+		"kubernetes_manifest.test.object.metadata.annotations.test": "1",
+		"kubernetes_manifest.test.object.metadata.labels.test":      "2",
+		"kubernetes_manifest.test.object.spec.ports.0.name":         "https",
+		"kubernetes_manifest.test.object.spec.ports.0.port":         json.Number("443"),
+		"kubernetes_manifest.test.object.spec.ports.0.targetPort":   json.Number("8443"),
+		"kubernetes_manifest.test.object.spec.ports.0.protocol":     "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":         "test",
+		"kubernetes_manifest.test.object.spec.type":                 "ClusterIP",
+	})
+
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.labels", 1)
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.annotations", 1)
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+}

--- a/manifest/test/acceptance/testdata/Service/service.tf
+++ b/manifest/test/acceptance/testdata/Service/service.tf
@@ -1,0 +1,27 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      ports = [{
+        name       = "http",
+        port       = 80,
+        targetPort = 8080,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service/service_modified.tf
@@ -1,0 +1,33 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        test = "1"
+      }
+      labels = {
+        test = "2"
+      }
+    }
+    spec = {
+      ports = [{
+        name       = "https",
+        port       = 443,
+        targetPort = 8443,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service/variables.tf
+++ b/manifest/test/acceptance/testdata/Service/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/manifest/test/acceptance/testdata/Service_ClusterIP/service.tf
+++ b/manifest/test/acceptance/testdata/Service_ClusterIP/service.tf
@@ -1,0 +1,28 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      ports = [{
+        name       = "http",
+        port       = 80,
+        targetPort = 8080,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "ClusterIP"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_ClusterIP/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_ClusterIP/service_modified.tf
@@ -1,0 +1,34 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        test = "1"
+      }
+      labels = {
+        test = "2"
+      }
+    }
+    spec = {
+      ports = [{
+        name       = "https",
+        port       = 443,
+        targetPort = 8443,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "ClusterIP"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_ClusterIP/variables.tf
+++ b/manifest/test/acceptance/testdata/Service_ClusterIP/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/manifest/test/acceptance/testdata/Service_ExternalName/service.tf
+++ b/manifest/test/acceptance/testdata/Service_ExternalName/service.tf
@@ -1,0 +1,22 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      selector = {
+        app = "test"
+      }
+      type         = "ExternalName"
+      externalName = "terraform.kubernetes.test.com"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_ExternalName/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_ExternalName/service_modified.tf
@@ -1,0 +1,28 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        test = "1"
+      }
+      labels = {
+        test = "2"
+      }
+    }
+    spec = {
+      selector = {
+        app = "test"
+      }
+      type         = "ExternalName"
+      externalName = "kubernetes-alpha.terraform.test.com"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_ExternalName/variables.tf
+++ b/manifest/test/acceptance/testdata/Service_ExternalName/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/manifest/test/acceptance/testdata/Service_LoadBalancer/service.tf
+++ b/manifest/test/acceptance/testdata/Service_LoadBalancer/service.tf
@@ -1,0 +1,29 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+
+    spec = {
+      ports = [{
+        name       = "http",
+        port       = 80,
+        targetPort = 8080,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "LoadBalancer"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_LoadBalancer/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_LoadBalancer/service_modified.tf
@@ -1,0 +1,34 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        test = "1"
+      }
+      labels = {
+        test = "2"
+      }
+    }
+    spec = {
+      ports = [{
+        name       = "https",
+        port       = 443,
+        targetPort = 8443,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "LoadBalancer"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_LoadBalancer/variables.tf
+++ b/manifest/test/acceptance/testdata/Service_LoadBalancer/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/manifest/test/acceptance/testdata/Service_NodePort/service.tf
+++ b/manifest/test/acceptance/testdata/Service_NodePort/service.tf
@@ -1,0 +1,28 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      ports = [{
+        name       = "http",
+        port       = 80,
+        targetPort = 8080,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "NodePort"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_NodePort/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_NodePort/service_modified.tf
@@ -1,0 +1,35 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        test = "1"
+      }
+      labels = {
+        test = "2"
+      }
+    }
+    spec = {
+      ports = [{
+        name       = "https",
+        port       = 443,
+        targetPort = 8443,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+        nodePort = 32767
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "NodePort"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/Service_NodePort/variables.tf
+++ b/manifest/test/acceptance/testdata/Service_NodePort/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
### Description

This carries over the Service acceptance tests added by @redeux in https://github.com/hashicorp/terraform-provider-kubernetes-alpha/pull/198

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -v -tags acceptance ./manifest/test/acceptance -test.run 'TestKubernetesManifest_Service'
2021/11/09 16:29:09 Testing against Kubernetes API version: v1.21.1
=== RUN   TestKubernetesManifest_Service_ClusterIP
--- PASS: TestKubernetesManifest_Service_ClusterIP (3.94s)
=== RUN   TestKubernetesManifest_Service_ExternalName
--- PASS: TestKubernetesManifest_Service_ExternalName (4.04s)
=== RUN   TestKubernetesManifest_Service_LoadBalancer
--- PASS: TestKubernetesManifest_Service_LoadBalancer (4.05s)
=== RUN   TestKubernetesManifest_Service_NodePort
--- PASS: TestKubernetesManifest_Service_NodePort (4.05s)
=== RUN   TestKubernetesManifest_Service
--- PASS: TestKubernetesManifest_Service (3.97s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     20.147s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
