### PR TITLE
Update 'Docker config' code example of kubernetes_secret(_v1) resource.

### DIFF
--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -59,24 +59,27 @@ resource "kubernetes_secret" "example" {
     name = "docker-cfg"
   }
 
+  type = "kubernetes.io/dockerconfigjson"
+
   data = {
     ".dockerconfigjson" = jsonencode({
       auths = {
         "${var.registry_server}" = {
-          auth = "${base64encode("${var.registry_username}:${var.registry_password}")}"
+          "username" = var.registry_username
+          "password" = var.registry_password
+          "email"    = var.registry_email
+          "auth"     = base64encode("${var.registry_username}:${var.registry_password}")
         }
       }
     })
   }
-
-  type = "kubernetes.io/dockerconfigjson"
 }
 ```
 
 This is equivalent to the following kubectl command:
 
 ```sh
-$ kubectl create secret docker-registry docker-cfg --docker-server=${registry_server} --docker-username=${registry_username} --docker-password=${registry_password}
+$ kubectl create secret docker-registry docker-cfg --docker-server=${registry_server} --docker-username=${registry_username} --docker-password=${registry_password} --docker-email=${registry_email}
 ```
 
 ## Example Usage (Service account token)

--- a/website/docs/r/secret_v1.html.markdown
+++ b/website/docs/r/secret_v1.html.markdown
@@ -59,24 +59,27 @@ resource "kubernetes_secret_v1" "example" {
     name = "docker-cfg"
   }
 
+  type = "kubernetes.io/dockerconfigjson"
+
   data = {
     ".dockerconfigjson" = jsonencode({
       auths = {
         "${var.registry_server}" = {
-          auth = "${base64encode("${var.registry_username}:${var.registry_password}")}"
+          "username" = var.registry_username
+          "password" = var.registry_password
+          "email"    = var.registry_email
+          "auth"     = base64encode("${var.registry_username}:${var.registry_password}")
         }
       }
     })
   }
-
-  type = "kubernetes.io/dockerconfigjson"
 }
 ```
 
 This is equivalent to the following kubectl command:
 
 ```sh
-$ kubectl create secret docker-registry docker-cfg --docker-server=${registry_server} --docker-username=${registry_username} --docker-password=${registry_password}
+$ kubectl create secret docker-registry docker-cfg --docker-server=${registry_server} --docker-username=${registry_username} --docker-password=${registry_password} --docker-email=${registry_email}
 ```
 
 ## Example Usage (Service account token)


### PR DESCRIPTION
### Description

This PR updates the 'Docker config' terraform code example of `kubernetes_secret` and `kubernetes_secret_v1` resources.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
```release-note
...
```

### References
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1621

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
