### PR TITLE
Fix type-morphing of null and same type values.

### DIFF
--- a/manifest/morph/morph.go
+++ b/manifest/morph/morph.go
@@ -13,7 +13,7 @@ func ValueToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (tft
 		return tftypes.Value{}, p.NewErrorf("type is nil")
 	}
 	if v.IsNull() {
-		return v, nil
+		return tftypes.NewValue(t, nil), nil
 	}
 	switch {
 	case v.Type().Is(tftypes.String):

--- a/manifest/morph/morph_test.go
+++ b/manifest/morph/morph_test.go
@@ -175,6 +175,32 @@ func TestMorphValueToType(t *testing.T) {
 				tftypes.NewValue(tftypes.String, "baz"),
 			}),
 		},
+		"tuple(object)->list(object)": {
+			In: sampleInType{
+				V: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.DynamicPseudoType}},
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+				}},
+					[]tftypes.Value{
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+							map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, "foo")}),
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.DynamicPseudoType}},
+							map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.DynamicPseudoType, nil)}),
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+							map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, "baz")}),
+					}),
+				T: tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}}},
+			},
+			Out: tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}}}, []tftypes.Value{
+				tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+					map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, "foo")}),
+				tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+					map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, nil)}),
+				tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+					map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, "baz")}),
+			}),
+		},
 		"set->tuple": {
 			In: sampleInType{
 				V: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{

--- a/manifest/test/acceptance/customresource_test.go
+++ b/manifest/test/acceptance/customresource_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -74,5 +75,6 @@ func TestKubernetesManifest_CustomResource(t *testing.T) {
 		"kubernetes_manifest.test.object.metadata.name":      name,
 		"kubernetes_manifest.test.object.metadata.namespace": namespace,
 		"kubernetes_manifest.test.object.data":               "this is a test",
+		"kubernetes_manifest.test.object.stuff.0":            map[string]interface{}{"foo": interface{}(nil)},
 	})
 }

--- a/manifest/test/acceptance/customresourcedefinition_test.go
+++ b/manifest/test/acceptance/customresourcedefinition_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance
@@ -57,6 +58,17 @@ func TestKubernetesManifest_CustomResourceDefinition(t *testing.T) {
 					},
 					"refs": map[string]interface{}{
 						"type": "number",
+					},
+					"stuff": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"foo": map[string]interface{}{
+									"type": "string",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/manifest/test/acceptance/testdata/CustomResource/custom_resource.tf
+++ b/manifest/test/acceptance/testdata/CustomResource/custom_resource.tf
@@ -9,5 +9,10 @@ resource "kubernetes_manifest" "test" {
       name      = var.name
     }
     data = "this is a test"
+    stuff = [
+      {
+        foo = null
+      }
+    ]
   }
 }

--- a/manifest/test/acceptance/testdata/CustomResourceDefinition/customresourcedefinition.tf
+++ b/manifest/test/acceptance/testdata/CustomResourceDefinition/customresourcedefinition.tf
@@ -29,6 +29,17 @@ resource "kubernetes_manifest" "test" {
                 refs = {
                   type = "number"
                 }
+                stuff = {
+                  type = "array"
+                  items = {
+                    type = "object"
+                    properties = {
+                      foo = {
+                        type = "string"
+                      }
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
### Description

Fixes #1478 

Tests to follow next
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -v -tags acceptance ./manifest/test/acceptance -test.run '^TestKubernetesManifest_CustomResource'
2021/11/18 23:16:36 Testing against Kubernetes API version: v1.21.1
=== RUN   TestKubernetesManifest_CustomResource_Multiversion
--- PASS: TestKubernetesManifest_CustomResource_Multiversion (3.38s)
=== RUN   TestKubernetesManifest_CustomResource
--- PASS: TestKubernetesManifest_CustomResource (9.08s)
=== RUN   TestKubernetesManifest_CustomResource_OAPIv3_metadata
--- PASS: TestKubernetesManifest_CustomResource_OAPIv3_metadata (8.60s)
=== RUN   TestKubernetesManifest_CustomResource_OAPIv3
--- PASS: TestKubernetesManifest_CustomResource_OAPIv3 (8.63s)
=== RUN   TestKubernetesManifest_CustomResourceDefinition
--- PASS: TestKubernetesManifest_CustomResourceDefinition (0.98s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     30.780s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
