### PR TITLE
Updated an Nginx image version and Liveness probe target in the examples

### DIFF
--- a/website/docs/guides/v2-upgrade-guide.markdown
+++ b/website/docs/guides/v2-upgrade-guide.markdown
@@ -214,7 +214,7 @@ resource "kubernetes_deployment" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
         }
 
@@ -274,7 +274,7 @@ resource "kubernetes_pod" "test" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
 
       resources {

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -38,7 +38,7 @@ resource "kubernetes_daemon_set_v1" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
 
           resources {
@@ -54,7 +54,7 @@ resource "kubernetes_daemon_set_v1" "example" {
 
           liveness_probe {
             http_get {
-              path = "/nginx_status"
+              path = "/"
               port = 80
 
               http_header {

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -38,7 +38,7 @@ resource "kubernetes_daemonset" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
 
           resources {
@@ -54,7 +54,7 @@ resource "kubernetes_daemonset" "example" {
 
           liveness_probe {
             http_get {
-              path = "/nginx_status"
+              path = "/"
               port = 80
 
               http_header {

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -40,7 +40,7 @@ resource "kubernetes_deployment" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
 
           resources {
@@ -56,7 +56,7 @@ resource "kubernetes_deployment" "example" {
 
           liveness_probe {
             http_get {
-              path = "/nginx_status"
+              path = "/"
               port = 80
 
               http_header {

--- a/website/docs/r/deployment_v1.html.markdown
+++ b/website/docs/r/deployment_v1.html.markdown
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
 
           resources {
@@ -56,7 +56,7 @@ resource "kubernetes_deployment_v1" "example" {
 
           liveness_probe {
             http_get {
-              path = "/nginx_status"
+              path = "/"
               port = 80
 
               http_header {

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -93,7 +93,7 @@ resource "kubernetes_pod" "example" {
   metadata {
     name = "terraform-example"
     labels = {
-      app = "MyApp1"
+      app = "myapp-1"
     }
   }
 
@@ -113,7 +113,7 @@ resource "kubernetes_pod" "example2" {
   metadata {
     name = "terraform-example2"
     labels = {
-      app = "MyApp2"
+      app = "myapp-2"
     }
   }
 

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -21,7 +21,7 @@ resource "kubernetes_ingress" "example_ingress" {
 
   spec {
     backend {
-      service_name = "MyApp1"
+      service_name = "myapp-1"
       service_port = 8080
     }
 
@@ -29,7 +29,7 @@ resource "kubernetes_ingress" "example_ingress" {
       http {
         path {
           backend {
-            service_name = "MyApp1"
+            service_name = "myapp-1"
             service_port = 8080
           }
 
@@ -38,7 +38,7 @@ resource "kubernetes_ingress" "example_ingress" {
 
         path {
           backend {
-            service_name = "MyApp2"
+            service_name = "myapp-2"
             service_port = 8080
           }
 
@@ -50,6 +50,42 @@ resource "kubernetes_ingress" "example_ingress" {
     tls {
       secret_name = "tls-secret"
     }
+  }
+}
+
+resource "kubernetes_service_v1" "example" {
+  metadata {
+    name = "myapp-1"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "NodePort"
+  }
+}
+
+resource "kubernetes_service_v1" "example2" {
+  metadata {
+    name = "myapp-2"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod.example2.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "NodePort"
   }
 }
 
@@ -96,16 +132,16 @@ resource "kubernetes_pod" "example2" {
 
 ## Example using Nginx ingress controller
 
-```
+```hcl
 resource "kubernetes_service" "example" {
   metadata {
     name = "ingress-service"
   }
   spec {
     port {
-      port = 80
+      port        = 80
       target_port = 80
-      protocol = "TCP"
+      protocol    = "TCP"
     }
     type = "NodePort"
   }

--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -22,7 +22,7 @@ resource "kubernetes_ingress_v1" "example_ingress" {
   spec {
     default_backend {
       service {
-        name = "MyApp1"
+        name = "myapp-1"
         port {
           number = 8080
         }
@@ -34,7 +34,7 @@ resource "kubernetes_ingress_v1" "example_ingress" {
         path {
           backend {
             service {
-              name = "MyApp1"
+              name = "myapp-1"
               port {
                 number = 8080
               }
@@ -47,7 +47,7 @@ resource "kubernetes_ingress_v1" "example_ingress" {
         path {
           backend {
             service {
-              name = "MyApp2"
+              name = "myapp-2"
               port {
                 number = 8080
               }
@@ -65,6 +65,42 @@ resource "kubernetes_ingress_v1" "example_ingress" {
   }
 }
 
+resource "kubernetes_service_v1" "example" {
+  metadata {
+    name = "myapp-1"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod_v1.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "NodePort"
+  }
+}
+
+resource "kubernetes_service_v1" "example2" {
+  metadata {
+    name = "myapp-2"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod_v1.example2.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "NodePort"
+  }
+}
+
 resource "kubernetes_pod_v1" "example" {
   metadata {
     name = "terraform-example"
@@ -75,11 +111,11 @@ resource "kubernetes_pod_v1" "example" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
 
       port {
-        container_port = 8080
+        container_port = 80
       }
     }
   }
@@ -95,11 +131,11 @@ resource "kubernetes_pod_v1" "example2" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
 
       port {
-        container_port = 8080
+        container_port = 80
       }
     }
   }
@@ -108,16 +144,16 @@ resource "kubernetes_pod_v1" "example2" {
 
 ## Example using Nginx ingress controller
 
-```
+```hcl
 resource "kubernetes_service_v1" "example" {
   metadata {
     name = "ingress-service"
   }
   spec {
     port {
-      port = 80
+      port        = 80
       target_port = 80
-      protocol = "TCP"
+      protocol    = "TCP"
     }
     type = "NodePort"
   }

--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -105,7 +105,7 @@ resource "kubernetes_pod_v1" "example" {
   metadata {
     name = "terraform-example"
     labels = {
-      app = "MyApp1"
+      app = "myapp-1"
     }
   }
 
@@ -125,7 +125,7 @@ resource "kubernetes_pod_v1" "example2" {
   metadata {
     name = "terraform-example2"
     labels = {
-      app = "MyApp2"
+      app = "myapp-2"
     }
   }
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -22,7 +22,7 @@ resource "kubernetes_pod" "test" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
 
       env {
@@ -31,12 +31,12 @@ resource "kubernetes_pod" "test" {
       }
 
       port {
-        container_port = 8080
+        container_port = 80
       }
 
       liveness_probe {
         http_get {
-          path = "/nginx_status"
+          path = "/"
           port = 80
 
           http_header {

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -22,7 +22,7 @@ resource "kubernetes_pod_v1" "test" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
 
       env {
@@ -31,12 +31,12 @@ resource "kubernetes_pod_v1" "test" {
       }
 
       port {
-        container_port = 8080
+        container_port = 80
       }
 
       liveness_probe {
         http_get {
-          path = "/nginx_status"
+          path = "/"
           port = 80
 
           http_header {

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -39,13 +39,13 @@ resource "kubernetes_replication_controller" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
 
           liveness_probe {
             http_get {
-              path = "/nginx_status"
-              port = 8080
+              path = "/"
+              port = 80
 
               http_header {
                 name  = "X-Custom-Header"

--- a/website/docs/r/replication_controller_v1.html.markdown
+++ b/website/docs/r/replication_controller_v1.html.markdown
@@ -39,13 +39,13 @@ resource "kubernetes_replication_controller_v1" "example" {
 
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:1.21.6"
           name  = "example"
 
           liveness_probe {
             http_get {
-              path = "/nginx_status"
-              port = 8080
+              path = "/"
+              port = 80
 
               http_header {
                 name  = "X-Custom-Header"

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -42,7 +42,7 @@ resource "kubernetes_pod" "example" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
     }
   }
@@ -51,7 +51,7 @@ resource "kubernetes_pod" "example" {
 
 ## Example using AWS load balancer
 
-```
+```hcl
 variable "cluster_name" {
   type = string
 }
@@ -84,7 +84,7 @@ resource "kubernetes_service" "example" {
   }
   spec {
     port {
-      port = 8080
+      port        = 8080
       target_port = 80
     }
     type = "LoadBalancer"

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -42,7 +42,7 @@ resource "kubernetes_pod" "example" {
 
   spec {
     container {
-      image = "nginx:1.7.9"
+      image = "nginx:1.21.6"
       name  = "example"
     }
   }
@@ -51,7 +51,7 @@ resource "kubernetes_pod" "example" {
 
 ## Example using AWS load balancer
 
-```
+```hcl
 variable "cluster_name" {
   type = string
 }
@@ -84,7 +84,7 @@ resource "kubernetes_service_v1" "example" {
   }
   spec {
     port {
-      port = 8080
+      port        = 8080
       target_port = 80
     }
     type = "LoadBalancer"


### PR DESCRIPTION
### Description

This PRs has the following changes:
- Updates an Nginx image version in the code examples.
- Updates Liveness probe path from `/nginx_status` to `/` and target port.
- Updates ingress examples with the service resource.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user-facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1598
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
