### PR TITLE
Remove references to 'kubernetes_alpha' provider from Service tests.

### DIFF
--- a/manifest/test/acceptance/testdata/Service/service.tf
+++ b/manifest/test/acceptance/testdata/Service/service.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service/service_modified.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_ClusterIP/service.tf
+++ b/manifest/test/acceptance/testdata/Service_ClusterIP/service.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_ClusterIP/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_ClusterIP/service_modified.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_ExternalName/service.tf
+++ b/manifest/test/acceptance/testdata/Service_ExternalName/service.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_ExternalName/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_ExternalName/service_modified.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_LoadBalancer/service.tf
+++ b/manifest/test/acceptance/testdata/Service_LoadBalancer/service.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_LoadBalancer/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_LoadBalancer/service_modified.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_NodePort/service.tf
+++ b/manifest/test/acceptance/testdata/Service_NodePort/service.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"

--- a/manifest/test/acceptance/testdata/Service_NodePort/service_modified.tf
+++ b/manifest/test/acceptance/testdata/Service_NodePort/service_modified.tf
@@ -1,9 +1,4 @@
-provider "kubernetes-alpha" {
-}
-
 resource "kubernetes_manifest" "test" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "v1"
     kind       = "Service"


### PR DESCRIPTION


### Description

This change removes refrences to the  "kubernetes-alpha" provider, allowing tests to run against the current  branch.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -v -tags acceptance ./manifest/test/acceptance -test.run '^TestKubernetesManifest_Service'
2021/11/16 16:34:00 Testing against Kubernetes API version: v1.21.1
=== RUN   TestKubernetesManifest_Service_ClusterIP
--- PASS: TestKubernetesManifest_Service_ClusterIP (2.83s)
=== RUN   TestKubernetesManifest_Service_ExternalName
--- PASS: TestKubernetesManifest_Service_ExternalName (4.20s)
=== RUN   TestKubernetesManifest_Service_LoadBalancer
--- PASS: TestKubernetesManifest_Service_LoadBalancer (4.20s)
=== RUN   TestKubernetesManifest_Service_NodePort
--- PASS: TestKubernetesManifest_Service_NodePort (4.20s)
=== RUN   TestKubernetesManifest_Service
--- PASS: TestKubernetesManifest_Service (4.20s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     19.739s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
