### PR TITLE
Use subcategories to group resources into API groups

### DIFF
--- a/website/docs/d/all_namespaces.html.markdown
+++ b/website/docs/d/all_namespaces.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_all_namespaces"
 description: |-

--- a/website/docs/d/config_map.html.markdown
+++ b/website/docs/d/config_map.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_config_map"
 description: |-

--- a/website/docs/d/config_map_v1.html.markdown
+++ b/website/docs/d/config_map_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_config_map_v1"
 description: |-

--- a/website/docs/d/ingress.html.markdown
+++ b/website/docs/d/ingress.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "extensions/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress"
 description: |-

--- a/website/docs/d/ingress_v1.html.markdown
+++ b/website/docs/d/ingress_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "networking/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress_v1"
 description: |-

--- a/website/docs/d/namespace.html.markdown
+++ b/website/docs/d/namespace.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_namespace"
 description: |-

--- a/website/docs/d/namespace_v1.html.markdown
+++ b/website/docs/d/namespace_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_namespace_v1"
 description: |-

--- a/website/docs/d/persistent_volume_claim.html.markdown
+++ b/website/docs/d/persistent_volume_claim.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume_claim"
 description: |-

--- a/website/docs/d/persistent_volume_claim_v1.html.markdown
+++ b/website/docs/d/persistent_volume_claim_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume_claim_v1"
 description: |-

--- a/website/docs/d/pod.html.markdown
+++ b/website/docs/d/pod.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod"
 description: |-

--- a/website/docs/d/pod_v1.html.markdown
+++ b/website/docs/d/pod_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod_v1"
 description: |-

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_secret"
 description: |-

--- a/website/docs/d/secret_v1.html.markdown
+++ b/website/docs/d/secret_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_secret_v1"
 description: |-

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service"
 description: |-

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_account"
 description: |-

--- a/website/docs/d/service_account_v1.html.markdown
+++ b/website/docs/d/service_account_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_account_v1"
 description: |-

--- a/website/docs/d/service_v1.html.markdown
+++ b/website/docs/d/service_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_v1"
 description: |-

--- a/website/docs/d/storage_class.html.markdown
+++ b/website/docs/d/storage_class.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "storage/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_storage_class"
 description: |-

--- a/website/docs/d/storage_class_v1.html.markdown
+++ b/website/docs/d/storage_class_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "storage/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_storage_class_v1"
 description: |-

--- a/website/docs/r/api_service.html.markdown
+++ b/website/docs/r/api_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apiregistration/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_api_service"
 description: |-

--- a/website/docs/r/api_service_v1.html.markdown
+++ b/website/docs/r/api_service_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apiregistration/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_api_service_v1"
 description: |-

--- a/website/docs/r/certificate_signing_request.html.markdown
+++ b/website/docs/r/certificate_signing_request.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "certificates/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_certificate_signing_request"
 description: |-

--- a/website/docs/r/certificate_signing_request_v1.html.markdown
+++ b/website/docs/r/certificate_signing_request_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "certificates/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_certificate_signing_request_v1"
 description: |-

--- a/website/docs/r/cluster_role.html.markdown
+++ b/website/docs/r/cluster_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_cluster_role"
 description: |-

--- a/website/docs/r/cluster_role_binding.html.markdown
+++ b/website/docs/r/cluster_role_binding.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_cluster_role_binding"
 description: |-

--- a/website/docs/r/cluster_role_binding_v1.html.markdown
+++ b/website/docs/r/cluster_role_binding_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_cluster_role_binding_v1"
 description: |-

--- a/website/docs/r/cluster_role_v1.html.markdown
+++ b/website/docs/r/cluster_role_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_cluster_role_v1"
 description: |-

--- a/website/docs/r/config_map.html.markdown
+++ b/website/docs/r/config_map.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_config_map"
 description: |-

--- a/website/docs/r/config_map_v1.html.markdown
+++ b/website/docs/r/config_map_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_config_map_v1"
 description: |-

--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "batch/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_cron_job"
 description: |-

--- a/website/docs/r/cron_job_v1.html.markdown
+++ b/website/docs/r/cron_job_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "batch/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_cron_job_v1"
 description: |-

--- a/website/docs/r/csi_driver.html.markdown
+++ b/website/docs/r/csi_driver.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "storage/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_csi_driver"
 description: |-

--- a/website/docs/r/csi_driver_v1.html.markdown
+++ b/website/docs/r/csi_driver_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "storage/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_csi_driver_v1"
 description: |-

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apps/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_daemon_set_v1"
 description: |-

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apps/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_daemonset"
 description: |-

--- a/website/docs/r/default_service_account.html.markdown
+++ b/website/docs/r/default_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_default_service_account"
 description: |-

--- a/website/docs/r/default_service_account_v1.html.markdown
+++ b/website/docs/r/default_service_account_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_default_service_account_v1"
 description: |-

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apps/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_deployment"
 description: |-

