### PR TITLE
Fix code example in kubernetes_manifest

### DIFF
--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -17,7 +17,11 @@ How to enable the experiment:
 
 ```hcl
 provider "kubernetes" {
-  config_path = "~/.kube/config"
+  experiments {
+    manifest_resource = true
+  }
+
+  // provider config...
 }
 ```
 


### PR DESCRIPTION
### Description

This PR updates the provider code example to show to how you can enable the manifest experiment.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
