### PR TITLE
Fix the type of kubernetes_ingress_v1 port name

### DIFF
--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -45,7 +45,7 @@ func TestAccKubernetesIngressV1_serviceBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_ingress_v1.test", "spec.0.rule.0.http.0.path.0.path", "/.*"),
 					resource.TestCheckResourceAttr("kubernetes_ingress_v1.test", "spec.0.rule.0.http.0.path.0.backend.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_ingress_v1.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.name", "app2"),
-					resource.TestCheckResourceAttr("kubernetes_ingress_v1.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.port.0.number", "80"),
+					resource.TestCheckResourceAttr("kubernetes_ingress_v1.test", "spec.0.rule.0.http.0.path.0.backend.0.service.0.port.0.name", "http"),
 				),
 			},
 			{
@@ -320,7 +320,7 @@ func testAccKubernetesIngressV1Config_serviceBackend(name string) string {
             service {
               name = "app2"
               port {
-                number = 80
+                name = "http"
               }
             }
           }

--- a/kubernetes/schema_backend_spec_v1.go
+++ b/kubernetes/schema_backend_spec_v1.go
@@ -62,7 +62,7 @@ func backendSpecFieldsV1(description string) *schema.Schema {
 											Optional:    true,
 										},
 										"name": {
-											Type:        schema.TypeInt,
+											Type:        schema.TypeString,
 											Description: "Specifies the name of the port of the referenced service.",
 											Optional:    true,
 										},


### PR DESCRIPTION
### Description

Fixes the type of kubernetes_ingress_v1 service port name.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccKubernetesIngressV1_serviceBackend
--- PASS: TestAccKubernetesIngressV1_serviceBackend (8.16s)
=== RUN   TestAccKubernetesIngressV1_resourceBackend
--- PASS: TestAccKubernetesIngressV1_resourceBackend (4.64s)
=== RUN   TestAccKubernetesIngressV1_TLS
--- PASS: TestAccKubernetesIngressV1_TLS (7.86s)
=== RUN   TestAccKubernetesIngressV1_InternalKey
--- PASS: TestAccKubernetesIngressV1_InternalKey (11.64s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix: `spec.rule.http.path.backend.service.port.name` in `kubernetes_ingress_v1` should be type String 
```

### References

Fixes #1533.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