--- a/website/docs/r/deployment_v1.html.markdown
+++ b/website/docs/r/deployment_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apps/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_deployment_v1"
 description: |-

--- a/website/docs/r/endpoints.html.markdown
+++ b/website/docs/r/endpoints.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_endpoints"
 description: |-

--- a/website/docs/r/endpoints_v1.html.markdown
+++ b/website/docs/r/endpoints_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_endpoints_v1"
 description: |-

--- a/website/docs/r/horizontal_pod_autoscaler.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler.html.markdown
@@ -1,5 +1,6 @@
 ---
 layout: "kubernetes"
+subcategory: "autoscaling/v1"
 page_title: "Kubernetes: kubernetes_horizontal_pod_autoscaler"
 description: |-
   Horizontal Pod Autoscaler automatically scales the number of pods in a replication controller, deployment or replica set based on observed CPU utilization.

--- a/website/docs/r/horizontal_pod_autoscaler_v1.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "autoscaling/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_horizontal_pod_autoscaler_v1"
 description: |-

--- a/website/docs/r/horizontal_pod_autoscaler_v2beta2.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler_v2beta2.html.markdown
@@ -1,5 +1,6 @@
 ---
 layout: "kubernetes"
+subcategory: "autoscaling/v2beta2"
 page_title: "Kubernetes: kubernetes_horizontal_pod_autoscaler_v2beta2"
 description: |-
   Horizontal Pod Autoscaler automatically scales the number of pods in a replication controller, deployment or replica set based on observed CPU utilization.

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "extensions/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress"
 description: |-

--- a/website/docs/r/ingress_class.html.markdown
+++ b/website/docs/r/ingress_class.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "networking/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress_class"
 description: |-

--- a/website/docs/r/ingress_class_v1.html.markdown
+++ b/website/docs/r/ingress_class_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "networking/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress_class_v1"
 description: |-

--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "networking/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_ingress_v1"
 description: |-

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "batch/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_job"
 description: |-

--- a/website/docs/r/job_v1.html.markdown
+++ b/website/docs/r/job_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "batch/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_job_v1"
 description: |-

--- a/website/docs/r/limit_range.html.markdown
+++ b/website/docs/r/limit_range.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_limit_range"
 description: |-

--- a/website/docs/r/limit_range_v1.html.markdown
+++ b/website/docs/r/limit_range_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_limit_range_v1"
 description: |-

--- a/website/docs/r/mutating_webhook_configuration.html.markdown
+++ b/website/docs/r/mutating_webhook_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "admissionregistration/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: mutating_webhook_configuration"
 description: |-

--- a/website/docs/r/mutating_webhook_configuration_v1.html.markdown
+++ b/website/docs/r/mutating_webhook_configuration_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "admissionregistration/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: mutating_webhook_configuration_v1"
 description: |-

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_namespace"
 description: |-

--- a/website/docs/r/namespace_v1.html.markdown
+++ b/website/docs/r/namespace_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_namespace_v1"
 description: |-

--- a/website/docs/r/network_policy.html.markdown
+++ b/website/docs/r/network_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "networking/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_network_policy"
 description: |-

--- a/website/docs/r/network_policy_v1.html.markdown
+++ b/website/docs/r/network_policy_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "networking/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_network_policy_v1"
 description: |-

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume"
 description: |-

--- a/website/docs/r/persistent_volume_claim.html.markdown
+++ b/website/docs/r/persistent_volume_claim.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume_claim"
 description: |-

--- a/website/docs/r/persistent_volume_claim_v1.html.markdown
+++ b/website/docs/r/persistent_volume_claim_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume_claim_v1"
 description: |-

--- a/website/docs/r/persistent_volume_v1.html.markdown
+++ b/website/docs/r/persistent_volume_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_persistent_volume_v1"
 description: |-

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod"
 description: |-

--- a/website/docs/r/pod_disruption_budget.html.markdown
+++ b/website/docs/r/pod_disruption_budget.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "policy/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod_disruption_budget"
 description: |-

--- a/website/docs/r/pod_disruption_budget_v1.html.markdown
+++ b/website/docs/r/pod_disruption_budget_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "policy/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod_disruption_budget_v1"
 description: |-

--- a/website/docs/r/pod_security_policy.html.markdown
+++ b/website/docs/r/pod_security_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "policy/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod_security_policy"
 description: |-

--- a/website/docs/r/pod_security_policy_v1beta1.html.markdown
+++ b/website/docs/r/pod_security_policy_v1beta1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "policy/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod_security_policy_v1beta1"
 description: |-

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_pod_v1"
 description: |-

--- a/website/docs/r/priority_class.html.markdown
+++ b/website/docs/r/priority_class.html.markdown
@@ -1,18 +1,19 @@
 ---
