### PR TITLE
Fix kubernetes default service account

### DIFF
--- a/kubernetes/resource_kubernetes_default_service_account.go
+++ b/kubernetes/resource_kubernetes_default_service_account.go
@@ -61,22 +61,19 @@ func resourceKubernetesDefaultServiceAccountCreate(ctx context.Context, d *schem
 	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
-	if d.HasChange("image_pull_secret") {
-		v := d.Get("image_pull_secret").(*schema.Set).List()
-		ops = append(ops, &ReplaceOperation{
-			Path:  "/imagePullSecrets",
-			Value: expandLocalObjectReferenceArray(v),
-		})
-	}
-	if d.HasChange("secret") {
-		v := d.Get("secret").(*schema.Set).List()
-		defaultSecretName := d.Get("default_secret_name").(string)
+	imagePullSecrets := d.Get("image_pull_secret").(*schema.Set).List()
+	ops = append(ops, &ReplaceOperation{
+		Path:  "/imagePullSecrets",
+		Value: expandLocalObjectReferenceArray(imagePullSecrets),
+	})
 
-		ops = append(ops, &ReplaceOperation{
-			Path:  "/secrets",
-			Value: expandServiceAccountSecrets(v, defaultSecretName),
-		})
-	}
+	secrets := d.Get("secret").(*schema.Set).List()
+	defaultSecretName := d.Get("default_secret_name").(string)
+
+	ops = append(ops, &ReplaceOperation{
+		Path:  "/secrets",
+		Value: expandServiceAccountSecrets(secrets, defaultSecretName),
+	})
 
 	automountServiceAccountToken := d.Get("automount_service_account_token").(bool)
 	ops = append(ops, &ReplaceOperation{

--- a/kubernetes/resource_kubernetes_default_service_account.go
+++ b/kubernetes/resource_kubernetes_default_service_account.go
@@ -60,24 +60,40 @@ func resourceKubernetesDefaultServiceAccountCreate(ctx context.Context, d *schem
 		return diag.FromErr(err)
 	}
 
-	if v, ok := d.GetOkExists("automount_service_account_token"); ok {
-		ops := patchMetadata("metadata.0.", "/metadata/", d)
+	ops := patchMetadata("metadata.0.", "/metadata/", d)
+	if d.HasChange("image_pull_secret") {
+		v := d.Get("image_pull_secret").(*schema.Set).List()
 		ops = append(ops, &ReplaceOperation{
-			Path:  "/automountServiceAccountToken",
-			Value: v.(bool),
+			Path:  "/imagePullSecrets",
+			Value: expandLocalObjectReferenceArray(v),
 		})
-
-		data, err := ops.MarshalJSON()
-		if err != nil {
-			return diag.Errorf("Failed to marshal update operations: %s", err)
-		}
-		log.Printf("[INFO] Updating default service account %q: %v", metadata.Name, string(data))
-		out, err := conn.CoreV1().ServiceAccounts(metadata.Namespace).Patch(ctx, metadata.Name, pkgApi.JSONPatchType, data, metav1.PatchOptions{})
-		if err != nil {
-			return diag.Errorf("Failed to update default service account: %s", err)
-		}
-		log.Printf("[INFO] Submitted updated default service account: %#v", out)
 	}
+	if d.HasChange("secret") {
+		v := d.Get("secret").(*schema.Set).List()
+		defaultSecretName := d.Get("default_secret_name").(string)
+
+		ops = append(ops, &ReplaceOperation{
+			Path:  "/secrets",
+			Value: expandServiceAccountSecrets(v, defaultSecretName),
+		})
+	}
+
+	automountServiceAccountToken := d.Get("automount_service_account_token").(bool)
+	ops = append(ops, &ReplaceOperation{
+		Path:  "/automountServiceAccountToken",
+		Value: automountServiceAccountToken,
+	})
+
+	data, err := ops.MarshalJSON()
+	if err != nil {
+		return diag.Errorf("Failed to marshal update operations: %s", err)
+	}
+	log.Printf("[INFO] Updating default service account %q: %v", metadata.Name, string(data))
+	out, err := conn.CoreV1().ServiceAccounts(metadata.Namespace).Patch(ctx, metadata.Name, pkgApi.JSONPatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return diag.Errorf("Failed to update default service account: %s", err)
+	}
+	log.Printf("[INFO] Submitted updated default service account: %#v", out)
 
 	d.SetId(buildId(metadata))
 
@@ -87,5 +103,5 @@ func resourceKubernetesDefaultServiceAccountCreate(ctx context.Context, d *schem
 	}
 	d.Set("default_secret_name", secret.Name)
 
-	return resourceKubernetesServiceAccountUpdate(ctx, d, meta)
+	return resourceKubernetesServiceAccountRead(ctx, d, meta)
 }


### PR DESCRIPTION
### Description

Fixes `kubernetes_default_service_account` to set `automount_service_account_token` to false. 
Issue https://github.com/hashicorp/terraform-provider-kubernetes/issues/1247

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
=== RUN   TestAccKubernetesDefaultServiceAccount_basic
--- PASS: TestAccKubernetesDefaultServiceAccount_basic (16.35s)
=== RUN   TestAccKubernetesDefaultServiceAccount_secrets
--- PASS: TestAccKubernetesDefaultServiceAccount_secrets (10.32s)
=== RUN   TestAccKubernetesDefaultServiceAccount_automountServiceAccountToken
--- PASS: TestAccKubernetesDefaultServiceAccount_automountServiceAccountToken (10.77s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   38.141s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):


```release-note
Fix `kubernetes_default_service_account` doesn't set the `automount_service_account_token` to false.
```

### References
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1247


### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
