### PR TITLE
Add nested condition block to wait block

### DIFF
--- a/manifest/provider/waiter.go
+++ b/manifest/provider/waiter.go
@@ -59,6 +59,19 @@ func NewResourceWaiter(resource dynamic.ResourceInterface, resourceName string, 
 		}
 	}
 
+	if v, ok := waitForBlockVal["condition"]; ok {
+		var conditionsBlocks []tftypes.Value
+		v.As(&conditionsBlocks)
+		if len(conditionsBlocks) > 0 {
+			return &ConditionsWaiter{
+				resource,
+				resourceName,
+				conditionsBlocks,
+				hl,
+			}, nil
+		}
+	}
+
 	fields, ok := waitForBlockVal["fields"]
 	if !ok || fields.IsNull() || !fields.IsKnown() {
 		return &NoopWaiter{}, nil
@@ -298,5 +311,69 @@ func (w *RolloutWaiter) Wait(ctx context.Context) error {
 	}
 
 	w.logger.Info("[ApplyResourceChange][Wait] Rollout complete\n")
+	return nil
+}
+
+// ConditionsWaiter will wait for the specified conditions on
+// the resource to be met
+type ConditionsWaiter struct {
+	resource     dynamic.ResourceInterface
+	resourceName string
+	conditions   []tftypes.Value
+	logger       hclog.Logger
+}
+
+// Wait checks all the configured conditions have been met
+func (w *ConditionsWaiter) Wait(ctx context.Context) error {
+	w.logger.Info("[ApplyResourceChange][Wait] Waiting for conditions...\n")
+
+	for {
+		if deadline, ok := ctx.Deadline(); ok {
+			if time.Now().After(deadline) {
+				return context.DeadlineExceeded
+			}
+		}
+
+		res, err := w.resource.Get(ctx, w.resourceName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if errors.IsGone(err) {
+			return fmt.Errorf("resource was deleted")
+		}
+
+		status := res.Object["status"].(map[string]interface{})
+		conditions := status["conditions"].([]interface{})
+		conditionsMet := map[string]bool{}
+		for _, c := range w.conditions {
+			var condition map[string]tftypes.Value
+			c.As(&condition)
+			var conditionType, conditionStatus string
+			condition["type"].As(&conditionType)
+			condition["status"].As(&conditionStatus)
+			conditionsMet[conditionType] = false
+			for _, cc := range conditions {
+				ccc := cc.(map[string]interface{})
+				if ccc["type"].(string) != conditionType {
+					continue
+				}
+				conditionsMet[conditionType] = ccc["status"].(string) == conditionStatus
+			}
+		}
+
+		done := true
+		for _, v := range conditionsMet {
+			if !v {
+				done = false
+			}
+		}
+		if done {
+			break
+		}
+
+		time.Sleep(waiterSleepTime) // lintignore:R018
+	}
+
+	w.logger.Info("[ApplyResourceChange][Wait] All conditions met.\n")
 	return nil
 }

--- a/manifest/test/acceptance/testdata/Wait/wait_for_conditions.tf
+++ b/manifest/test/acceptance/testdata/Wait/wait_for_conditions.tf
@@ -1,0 +1,51 @@
+
+resource "kubernetes_manifest" "test" {
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Pod"
+
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+
+      annotations = {
+        "test.terraform.io" = "test"
+      }
+
+      labels = {
+        app = "nginx"
+      }
+    }
+
+    spec = {
+      containers = [
+        {
+          name  = "nginx"
+          image = "nginx:1.19"
+
+          readinessProbe = {
+            initialDelaySeconds = 10
+
+            httpGet = {
+              path = "/"
+              port = 80
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  wait {
+    condition {
+      type = "Ready"
+      status = "True"
+    }
+
+    condition {
+      type = "ContainersReady"
+      status = "True"
+    }
+  }
+}

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -200,6 +200,7 @@ The following arguments are supported:
 #### Arguments
 
 - **rollout** (Optional) When set to `true` will wait for the resource to roll out, equivalent to `kubectl rollout status`. 
+- **conditions** (Optional) A set of conditions to wait for.
 - **fields** (Optional) A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use `*` for any value. 
 
 ### `wait_for` (deprecated, use `wait`)


### PR DESCRIPTION
### Description

This PR adds a nested `condition` block to the `wait` block to configure sets of conditions to wait to be met. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add nested condition block to wait block 
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