+subcategory: "scheduling/v1"
 layout: "kubernetes"
-page_title: "Kubernetes: kubernetes_priority_class_v1"
+page_title: "Kubernetes: kubernetes_priority_class"
 description: |-
   A PriorityClass is a non-namespaced object that defines a mapping from a priority class name to the integer value of the priority.
 ---
 
-# kubernetes_priority_class_v1
+# kubernetes_priority_class
 
 A PriorityClass is a non-namespaced object that defines a mapping from a priority class name to the integer value of the priority.
 
 ## Example Usage
 
 ```hcl
-resource "kubernetes_priority_class_v1" "example" {
+resource "kubernetes_priority_class" "example" {
   metadata {
     name = "terraform-example"
   }
@@ -57,5 +58,5 @@ The following arguments are supported:
 Priority Class can be imported using its name, e.g.
 
 ```
-$ terraform import kubernetes_priority_class_v1.example terraform-example
+$ terraform import kubernetes_priority_class.example terraform-example
 ```

--- a/website/docs/r/priority_class_v1.html.markdown
+++ b/website/docs/r/priority_class_v1.html.markdown
@@ -1,18 +1,19 @@
 ---
+subcategory: "scheduling/v1"
 layout: "kubernetes"
-page_title: "Kubernetes: kubernetes_priority_class"
+page_title: "Kubernetes: kubernetes_priority_class_v1"
 description: |-
   A PriorityClass is a non-namespaced object that defines a mapping from a priority class name to the integer value of the priority.
 ---
 
-# kubernetes_priority_class
+# kubernetes_priority_class_v1
 
 A PriorityClass is a non-namespaced object that defines a mapping from a priority class name to the integer value of the priority.
 
 ## Example Usage
 
 ```hcl
-resource "kubernetes_priority_class" "example" {
+resource "kubernetes_priority_class_v1" "example" {
   metadata {
     name = "terraform-example"
   }
@@ -57,5 +58,5 @@ The following arguments are supported:
 Priority Class can be imported using its name, e.g.
 
 ```
-$ terraform import kubernetes_priority_class.example terraform-example
+$ terraform import kubernetes_priority_class_v1.example terraform-example
 ```

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_replication_controller"
 description: |-

--- a/website/docs/r/replication_controller_v1.html.markdown
+++ b/website/docs/r/replication_controller_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_replication_controller_v1"
 description: |-

--- a/website/docs/r/resource_quota.html.markdown
+++ b/website/docs/r/resource_quota.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_resource_quota"
 description: |-

--- a/website/docs/r/resource_quota_v1.html.markdown
+++ b/website/docs/r/resource_quota_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_resource_quota_v1"
 description: |-

--- a/website/docs/r/role.html.markdown
+++ b/website/docs/r/role.html.markdown
@@ -1,5 +1,6 @@
 ---
 layout: "kubernetes"
+subcategory: "rbac/v1"
 page_title: "Kubernetes: kubernetes_role"
 description: |-
   A role contains rules that represent a set of permissions. Permissions are purely additive (there are no “deny” rules).

--- a/website/docs/r/role_binding.html.markdown
+++ b/website/docs/r/role_binding.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_role_binding"
 description: |-

--- a/website/docs/r/role_binding_v1.html.markdown
+++ b/website/docs/r/role_binding_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_role_binding_v1"
 description: |-

--- a/website/docs/r/role_v1.html.markdown
+++ b/website/docs/r/role_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "rbac/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_role_v1"
 description: |-

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_secret"
 description: |-

--- a/website/docs/r/secret_v1.html.markdown
+++ b/website/docs/r/secret_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_secret_v1"
 description: |-

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service"
 description: |-

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_account"
 description: |-

--- a/website/docs/r/service_account_v1.html.markdown
+++ b/website/docs/r/service_account_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_account_v1"
 description: |-

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_service_v1"
 description: |-

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apps/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_stateful_set"
 description: |-

--- a/website/docs/r/stateful_set_v1.html.markdown
+++ b/website/docs/r/stateful_set_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "apps/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_stateful_set_v1"
 description: |-

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "storage/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_storage_class"
 description: |-

--- a/website/docs/r/storage_class_v1.html.markdown
+++ b/website/docs/r/storage_class_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "storage/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_storage_class_v1"
 description: |-

--- a/website/docs/r/validating_webhook_configuration.html.markdown
+++ b/website/docs/r/validating_webhook_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "admissionregistration/v1beta1"
 layout: "kubernetes"
 page_title: "Kubernetes: validating_webhook_configuration"
 description: |-

--- a/website/docs/r/validating_webhook_configuration_v1.html.markdown
+++ b/website/docs/r/validating_webhook_configuration_v1.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "admissionregistration/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: validating_webhook_configuration_v1"
 description: |-


### PR DESCRIPTION
### Description

Thought this was a good opportunity to group the docs into the API groups they belong to. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
