### PR TITLE
Handle 'x-kubernetes-preserve-unknown-fields' type annotation

### DIFF
--- a/manifest/const.go
+++ b/manifest/const.go
@@ -1,0 +1,5 @@
+package manifest
+
+const (
+	PreserveUnknownFieldsLabel string = "x-kubernetes-preserve-unknown-fields"
+)

--- a/manifest/morph/morph.go
+++ b/manifest/morph/morph.go
@@ -345,3 +345,25 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 	}
 	return tftypes.Value{}, p.NewErrorf("[%s] unsupported morph of object value into type: %s", p.String(), t.String())
 }
+
+// ValueToTypePath "normalizes" AttributePaths of values into a form that only describes the type hyerarchy.
+// this is used when comparing value paths to type hints generated during the translation from OpenAPI into tftypes.
+func ValueToTypePath(a *tftypes.AttributePath) *tftypes.AttributePath {
+	if a == nil {
+		return nil
+	}
+	ns := make([]tftypes.AttributePathStep, len(a.Steps()))
+	os := a.Steps()
+	for i := range os {
+		switch os[i].(type) {
+		case tftypes.AttributeName:
+			ns[i] = tftypes.AttributeName(os[i].(tftypes.AttributeName))
+		case tftypes.ElementKeyString:
+			ns[i] = tftypes.ElementKeyString("#")
+		case tftypes.ElementKeyInt:
+			ns[i] = tftypes.ElementKeyInt(-1)
+		}
+	}
+
+	return tftypes.NewAttributePathWithSteps(ns)
+}

--- a/manifest/openapi/schema.go
+++ b/manifest/openapi/schema.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest"
 	"github.com/mitchellh/hashstructure"
 )
 
@@ -69,13 +70,13 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 	// Check if attribute type is tagged as 'x-kubernetes-preserve-unknown-fields' in OpenAPI.
 	// If so, we add a type hint to indicate this and return DynamicPseudoType for this attribute,
 	// since we have no further structural information about it.
-	if xpufJSON, ok := elem.Extensions["x-kubernetes-preserve-unknown-fields"]; ok {
+	if xpufJSON, ok := elem.Extensions[manifest.PreserveUnknownFieldsLabel]; ok {
 		var xpuf bool
 		v, err := xpufJSON.(json.RawMessage).MarshalJSON()
 		if err == nil {
 			err = json.Unmarshal(v, &xpuf)
 			if err == nil && xpuf {
-				th[ap.String()] = "x-kubernetes-preserve-unknown-fields"
+				th[ap.String()] = manifest.PreserveUnknownFieldsLabel
 			}
 		}
 	}

--- a/manifest/payload/from_value.go
+++ b/manifest/payload/from_value.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
 )
 
 // FromTFValue converts a Terraform specific tftypes.Value type object
