### PR TITLE
Fix invalid allowedHostPaths PodSecurityPolicy patch

### DIFF
--- a/kubernetes/resource_kubernetes_pod_security_policy_test.go
+++ b/kubernetes/resource_kubernetes_pod_security_policy_test.go
@@ -137,6 +137,9 @@ func TestAccKubernetesPodSecurityPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.default_allow_privilege_escalation", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.host_ipc", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.host_network", "true"),
+					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.allowed_host_paths.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.allowed_host_paths.0.path_prefix", "/"),
+					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.allowed_host_paths.0.read_only", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.allowed_unsafe_sysctls.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.allowed_unsafe_sysctls.0", "kernel.msg*"),
 					resource.TestCheckResourceAttr("kubernetes_pod_security_policy.test", "spec.0.forbidden_sysctls.#", "1"),
@@ -354,6 +357,11 @@ func testAccKubernetesPodSecurityPolicyConfig_specModified(name string) string {
       "downwardAPI",
       "persistentVolumeClaim",
     ]
+
+	allowed_host_paths {
+		path_prefix = "/"
+		read_only   = true
+	}
 
     allowed_unsafe_sysctls = [
       "kernel.msg*"

--- a/kubernetes/structure_pod_security_policy_spec.go
+++ b/kubernetes/structure_pod_security_policy_spec.go
@@ -518,9 +518,11 @@ func patchPodSecurityPolicySpec(keyPrefix string, pathPrefix string, d *schema.R
 	}
 
 	if d.HasChange(keyPrefix + "allowed_host_paths") {
+		n := d.Get(keyPrefix + "allowed_host_paths").([]interface{})
+		allowedHostPaths := expandAllowedHostPathSlice(n)
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/allowedHostPaths",
-			Value: d.Get(keyPrefix + "allowed_host_paths").([]interface{}),
+			Value: allowedHostPaths,
 		})
 	}
 


### PR DESCRIPTION
### Description

Fixes #997 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccKubernetesPodSecurityPolicy_basic'
...
TF_CLI_CONFIG_FILE=/Users/fhlq/Documents/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraformrc TF_PLUGIN_CACHE_DIR=/Users/fhlq/Documents/terraform-provider-kubernetes/kubernetes/test-infra/external-providers/.terraform TF_ACC=1 go test "/Users/fhlq/Documents/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesPodSecurityPolicy_basic -timeout 120m
=== RUN   TestAccKubernetesPodSecurityPolicy_basic
--- PASS: TestAccKubernetesPodSecurityPolicy_basic (23.42s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   23.946s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`kubernetes_pod_security_policy`: Fix `spec.allowedHostPaths[0]: Required value: is required` error when updating `allowed_host_paths`
```

### References

#997 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
