### PR TITLE
Add `kubernetes_resource` data source

### DIFF
--- a/manifest/provider/datasource.go
+++ b/manifest/provider/datasource.go
@@ -1,0 +1,207 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/payload"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ReadDataSource function
+func (s *RawProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
+	s.logger.Trace("[ReadDataSource][Request]\n%s\n", dump(*req))
+
+	resp := &tfprotov5.ReadDataSourceResponse{}
+
+	execDiag := s.canExecute()
+	if len(execDiag) > 0 {
+		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
+		return resp, nil
+	}
+
+	rt, err := GetDataSourceType(req.TypeName)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to determine data source type",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	config, err := req.Config.Unmarshal(rt)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to unmarshal data source configuration",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	var dsConfig map[string]tftypes.Value
+	err = config.As(&dsConfig)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to extract attributes from data source configuration",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	rm, err := s.getRestMapper()
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to get RESTMapper client",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	client, err := s.getDynamicClient()
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "failed to get Dynamic client",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	var apiVersion, kind string
+	dsConfig["api_version"].As(&apiVersion)
+	dsConfig["kind"].As(&kind)
+
+	gvr, err := getGVR(apiVersion, kind, rm)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to determine resource GroupVersion",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	gvk := gvr.GroupVersion().WithKind(kind)
+	ns, err := IsResourceNamespaced(gvk, rm)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed determine if resource is namespaced",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	rcl := client.Resource(gvr)
+
+	objectType, th, err := s.TFTypeFromOpenAPI(ctx, gvk, false)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to save resource state",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	var metadataBlock []tftypes.Value
+	dsConfig["metadata"].As(&metadataBlock)
+
+	var metadata map[string]tftypes.Value
+	metadataBlock[0].As(&metadata)
+
+	var name string
+	metadata["name"].As(&name)
+
+	var res *unstructured.Unstructured
+	if ns {
+		var namespace string
+		metadata["namespace"].As(&namespace)
+		if namespace == "" {
+			namespace = "default"
+		}
+		res, err = rcl.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	} else {
+		res, err = rcl.Get(ctx, name, metav1.GetOptions{})
+	}
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return resp, nil
+		}
+		d := tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  fmt.Sprintf("Failed to get data source"),
+			Detail:   err.Error(),
+		}
+		resp.Diagnostics = append(resp.Diagnostics, &d)
+		return resp, nil
+	}
+
+	fo := RemoveServerSideFields(res.Object)
+	nobj, err := payload.ToTFValue(fo, objectType, th, tftypes.NewAttributePath())
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to convert API response to Terraform value type",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+
+	nobj, err = morph.DeepUnknown(objectType, nobj, tftypes.NewAttributePath())
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to save resource state",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	rawState := make(map[string]tftypes.Value)
+	err = config.As(&rawState)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to save resource state",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	rawState["object"] = morph.UnknownToNull(nobj)
+
+	v := tftypes.NewValue(rt, rawState)
+	state, err := tfprotov5.NewDynamicValue(v.Type(), v)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Failed to save resource state",
+			Detail:   err.Error(),
+		})
+		return resp, nil
+	}
+	resp.State = &state
+	return resp, nil
+}
+
+func getGVR(apiVersion, kind string, m meta.RESTMapper) (schema.GroupVersionResource, error) {
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	mapping, err := m.RESTMapping(gv.WithKind(kind).GroupKind(), gv.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, err
+}

--- a/manifest/provider/getproviderschema.go
+++ b/manifest/provider/getproviderschema.go
@@ -12,9 +12,11 @@ func (s *RawProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov
 	cfgSchema := GetProviderConfigSchema()
 
 	resSchema := GetProviderResourceSchema()
+	dsSchema := GetProviderDataSourceSchema()
 
 	return &tfprotov5.GetProviderSchemaResponse{
-		Provider:        cfgSchema,
-		ResourceSchemas: resSchema,
+		Provider:          cfgSchema,
+		ResourceSchemas:   resSchema,
+		DataSourceSchemas: dsSchema,
 	}, nil
 }

--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -39,6 +39,16 @@ func GetResourceType(name string) (tftypes.Type, error) {
 	return GetObjectTypeFromSchema(rsch), nil
 }
 
+// GetDataSourceType returns the tftypes.Type of a datasource of type 'name'
+func GetDataSourceType(name string) (tftypes.Type, error) {
+	sch := GetProviderDataSourceSchema()
+	rsch, ok := sch[name]
+	if !ok {
+		return tftypes.DynamicPseudoType, fmt.Errorf("unknown data source %q: cannot find schema", name)
+	}
+	return GetObjectTypeFromSchema(rsch), nil
+}
+
 // GetProviderResourceSchema contains the definitions of all supported resources
 func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 	waitForType := tftypes.Object{
@@ -141,6 +151,63 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 						Type:        tftypes.List{ElementType: tftypes.String},
 						Description: "List of manifest fields whose values can be altered by the API server during 'apply'. Defaults to: [\"metadata.annotations\", \"metadata.labels\"]",
 						Optional:    true,
+					},
+				},
+			},
+		},
+	}
+}
+
+// GetProviderDataSourceSchema contains the definitions of all supported data sources
+func GetProviderDataSourceSchema() map[string]*tfprotov5.Schema {
+	return map[string]*tfprotov5.Schema{
+		"kubernetes_resource": {
+			Version: 1,
+			Block: &tfprotov5.SchemaBlock{
+				Attributes: []*tfprotov5.SchemaAttribute{
+					{
+						Name:        "api_version",
+						Type:        tftypes.String,
+						Required:    true,
+						Description: "The resource apiVersion.",
+					},
+					{
+						Name:        "kind",
+						Type:        tftypes.String,
+						Required:    true,
+						Description: "The resource kind.",
+					},
+					{
+						Name:        "object",
+						Type:        tftypes.DynamicPseudoType,
+						Optional:    true,
+						Computed:    true,
+						Description: "The response from the API server.",
+					},
+				},
+				BlockTypes: []*tfprotov5.SchemaNestedBlock{
+					{
+						TypeName: "metadata",
+						Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+						MinItems: 1,
+						MaxItems: 1,
+						Block: &tfprotov5.SchemaBlock{
+							Description: "Metadata for the resource",
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:        "name",
+									Type:        tftypes.String,
+									Required:    true,
+									Description: "The resource name.",
+								},
+								{
+									Name:        "namespace",
+									Type:        tftypes.String,
+									Optional:    true,
+									Description: "The resource namespace.",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -55,13 +55,6 @@ func (s *RawProviderServer) ValidateDataSourceConfig(ctx context.Context, req *t
 	return resp, nil
 }
 
-// ReadDataSource function
-func (s *RawProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
-	s.logger.Trace("[ReadDataSource][Request]\n%s\n", dump(*req))
-
-	return nil, status.Errorf(codes.Unimplemented, "method ReadDataSource not implemented")
-}
-
 // StopProvider function
 func (s *RawProviderServer) StopProvider(ctx context.Context, req *tfprotov5.StopProviderRequest) (*tfprotov5.StopProviderResponse, error) {
 	s.logger.Trace("[StopProvider][Request]\n%s\n", dump(*req))

--- a/manifest/test/acceptance/datasource_test.go
+++ b/manifest/test/acceptance/datasource_test.go
@@ -1,0 +1,73 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
+	name := randName()
+	name2 := randName()
+	namespace := randName()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+
+	// STEP 1: Create a ConfigMap to use as a data source
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+	}()
+
+	tfvars := TFVARS{
+		"name":      name,
+		"name2":     name2,
+		"namespace": namespace,
+	}
+	tfconfig := loadTerraformConfig(t, "datasource/step1.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)
+
+	// STEP 2: Create another ConfigMap using the ConfigMap from step 1 as a data source
+	reattachInfo2, err := provider.ServeTest(context.TODO(), hclog.Default())
+	if err != nil {
+		t.Errorf("Failed to create additional provider instance: %q", err)
+	}
+	step2 := tfhelper.RequireNewWorkingDir(t)
+	step2.SetReattachInfo(reattachInfo2)
+	defer func() {
+		step2.RequireDestroy(t)
+		step2.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name2)
+	}()
+
+	tfconfig = loadTerraformConfig(t, "datasource/step2.tf", tfvars)
+	step2.RequireSetConfig(t, string(tfconfig))
+	step2.RequireInit(t)
+	step2.RequireApply(t)
+
+	tfstate := tfstatehelper.NewHelper(step2.RequireState(t))
+
+	// check the data source
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"data.kubernetes_resource.test_config.object.data.TEST": "hello world",
+	})
+	// check the resource was created with the correct value
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test_config2.object.data.TEST": "hello world",
+	})
+}

--- a/manifest/test/acceptance/datasource_test.go
+++ b/manifest/test/acceptance/datasource_test.go
@@ -14,6 +14,13 @@ import (
 )
 
 func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
+	ctx := context.Background()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
 	name := randName()
 	name2 := randName()
 	namespace := randName()
@@ -43,7 +50,7 @@ func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
 	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)
 
 	// STEP 2: Create another ConfigMap using the ConfigMap from step 1 as a data source
-	reattachInfo2, err := provider.ServeTest(context.TODO(), hclog.Default())
+	reattachInfo2, err := provider.ServeTest(ctx, hclog.Default(), t)
 	if err != nil {
 		t.Errorf("Failed to create additional provider instance: %q", err)
 	}

--- a/manifest/test/acceptance/testdata/datasource/step1.tf
+++ b/manifest/test/acceptance/testdata/datasource/step1.tf
@@ -1,0 +1,13 @@
+resource "kubernetes_manifest" "test_config" {
+  manifest = {
+    "apiVersion" = "v1"
+    "kind"       = "ConfigMap"
+    "metadata" = {
+      "name" = var.name
+      "namespace" = var.namespace
+    }
+    "data" = {
+      "TEST" = "hello world"
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/datasource/step2.tf
+++ b/manifest/test/acceptance/testdata/datasource/step2.tf
@@ -1,0 +1,22 @@
+data "kubernetes_resource" "test_config" {
+  api_version = "v1"
+  kind = "ConfigMap"
+  metadata {
+    name = var.name
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_manifest" "test_config2" {
+  manifest = {
+    "apiVersion" = "v1"
+    "kind"       = "ConfigMap"
+    "metadata" = {
+      "name" = var.name2
+      "namespace" = var.namespace
+    }
+    "data" = {
+      "TEST" = data.kubernetes_resource.test_config.object.data.TEST
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/datasource/variables.tf
+++ b/manifest/test/acceptance/testdata/datasource/variables.tf
@@ -1,0 +1,20 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "name2" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/website/docs/d/resource.html.markdown
+++ b/website/docs/d/resource.html.markdown
@@ -14,7 +14,7 @@ This data source is a generic way to retrieve resources from the Kubernetes API.
 ```hcl
 data "kubernetes_resource" "example" {
   api_version = "v1"
-  kind       = "ConfigMap"
+  kind        = "ConfigMap"
 
   metadata {
     name      = "example"

--- a/website/docs/d/resource.html.markdown
+++ b/website/docs/d/resource.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_resource"
+description: |-
+  This is a generic data source for Kubernetes API resources
+---
+
+# kubernetes_resource
+
+This data source is a generic way to retrieve resources from the Kubernetes API. 
+
+### Example: Get data from a ConfigMap
+
+```hcl
+data "kubernetes_resource" "example" {
+  api_version = "v1"
+  kind       = "ConfigMap"
+
+  metadata {
+    name      = "example"
+    namespace = "default"
+  }
+}
+
+output "test" {
+  value = data.kubernetes_resource.example.object.data.TEST
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_version` - (Required) The API version for the requested resource.
+* `kind` - (Required) The kind for the requested resource.
+* `metadata` - (Required) The metadata for the requested resource.
+* `object` - (Optional) The response returned from the API server.
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) The name of the requested resource.
+* `namespace` - (Optional) The namespace of the requested resource.
+


### PR DESCRIPTION
### Description

This PR adds a generic `kubernetes_resource` data source as an analogue to the `kubernetes_manifest` resource. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add kubernetes_resource data source
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