@@ -49,7 +50,7 @@ func FromTFValue(in tftypes.Value, th map[string]string, ap *tftypes.AttributePa
 		if err != nil {
 			return nil, ap.NewErrorf("[%s] cannot extract contents of attribute: %s", ap.String(), err)
 		}
-		tp := valueToTypePath(ap)
+		tp := morph.ValueToTypePath(ap)
 		ot, ok := th[tp.String()]
 		if ok && ot == "io.k8s.apimachinery.pkg.util.intstr.IntOrString" {
 			n, err := strconv.Atoi(sv)
@@ -107,26 +108,4 @@ func FromTFValue(in tftypes.Value, th map[string]string, ap *tftypes.AttributePa
 	default:
 		return nil, ap.NewErrorf("[%s] cannot convert value of unknown type (%s)", ap.String(), in.Type().String())
 	}
-}
-
-// valueToTypePath "normalizes" AttributePaths of values into a form that only describes the type hyerarchy.
-// this is used when comparing value paths to type hints generated during the translation from OpenAPI into tftypes.
-func valueToTypePath(a *tftypes.AttributePath) *tftypes.AttributePath {
-	if a == nil {
-		return nil
-	}
-	ns := make([]tftypes.AttributePathStep, len(a.Steps()))
-	os := a.Steps()
-	for i := range os {
-		switch os[i].(type) {
-		case tftypes.AttributeName:
-			ns[i] = tftypes.AttributeName(os[i].(tftypes.AttributeName))
-		case tftypes.ElementKeyString:
-			ns[i] = tftypes.ElementKeyString("#")
-		case tftypes.ElementKeyInt:
-			ns[i] = tftypes.ElementKeyInt(-1)
-		}
-	}
-
-	return tftypes.NewAttributePathWithSteps(ns)
 }

--- a/manifest/payload/from_value_test.go
+++ b/manifest/payload/from_value_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
 )
 
 func TestFromTFValue(t *testing.T) {
@@ -167,7 +168,7 @@ func TestValueToTypePath(t *testing.T) {
 	}
 	for n, s := range samples {
 		t.Run(n, func(t *testing.T) {
-			p := valueToTypePath(s.In)
+			p := morph.ValueToTypePath(s.In)
 			if !p.Equal(s.Out) {
 				t.Logf("Expected %#v, received: %#v", s.Out, p)
 				t.Fail()

--- a/manifest/payload/to_value.go
+++ b/manifest/payload/to_value.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
 )
 
 // ToTFValue converts a Kubernetes dynamic client unstructured value
@@ -51,7 +52,7 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 		case st.Is(tftypes.Number) || st.Is(tftypes.DynamicPseudoType):
 			return tftypes.NewValue(tftypes.Number, new(big.Float).SetInt64(int64(in.(int)))), nil
 		case st.Is(tftypes.String):
-			ht, ok := th[valueToTypePath(at).String()]
+			ht, ok := th[morph.ValueToTypePath(at).String()]
 			if ok && ht == "io.k8s.apimachinery.pkg.util.intstr.IntOrString" { // We store this in state as "string"
 				return tftypes.NewValue(tftypes.String, strconv.FormatInt(int64(in.(int)), 10)), nil
 			}
@@ -64,7 +65,7 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 		case st.Is(tftypes.Number) || st.Is(tftypes.DynamicPseudoType):
 			return tftypes.NewValue(tftypes.Number, new(big.Float).SetInt64(in.(int64))), nil
 		case st.Is(tftypes.String):
-			ht, ok := th[valueToTypePath(at).String()]
+			ht, ok := th[morph.ValueToTypePath(at).String()]
 			if ok && ht == "io.k8s.apimachinery.pkg.util.intstr.IntOrString" { // We store this in state as "string"
 				return tftypes.NewValue(tftypes.String, strconv.FormatInt(in.(int64), 10)), nil
 			}
@@ -77,7 +78,7 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 		case st.Is(tftypes.Number) || st.Is(tftypes.DynamicPseudoType):
 			return tftypes.NewValue(tftypes.Number, new(big.Float).SetInt64(int64(in.(int32)))), nil
 		case st.Is(tftypes.String):
-			ht, ok := th[valueToTypePath(at).String()]
+			ht, ok := th[morph.ValueToTypePath(at).String()]
 			if ok && ht == "io.k8s.apimachinery.pkg.util.intstr.IntOrString" { // We store this in state as "string"
 				return tftypes.NewValue(tftypes.String, strconv.FormatInt(int64(in.(int32)), 10)), nil
 			}
@@ -90,7 +91,7 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 		case st.Is(tftypes.Number) || st.Is(tftypes.DynamicPseudoType):
 			return tftypes.NewValue(tftypes.Number, new(big.Float).SetInt64(int64(in.(int16)))), nil
 		case st.Is(tftypes.String):
-			ht, ok := th[valueToTypePath(at).String()]
+			ht, ok := th[morph.ValueToTypePath(at).String()]
 			if ok && ht == "io.k8s.apimachinery.pkg.util.intstr.IntOrString" { // We store this in state as "string"
 				return tftypes.NewValue(tftypes.String, strconv.FormatInt(int64(in.(int16)), 10)), nil
 			}

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/payload"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -405,7 +406,7 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
 				if hasChanged {
 					h, ok := hints[morph.ValueToTypePath(ap).String()]
-					if ok && h == "x-kubernetes-preserve-unknown-fields" {
+					if ok && h == manifest.PreserveUnknownFieldsLabel {
 						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
 					}

--- a/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
+++ b/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
@@ -1,0 +1,114 @@
+//go:build acceptance
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestKubernetesManifest_CustomResource_x_preserve_unknown_fields(t *testing.T) {
+	ctx := context.Background()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
+	kind := strings.Title(randString(8))
+	plural := strings.ToLower(kind) + "s"
+	group := "terraform.io"
+	version := "v1"
+	groupVersion := group + "/" + version
+	crd := fmt.Sprintf("%s.%s", plural, group)
+
+	name := strings.ToLower(randName())
+	namespace := "default" //randName()
+
+	tfvars := TFVARS{
+		"name":          name,
+		"namespace":     namespace,
+		"kind":          kind,
+		"plural":        plural,
+		"group":         group,
+		"group_version": groupVersion,
+		"cr_version":    version,
+	}
+
+	crdStep := tfhelper.RequireNewWorkingDir(ctx, t)
+	crdStep.SetReattachInfo(ctx, reattachInfo)
+	defer func() {
+		crdStep.Destroy(ctx)
+		crdStep.Close()
+		k8shelper.AssertResourceDoesNotExist(t, "apiextensions.k8s.io/v1", "customresourcedefinitions", crd)
+	}()
+
+	tfconfig := loadTerraformConfig(t, "x-kubernetes-preserve-unknown-fields/crd/test.tf", tfvars)
+	crdStep.SetConfig(ctx, string(tfconfig))
+	crdStep.Init(ctx)
+	crdStep.Apply(ctx)
+	k8shelper.AssertResourceExists(t, "apiextensions.k8s.io/v1", "customresourcedefinitions", crd)
+
+	// wait for API to finish ingesting the CRD
+	time.Sleep(5 * time.Second) //lintignore:R018
+
+	reattachInfo2, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create additional provider instance: %q", err)
+	}
+
+	step1 := tfhelper.RequireNewWorkingDir(ctx, t)
+	step1.SetReattachInfo(ctx, reattachInfo2)
+	defer func() {
+		step1.Destroy(ctx)
+		step1.Close()
+		k8shelper.AssertResourceDoesNotExist(t, groupVersion, kind, name)
+	}()
+
+	tfconfig = loadTerraformConfig(t, "x-kubernetes-preserve-unknown-fields/test-cr-1.tf", tfvars)
+	step1.SetConfig(ctx, string(tfconfig))
+	step1.Init(ctx)
+	step1.Apply(ctx)
+
+	s1, err := step1.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform state: %q", err)
+	}
+	tfstate := tfstatehelper.NewHelper(s1)
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.spec.count":         json.Number("100"),
+		"kubernetes_manifest.test.object.spec.resources": map[string]interface{}{
+			"foo": interface{}("bar"),
+		},
+	})
+
+	tfconfig = loadTerraformConfig(t, "x-kubernetes-preserve-unknown-fields/test-cr-2.tf", tfvars)
+	step1.SetConfig(ctx, string(tfconfig))
+	step1.Apply(ctx)
+
+	s2, err := step1.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform state: %q", err)
+	}
+	tfstate2 := tfstatehelper.NewHelper(s2)
+	tfstate2.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.spec.count":         json.Number("100"),
+		"kubernetes_manifest.test.object.spec.resources": map[string]interface{}{
+			"foo": interface{}("bar"),
+			"baz": interface{}("42"),
+		},
+	})
+}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/crd/test.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/crd/test.tf
@@ -1,0 +1,77 @@
+resource "kubernetes_manifest" "customresourcedefinition_cephrbdmirrors_ceph_rook_io" {
+  manifest = {
+    apiVersion = "apiextensions.k8s.io/v1"
+    kind = "CustomResourceDefinition"
+    metadata = {
+      name = "${var.plural}.${var.group}"
+    }
+    spec = {
+      group = var.group
+      names = {
+        kind = var.kind
+        plural = var.plural
+      }
+      scope = "Namespaced"
+      versions = [
+        {
+          name = var.cr_version
+          schema = {
+            openAPIV3Schema = {
+              properties = {
+                spec = {
+                  properties = {
+                    annotations = {
+                      nullable = true
+                      type = "object"
+                      "x-kubernetes-preserve-unknown-fields" = true
+                    }
+                    count = {
+                      maximum = 100
+                      minimum = 1
+                      type = "integer"
+                    }
+                    peers = {
+                      properties = {
+                        secretNames = {
+                          items = {
+                            type = "string"
+                          }
+                          type = "array"
+                        }
+                      }
+                      type = "object"
+                    }
+                    placement = {
+                      nullable = true
+                      type = "object"
+                      "x-kubernetes-preserve-unknown-fields" = true
+                    }
+                    priorityClassName = {
+                      type = "string"
+                    }
+                    resources = {
+                      nullable = true
+                      type = "object"
+                      "x-kubernetes-preserve-unknown-fields" = true
+                    }
+                  }
+                  type = "object"
+                }
+                status = {
+                  type = "object"
+                  "x-kubernetes-preserve-unknown-fields" = true
+                }
+              }
+              type = "object"
+            }
+          }
+          served = true
+          storage = true
+          subresources = {
+            status = {}
+          }
+        },
+      ]
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/crd/variables.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/crd/variables.tf
@@ -1,0 +1,24 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "cr_version" {
+  type = string
+}
+
+variable "group" {
+  type = string
+}
+
+variable "kind" {
+  type = string
+}
+
+variable "plural" {
+  type = string
+}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-1.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-1.tf
@@ -1,0 +1,16 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = var.group_version
+    kind = var.kind
+    metadata = {
+      name = var.name
+      namespace = var.namespace
+    }
+    spec = {
+        count = 100
+        resources = {
+            foo = "bar"
+        }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-2.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-2.tf
@@ -1,0 +1,17 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = var.group_version
+    kind = var.kind
+    metadata = {
+      name = var.name
+      namespace = var.namespace
+    }
+    spec = {
+        count = 100
+        resources = {
+            foo = "bar"
+            baz = "42"
+        }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/variables.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/variables.tf
@@ -1,0 +1,25 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "group_version" {
+  type = string
+}
+
+variable "kind" {
+  type = string
+}
+


### PR DESCRIPTION
Handle `x-kubernetes-preserve-unknown-fields` type annotation in OpenAPI.

Since we cannot guarantee structural integrity due to missing schema information, changes to attributes of this type will trigger recreation of the whole resource.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
