### PR TITLE
Make attribute http of resource kubernetes_ingress_v1 optional

### DIFF
--- a/kubernetes/resource_kubernetes_ingress_v1.go
+++ b/kubernetes/resource_kubernetes_ingress_v1.go
@@ -64,7 +64,7 @@ func resourceKubernetesIngressV1Schema() map[string]*schema.Schema {
 								},
 								"http": {
 									Type:        schema.TypeList,
-									Required:    true,
+									Optional:    true,
 									MaxItems:    1,
 									Description: "http is a list of http selectors pointing to backends. In the example: http:///? -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
 									Elem: &schema.Resource{

--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -377,7 +377,8 @@ func testAccCheckKubernetesIngressV1Exists(n string, obj *networking.Ingress) re
 }
 
 func testAccKubernetesIngressV1Config_serviceBackend(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -412,7 +413,8 @@ func testAccKubernetesIngressV1Config_serviceBackend(name string) string {
 }
 
 func testAccKubernetesIngressV1Config_resourceBackend(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -446,7 +448,8 @@ func testAccKubernetesIngressV1Config_resourceBackend(name string) string {
 }
 
 func testAccKubernetesIngressV1Config_serviceBackend_modified(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -465,7 +468,8 @@ func testAccKubernetesIngressV1Config_serviceBackend_modified(name string) strin
 }
 
 func testAccKubernetesIngressV1Config_TLS(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -487,7 +491,8 @@ func testAccKubernetesIngressV1Config_TLS(name string) string {
 }
 
 func testAccKubernetesIngressV1Config_TLS_modified(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -509,7 +514,8 @@ func testAccKubernetesIngressV1Config_TLS_modified(name string) string {
 }
 
 func testAccKubernetesIngressV1Config_internalKey(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
     annotations = {
@@ -540,7 +546,8 @@ func testAccKubernetesIngressV1Config_internalKey(name string) string {
 }
 
 func testAccKubernetesIngressV1Config_internalKey_removed(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
     annotations = {
@@ -569,7 +576,8 @@ func testAccKubernetesIngressV1Config_internalKey_removed(name string) string {
 }
 
 func testAccKubernetesIngressV1Config_waitForLoadBalancer(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_service" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_service" "test" {
   metadata {
     name = %q
   }
@@ -639,7 +647,8 @@ resource "kubernetes_ingress_v1" "test" {
 }
 
 func testAccKubernetesIngressV1Config_ruleHostOnly(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -647,13 +656,14 @@ func testAccKubernetesIngressV1Config_ruleHostOnly(name string) string {
     ingress_class_name = "ingress-class"
     rule {
       host = "server.domain.com"
-	}
+    }
   }
 }`, name)
 }
 
 func testAccKubernetesIngressV1Config_multipleRulesDifferentHosts(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_ingress_v1" "test" {
+	return fmt.Sprintf(`
+resource "kubernetes_ingress_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -661,7 +671,7 @@ func testAccKubernetesIngressV1Config_multipleRulesDifferentHosts(name string) s
     ingress_class_name = "ingress-class"
     rule {
       host = "server.domain.com"
-	  http {
+      http {
         path {
           backend {
             service {
@@ -674,34 +684,34 @@ func testAccKubernetesIngressV1Config_multipleRulesDifferentHosts(name string) s
           path = "/app1/*"
         }
       }
-	}
+    }
     rule {
-		host = "server.example.com"
-		http {
-		  path {
-			backend {
-			  service {
-				name = "app1"
-				port {
-				  number = 8080
-				}
-			  }
-			}
-			path = "/app1/*"
-		  }
-		  path {
-			backend {
-			  service {
-				name = "app2"
-				port {
-				  number = 8080
-				}
-			  }
-			}
-			path = "/app2/*"
-		  }
-		}
-	  }
+      host = "server.example.com"
+      http {
+        path {
+          backend {
+            service {
+              name = "app1"
+              port {
+                number = 8080
+              }
+            }
+          }
+          path = "/app1/*"
+        }
+        path {
+          backend {
+            service {
+              name = "app2"
+              port {
+                number = 8080
+              }
+            }
+          }
+          path = "/app2/*"
+        }
+      }
+    }
   }
 }`, name)
 }

--- a/kubernetes/structure_ingress_spec_v1.go
+++ b/kubernetes/structure_ingress_spec_v1.go
@@ -148,13 +148,13 @@ func expandIngressV1Rule(l []interface{}) []networking.IngressRule {
 			}
 		}
 
-		obj[i] = networking.IngressRule{
-			Host: cfg["host"].(string),
-			IngressRuleValue: networking.IngressRuleValue{
+		obj[i].Host = cfg["host"].(string)
+		if len(paths) > 0 {
+			obj[i].IngressRuleValue = networking.IngressRuleValue{
 				HTTP: &networking.HTTPIngressRuleValue{
 					Paths: paths,
 				},
-			},
+			}
 		}
 	}
 	return obj

--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -233,7 +233,7 @@ The following arguments are supported:
 #### Arguments
 
 * `host` - (Optional) Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the IP in the Spec of the parent Ingress. 2. The : delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
-* `http` - (Required) http is a list of http selectors pointing to backends. In the example: http:///? -> backend where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'. See `http` block attributes below.
+* `http` - (Optional) http is a list of http selectors pointing to backends. In the example: http:///? -> backend where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'. See `http` block attributes below.
 
 
 #### `http`


### PR DESCRIPTION
### Description

This PR makes attribute `http` optional for resource `kubernetes_ingress_v1` that implements the following GVK:
```
apiVersion: networking.k8s.io/v1
kind: Ingress
```

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run ^TestAccKubernetesIngressV1_*'

=== RUN   TestAccKubernetesIngressV1_serviceBackend
--- PASS: TestAccKubernetesIngressV1_serviceBackend (12.22s)
=== RUN   TestAccKubernetesIngressV1_resourceBackend
--- PASS: TestAccKubernetesIngressV1_resourceBackend (6.62s)
=== RUN   TestAccKubernetesIngressV1_TLS
--- PASS: TestAccKubernetesIngressV1_TLS (16.85s)
=== RUN   TestAccKubernetesIngressV1_InternalKey
--- PASS: TestAccKubernetesIngressV1_InternalKey (21.96s)
=== RUN   TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud
--- PASS: TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud (102.94s)
=== RUN   TestAccKubernetesIngressV1_hostOnlyRule
--- PASS: TestAccKubernetesIngressV1_hostOnlyRule (6.48s)
=== RUN   TestAccKubernetesIngressV1_multipleRulesDifferentHosts
--- PASS: TestAccKubernetesIngressV1_multipleRulesDifferentHosts (6.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	174.344s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
```release-note
Make attribute `http` of resource `kubernetes_ingress_v1` optional
```

### References
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1199
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
