### PR TITLE
Fix identification of 'int-or-string' type attributes 

### DIFF
--- a/manifest/openapi/schema.go
+++ b/manifest/openapi/schema.go
@@ -31,12 +31,6 @@ func resolveSchemaRef(ref *openapi3.SchemaRef, defs map[string]*openapi3.SchemaR
 
 	// These are exceptional situations that require non-standard types.
 	switch sid {
-	case "io.k8s.apimachinery.pkg.util.intstr.IntOrString":
-		t := openapi3.Schema{
-			Type:        "string",
-			Description: "io.k8s.apimachinery.pkg.util.intstr.IntOrString", // this value later carries over as the "type hint"
-		}
-		return &t, nil
 	case "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps":
 		t := openapi3.Schema{
 			Type: "",
@@ -75,8 +69,7 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 	// }
 	switch elem.Type {
 	case "string":
-		switch elem.Description {
-		case "io.k8s.apimachinery.pkg.util.intstr.IntOrString":
+		if elem.Format == "int-or-string" {
 			th[ap.String()] = "io.k8s.apimachinery.pkg.util.intstr.IntOrString"
 		}
 		return tftypes.String, nil

--- a/manifest/payload/to_value.go
+++ b/manifest/payload/to_value.go
@@ -68,7 +68,7 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 			if ok && ht == "io.k8s.apimachinery.pkg.util.intstr.IntOrString" { // We store this in state as "string"
 				return tftypes.NewValue(tftypes.String, strconv.FormatInt(in.(int64), 10)), nil
 			}
-			return tftypes.Value{}, at.NewErrorf(`[%s] cannot convert payload from "in64" to "tftypes.String"`, at.String())
+			return tftypes.Value{}, at.NewErrorf(`[%s] cannot convert payload from "int64" to "tftypes.String"`, at.String())
 		default:
 			return tftypes.Value{}, at.NewErrorf(`[%s] cannot convert payload from "int64" to "%s"`, at.String(), st.String())
 		}


### PR DESCRIPTION
### Description
`int-or-string` types can also be defined by aggregated APIs, as 3rd party types.
Both built-in and 3rd party int-or-string types have a signature value of `int-or-string` in the format attribute.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

Fixes #1627

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
