### PR TITLE
Fix crash when env is empty

### DIFF
--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -212,3 +212,48 @@ func TestExpandConfigMapKeyRef(t *testing.T) {
 		}
 	}
 }
+
+func TestExpandContainerEnv(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput []v1.EnvVar
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"name":  "PGUSER",
+					"value": "postgres",
+				},
+				map[string]interface{}{
+					"name":  "PGHOST",
+					"value": "localhost",
+				},
+			},
+			[]v1.EnvVar{
+				{
+					Name:  "PGUSER",
+					Value: "postgres",
+				},
+				{
+					Name:  "PGHOST",
+					Value: "localhost",
+				},
+			},
+		},
+		{
+			[]interface{}{nil},
+			[]v1.EnvVar{},
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandContainerEnv(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected failure in expander.\nInput: %#v, error: %#v", tc.Input, err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Fixes #1476 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix crash when env is empty
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
