### PR TITLE
Fix map morphing in kubernetes_manifest

### DIFF
--- a/manifest/morph/morph.go
+++ b/manifest/morph/morph.go
@@ -284,16 +284,16 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 		}
 		return tftypes.NewValue(t, ovals), nil
 	case t.Is(tftypes.Map{}):
-		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(mvals))
+		var nmvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(mvals))
 		for k, v := range mvals {
 			elp := p.WithElementKeyString(k)
 			nv, err := ValueToType(v, t.(tftypes.Map).AttributeType, elp)
 			if err != nil {
 				return tftypes.Value{}, elp.NewErrorf("[%s] failed to morph object element into map element: %v", elp.String(), err)
 			}
-			mvals[k] = nv
+			nmvals[k] = nv
 		}
-		return tftypes.NewValue(t, mvals), nil
+		return tftypes.NewValue(t, nmvals), nil
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}

--- a/manifest/morph/morph_test.go
+++ b/manifest/morph/morph_test.go
@@ -288,6 +288,33 @@ func TestMorphValueToType(t *testing.T) {
 				"three": tftypes.NewValue(tftypes.String, "baz"),
 			}),
 		},
+		"object->object": {
+			In: sampleInType{
+				V: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"one":   tftypes.String,
+					"two":   tftypes.String,
+					"three": tftypes.String,
+				}}, map[string]tftypes.Value{
+					"one":   tftypes.NewValue(tftypes.String, "foo"),
+					"two":   tftypes.NewValue(tftypes.String, "bar"),
+					"three": tftypes.NewValue(tftypes.String, "baz"),
+				}),
+				T: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"one":   tftypes.String,
+					"two":   tftypes.String,
+					"three": tftypes.String,
+				}},
+			},
+			Out: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+				"one":   tftypes.String,
+				"two":   tftypes.String,
+				"three": tftypes.String,
+			}}, map[string]tftypes.Value{
+				"one":   tftypes.NewValue(tftypes.String, "foo"),
+				"two":   tftypes.NewValue(tftypes.String, "bar"),
+				"three": tftypes.NewValue(tftypes.String, "baz"),
+			}),
+		},
 
 		// Testcases to demonstrate https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/190
 		"string(unknown value)->string": {

--- a/manifest/morph/morph_test.go
+++ b/manifest/morph/morph_test.go
@@ -254,6 +254,21 @@ func TestMorphValueToType(t *testing.T) {
 				"three": tftypes.NewValue(tftypes.String, "baz"),
 			}),
 		},
+		"map->map": {
+			In: sampleInType{
+				V: tftypes.NewValue(tftypes.Map{AttributeType: tftypes.String}, map[string]tftypes.Value{
+					"one":   tftypes.NewValue(tftypes.String, "foo"),
+					"two":   tftypes.NewValue(tftypes.String, "bar"),
+					"three": tftypes.NewValue(tftypes.String, "baz"),
+				}),
+				T: tftypes.Map{AttributeType: tftypes.String},
+			},
+			Out: tftypes.NewValue(tftypes.Map{AttributeType: tftypes.String}, map[string]tftypes.Value{
+				"one":   tftypes.NewValue(tftypes.String, "foo"),
+				"two":   tftypes.NewValue(tftypes.String, "bar"),
+				"three": tftypes.NewValue(tftypes.String, "baz"),
+			}),
+		},
 		"object->map": {
 			In: sampleInType{
 				V: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{


### PR DESCRIPTION
### Description

Fix issue caused by variable shadowing in the type morphing logic. The variable shadowing was preventing values of maps to be carried over into the new maps when type morphing.

This issue was present for a long time but unable to manifest due to a type idempotency check.
It was uncovered by a recent change removing the check, here: https://github.com/hashicorp/terraform-provider-kubernetes/pull/1499/files#diff-e09004f47b5128fd62f2b4904fb3ce13ea675ae2ce393d4fbb8363e7d460de06L253

Fixes #1521 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* fix handling of map typed field values in `kubernetes_manifest`
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
