### PR TITLE
Add rollout flag to wait_for block in kubernetes_manifest

### DIFF
--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -43,6 +43,7 @@ func GetResourceType(name string) (tftypes.Type, error) {
 func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 	waitForType := tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
+			"rollout": tftypes.Bool,
 			"fields": tftypes.Map{
 				AttributeType: tftypes.String,
 			},

--- a/manifest/provider/waiter.go
+++ b/manifest/provider/waiter.go
@@ -17,7 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/kubectl/pkg/polymorphichelpers"
 )
+
+const waiterSleepTime = 1 * time.Second
 
 func (s *RawProviderServer) waitForCompletion(ctx context.Context, waitForBlock tftypes.Value, rs dynamic.ResourceInterface, rname string, rtype tftypes.Type) error {
 	if waitForBlock.IsNull() || !waitForBlock.IsKnown() {
@@ -37,11 +40,25 @@ type Waiter interface {
 }
 
 // NewResourceWaiter constructs an appropriate Waiter using the supplied waitForBlock configuration
-func NewResourceWaiter(resource dynamic.ResourceInterface, resourceName string, resourceType tftypes.Type, waitForBlock tftypes.Value, hl hclog.Logger) (Waiter, error) {
+func NewResourceWaiter(resource dynamic.ResourceInterface,
+	resourceName string, resourceType tftypes.Type,
+	waitForBlock tftypes.Value, hl hclog.Logger) (Waiter, error) {
 	var waitForBlockVal map[string]tftypes.Value
 	err := waitForBlock.As(&waitForBlockVal)
 	if err != nil {
 		return nil, err
+	}
+
+	if v, ok := waitForBlockVal["rollout"]; ok {
+		var rollout bool
+		v.As(&rollout)
+		if rollout {
+			return &RolloutWaiter{
+				resource,
+				resourceName,
+				hl,
+			}, nil
+		}
 	}
 
 	fields, ok := waitForBlockVal["fields"]
@@ -183,7 +200,7 @@ func (w *FieldWaiter) Wait(ctx context.Context) error {
 		}
 
 		// TODO: implement with exponential back-off.
-		time.Sleep(1 * time.Second) // lintignore:R018
+		time.Sleep(waiterSleepTime) // lintignore:R018
 	}
 }
 
@@ -233,4 +250,52 @@ func FieldPathToTftypesPath(fieldPath string) (*tftypes.AttributePath, error) {
 	}
 
 	return path, nil
+}
+
+// FieldWaiter will wait for a resource that has a StatusViewer to
+// finish rolling out
+type RolloutWaiter struct {
+	resource     dynamic.ResourceInterface
+	resourceName string
+	logger       hclog.Logger
+}
+
+// Wait uses StatusViewer to determine if the rollout is done
+func (w *RolloutWaiter) Wait(ctx context.Context) error {
+	w.logger.Info("[ApplyResourceChange][Wait] Waiting until rollout complete...\n")
+	for {
+		if deadline, ok := ctx.Deadline(); ok {
+			if time.Now().After(deadline) {
+				return context.DeadlineExceeded
+			}
+		}
+
+		res, err := w.resource.Get(ctx, w.resourceName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if errors.IsGone(err) {
+			return fmt.Errorf("resource was deleted")
+		}
+
+		gk := res.GetObjectKind().GroupVersionKind().GroupKind()
+		statusViewer, err := polymorphichelpers.StatusViewerFor(gk)
+		if err != nil {
+			return fmt.Errorf("error getting resource status: %v", err)
+		}
+
+		_, done, err := statusViewer.Status(res, 0)
+		if err != nil {
+			return fmt.Errorf("error getting resource status: %v", err)
+		}
+
+		if done {
+			break
+		}
+
+		time.Sleep(waiterSleepTime) // lintignore:R018
+	}
+
+	w.logger.Info("[ApplyResourceChange][Wait] Rollout complete\n")
+	return nil
 }

--- a/manifest/test/acceptance/testdata/WaitFor/wait_for_rollout.tf
+++ b/manifest/test/acceptance/testdata/WaitFor/wait_for_rollout.tf
@@ -1,0 +1,47 @@
+resource kubernetes_manifest wait_for_rollout {
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name       = var.name
+      namespace  = var.namespace
+    }
+    spec = {
+      replicas = 2
+      selector = {
+        matchLabels = {
+          app = "tf-acc-test"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            app = "tf-acc-test"
+          }
+        }
+        spec = {
+          containers = [
+            {
+              image           = "nginx:1.19.4"
+              imagePullPolicy = "IfNotPresent"
+              name            = "tf-acc-test"
+              readinessProbe  = {
+                httpGet = {
+                  port = 80
+                  path = "/"
+                }
+                initialDelaySeconds = 10
+              }
+            },
+          ]
+        }
+      }
+    }
+  }
+
+  wait_for = {
+    rollout = true
+    
+    fields = {} # FIXME remove this
+  }
+}

--- a/manifest/test/acceptance/wait_for_test.go
+++ b/manifest/test/acceptance/wait_for_test.go
@@ -61,3 +61,45 @@ func TestKubernetesManifest_WaitForFields_Pod(t *testing.T) {
 		},
 	})
 }
+
+func TestKubernetesManifest_WaitForRollout_Deployment(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "apps/v1", "deployments", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "WaitFor/wait_for_rollout.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+
+	startTime := time.Now()
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "apps/v1", "deployments", namespace, name)
+
+	// NOTE We set a readinessProbe in the fixture with a delay of 10s
+	// so the apply should take at least 10 seconds to complete.
+	minDuration := time.Duration(5) * time.Second
+	applyDuration := time.Since(startTime)
+	if applyDuration < minDuration {
+		t.Fatalf("the apply should have taken at least %s", minDuration)
+	}
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.wait_for_rollout.wait_for.rollout": true,
+	})
+}

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -207,7 +207,8 @@ The following arguments are supported:
 
 #### Arguments
 
-- **fields** (Required) A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use `*` for any value. 
+- **rollout** (Optional) When set to `true` will wait for the resource to roll out, equivalent to `kubectl rollout status`. 
+- **fields** (Optional) A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use `*` for any value. 
 
 ### `field_manager`
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add rollout option to wait_for block in kubernetes_manifest
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
