### PR TITLE
GKE test infra: use gcloud as auth provider

### DIFF
--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -85,7 +85,7 @@ locals {
           auth-provider = {
             name = "gcp"
             config = {
-              cmd-args = "config config-helper --format=json --access-token-file=gcptoken"
+              cmd-args = "config config-helper --format=json --access-token-file=$${GCPTOKEN}/gcptoken"
               cmd-path = "gcloud"
               expiry-key = "{.credential.token_expiry}"
               token-key = "{.credential.access_token}"

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -22,8 +22,8 @@ resource "random_id" "cluster_name" {
 }
 
 resource "google_service_account" "default" {
-  account_id   = "terraform-k8s"
-  display_name = "Service Account"
+  account_id   = "tf-k8s-${random_id.cluster_name.hex}"
+  display_name = "Kubernetes provider SA"
 }
 
 resource "google_container_cluster" "primary" {

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -85,7 +85,7 @@ locals {
           auth-provider = {
             name = "gcp"
             config = {
-              cmd-args = "config config-helper --format=json --access-token-file=$${GCPTOKEN}/gcptoken"
+              cmd-args = "config config-helper --format=json --access-token-file=${path.cwd}/gcptoken"
               cmd-path = "gcloud"
               expiry-key = "{.credential.token_expiry}"
               token-key = "{.credential.access_token}"


### PR DESCRIPTION
### Description

Some bits missing from the kubeconfig template for the GKE test infra.
This change enables client-go to use the gcloud cli tool as the auth provider plugin, allowing automatic token refreshing.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
