### PR TITLE
Don't fail when unable to find default SA token secret

### DIFF
--- a/kubernetes/data_source_kubernetes_service_account.go
+++ b/kubernetes/data_source_kubernetes_service_account.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -68,10 +67,7 @@ func dataSourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf("Unable to fetch service account from Kubernetes: %s", err)
 	}
 
-	defaultSecret, err := findDefaultServiceAccount(ctx, sa, conn)
-	if err != nil {
-		log.Printf("[WARN] Failed to discover the default service account token: %s", err)
-	}
+	defaultSecret, diagMsg := findDefaultServiceAccount(ctx, sa, conn)
 
 	err = d.Set("default_secret_name", defaultSecret)
 	if err != nil {
@@ -80,5 +76,7 @@ func dataSourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resou
 
 	d.SetId(buildId(sa.ObjectMeta))
 
-	return resourceKubernetesServiceAccountRead(ctx, d, meta)
+	diagMsg = append(diagMsg, resourceKubernetesServiceAccountRead(ctx, d, meta)...)
+
+	return diagMsg
 }

--- a/kubernetes/data_source_kubernetes_service_account.go
+++ b/kubernetes/data_source_kubernetes_service_account.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -69,7 +70,7 @@ func dataSourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resou
 
 	defaultSecret, err := findDefaultServiceAccount(ctx, sa, conn)
 	if err != nil {
-		return diag.Errorf("Failed to discover the default service account token: %s", err)
+		log.Printf("[WARN] Failed to discover the default service account token: %s", err)
 	}
 
 	err = d.Set("default_secret_name", defaultSecret)

--- a/kubernetes/data_source_kubernetes_service_account_test.go
+++ b/kubernetes/data_source_kubernetes_service_account_test.go
@@ -125,7 +125,7 @@ variable "token_name" {
 
 resource "kubernetes_service_account" "test" {
   metadata {
-   name = "%s"
+    name = "%s"
   }
   secret {
     name = var.token_name

--- a/kubernetes/data_source_kubernetes_service_account_test.go
+++ b/kubernetes/data_source_kubernetes_service_account_test.go
@@ -45,6 +45,33 @@ func TestAccKubernetesDataSourceServiceAccount_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesDataSourceServiceAccount_default_secret(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesServiceAccountConfig_default_secret(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "secret.#", "1"),
+				),
+			},
+			{
+				Config: testAccKubernetesServiceAccountConfig_default_secret(name) +
+					testAccKubernetesDataSourceServiceAccountConfig_default_secret_read(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "secret.#", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "default_secret_name", ""),
+				),
+			},
+		},
+	})
+}
+
 func testAccKubernetesDataSourceServiceAccountConfig_basic(name string) string {
 	return fmt.Sprintf(`resource "kubernetes_service_account" "test" {
   metadata {
@@ -88,4 +115,47 @@ func testAccKubernetesDataSourceServiceAccountConfig_read() string {
   }
 }
 `)
+}
+
+func testAccKubernetesServiceAccountConfig_default_secret(name string) string {
+	return fmt.Sprintf(`
+variable "token_name" {
+  default = "%s-token-test0"
+}
+
+resource "kubernetes_service_account" "test" {
+  metadata {
+   name = "%s"
+  }
+  secret {
+    name = var.token_name
+  }
+}
+
+resource "kubernetes_secret" "test" {
+  metadata {
+    name = var.token_name
+    annotations = {
+      "kubernetes.io/service-account.name" = "%s"
+    }
+  }
+  type = "kubernetes.io/service-account-token"
+  depends_on = [
+    kubernetes_service_account.test
+  ]
+}
+`, name, name, name)
+}
+
+func testAccKubernetesDataSourceServiceAccountConfig_default_secret_read(name string) string {
+	return fmt.Sprintf(`
+data "kubernetes_service_account" "test" {
+  metadata {
+    name = "%s"
+  }
+  depends_on = [
+    kubernetes_secret.test
+  ]
+}
+`, name)
 }

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -385,9 +385,10 @@ func resourceKubernetesServiceAccountImportState(ctx context.Context, d *schema.
 	if err != nil {
 		return nil, fmt.Errorf("Unable to fetch service account from Kubernetes: %s", err)
 	}
+
 	defaultSecret, err := findDefaultServiceAccount(ctx, sa, conn)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to discover the default service account token: %s", err)
+		log.Printf("[WARN] Failed to discover the default service account token: %s", err)
 	}
 
 	err = d.Set("default_secret_name", defaultSecret)

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -156,7 +156,7 @@ func getServiceAccountDefaultSecret(ctx context.Context, name string, config api
 	return &svcAccTokens[0], nil
 }
 
-func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn *kubernetes.Clientset) (string, error) {
+func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn *kubernetes.Clientset) (string, diag.Diagnostics) {
 	/*
 	   The default service account token secret would have:
 	   - been created either at the same moment as the service account or _just_ after (Kubernetes controllers appears to work off a queue)
@@ -165,6 +165,8 @@ func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn
 	   See this for where the default token is created in Kubernetes
 	   https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/controller/serviceaccount/tokens_controller.go#L384
 	*/
+	ds := make([]string, 0)
+
 	for _, saSecret := range sa.Secrets {
 		if !strings.HasPrefix(saSecret.Name, fmt.Sprintf("%s-token-", sa.Name)) {
 			log.Printf("[DEBUG] Skipping %s as it doesn't have the right name", saSecret.Name)
@@ -173,7 +175,7 @@ func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn
 
 		secret, err := conn.CoreV1().Secrets(sa.Namespace).Get(ctx, saSecret.Name, metav1.GetOptions{})
 		if err != nil {
-			return "", fmt.Errorf("Unable to fetch secret %s/%s from Kubernetes: %s", sa.Namespace, saSecret.Name, err)
+			return "", diag.Errorf("Unable to fetch secret %s/%s from Kubernetes: %s", sa.Namespace, saSecret.Name, err)
 		}
 
 		if secret.Type != api.SecretTypeServiceAccountToken {
@@ -181,22 +183,40 @@ func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn
 			continue
 		}
 
-		if secret.CreationTimestamp.Before(&sa.CreationTimestamp) {
-			log.Printf("[DEBUG] Skipping %s as it existed before the service account", saSecret.Name)
+		if secret.Annotations[api.ServiceAccountNameKey] != sa.ObjectMeta.Name {
+			log.Printf("[DEBUG] Skipping %s as it has a different name than the service account", saSecret.Name)
 			continue
 		}
 
-		if secret.CreationTimestamp.Sub(sa.CreationTimestamp.Time) > (3 * time.Second) {
-			log.Printf("[DEBUG] Skipping %s as it wasn't created at the same time as the service account", saSecret.Name)
+		if secret.Annotations[api.ServiceAccountUIDKey] != string(sa.ObjectMeta.UID) {
+			log.Printf("[DEBUG] Skipping %s as it has a different UID than the service account", saSecret.Name)
 			continue
 		}
 
 		log.Printf("[DEBUG] Found %s as a candidate for the default service account token", saSecret.Name)
-
-		return saSecret.Name, nil
+		ds = append(ds, saSecret.Name)
 	}
 
-	return "", fmt.Errorf("Unable to find any service accounts tokens which could have been the default one")
+	if len(ds) == 0 {
+		return "", diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Unable to find any service accounts tokens which could have been the default one.",
+			},
+		}
+	}
+
+	if len(ds) == 1 {
+		return ds[0], nil
+	}
+
+	return "", diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Unable to discover default secret name.",
+			Detail:   "There is more than one service account token associated to the service account.",
+		},
+	}
 }
 
 func diffObjectReferences(origOrs []api.ObjectReference, ors []api.ObjectReference) []api.ObjectReference {
@@ -386,9 +406,9 @@ func resourceKubernetesServiceAccountImportState(ctx context.Context, d *schema.
 		return nil, fmt.Errorf("Unable to fetch service account from Kubernetes: %s", err)
 	}
 
-	defaultSecret, err := findDefaultServiceAccount(ctx, sa, conn)
-	if err != nil {
-		log.Printf("[WARN] Failed to discover the default service account token: %s", err)
+	defaultSecret, diagMsg := findDefaultServiceAccount(ctx, sa, conn)
+	if diagMsg.HasError() {
+		log.Print("[WARN] Failed to discover the default service account token")
 	}
 
 	err = d.Set("default_secret_name", defaultSecret)

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `image_pull_secret` - A list of image pull secrets associated with the service account.
 * `secret` - A list of secrets associated with the service account.
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
 ### `image_pull_secret`
 

--- a/website/docs/d/service_account_v1.html.markdown
+++ b/website/docs/d/service_account_v1.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `image_pull_secret` - A list of image pull secrets associated with the service account.
 * `secret` - A list of secrets associated with the service account.
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
 ### `image_pull_secret`
 

--- a/website/docs/r/default_service_account.html.markdown
+++ b/website/docs/r/default_service_account.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
 ## Destroying
 

--- a/website/docs/r/default_service_account_v1.html.markdown
+++ b/website/docs/r/default_service_account_v1.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
 ## Destroying
 

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
 ## Import
 

--- a/website/docs/r/service_account_v1.html.markdown
+++ b/website/docs/r/service_account_v1.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
 ## Import
 


### PR DESCRIPTION
Both the `kubernetes_service_account` datasource and resource contain a conveniece attribute to expose the default service account created automatically by the cluster along with the SA. The check for the secret to be deemed the "default" one, includes a matching of the creation timestamps between the SA and the associated Secret.

It's a valid scenario for the default token secret of a Service Account to be replaced throughout the lifecycle of the SA.

When this default secret is deleted, the cluster automatically generates a new one and updates the SA accordingly.

The provider should not fail when the default token is no longer available.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=^TestAccKubernetesDataSourceServiceAccount_*'

=== RUN   TestAccKubernetesDataSourceServiceAccount_basic
--- PASS: TestAccKubernetesDataSourceServiceAccount_basic (4.42s)
=== RUN   TestAccKubernetesDataSourceServiceAccount_default_secret
--- PASS: TestAccKubernetesDataSourceServiceAccount_default_secret (4.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	9.389s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix fail when the provider cannot determine `default_secret_name`.
```

### References

Fixes #1104 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
