### PR TITLE
Add support for HPA Container Resource metrics

### DIFF
--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2.go
@@ -53,7 +53,6 @@ func resourceKubernetesHorizontalPodAutoscalerV2Beta2() *schema.Resource {
 						"behavior": {
 							Type:        schema.TypeList,
 							Description: "Behavior configures the scaling behavior of the target in both Up and Down directions (scale_up and scale_down fields respectively).",
-							Computed:    true,
 							Optional:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2.go
@@ -53,6 +53,7 @@ func resourceKubernetesHorizontalPodAutoscalerV2Beta2() *schema.Resource {
 						"behavior": {
 							Type:        schema.TypeList,
 							Description: "Behavior configures the scaling behavior of the target in both Up and Down directions (scale_up and scale_down fields respectively).",
+							Computed:    true,
 							Optional:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2_test.go
@@ -138,6 +138,10 @@ func TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource(t *testin
 		IDRefreshName:     "kubernetes_horizontal_pod_autoscaler_v2beta2.test",
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesHorizontalPodAutoscalerDestroy,
+		ErrorCheck: func(err error) error {
+			t.Skipf("HPAContainerMetrics feature might not be enabled on the cluster and therefore this step will be skipped if an error occurs. Refer to the error for more details:\n%s", err)
+			return nil
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesHorizontalPodAutoscalerV2Beta2Config_containerResource(name),

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2_test.go
@@ -129,6 +129,48 @@ func TestAccKubernetesHorizontalPodAutoscalerV2Beta2_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	resourceName := "kubernetes_horizontal_pod_autoscaler_v2beta2.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     "kubernetes_horizontal_pod_autoscaler_v2beta2.test",
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesHorizontalPodAutoscalerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesHorizontalPodAutoscalerV2Beta2Config_containerResource(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesHorizontalPodAutoscalerV2Exists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.test", "test"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.test", "test"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.min_replicas", "50"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.max_replicas", "100"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scale_target_ref.0.api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scale_target_ref.0.kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.scale_target_ref.0.name", "TerraformAccTest"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.type", "ContainerResource"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.container_resource.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.container_resource.0.name", "cpu"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.container_resource.0.container", "test"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.container_resource.0.target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.container_resource.0.target.0.type", "Utilization"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.metric.0.container_resource.0.target.0.average_utilization", "75"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesHorizontalPodAutoscalerV2Exists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -338,6 +380,47 @@ func testAccKubernetesHorizontalPodAutoscalerV2Beta2Config_modified(name string)
         target {
           type  = "Value"
           value = "100"
+        }
+      }
+    }
+  }
+}
+`, name)
+}
+
+func testAccKubernetesHorizontalPodAutoscalerV2Beta2Config_containerResource(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_horizontal_pod_autoscaler_v2beta2" "test" {
+  metadata {
+    name = %q
+
+    annotations = {
+      test = "test"
+    }
+
+    labels = {
+      test = "test"
+    }
+  }
+
+  spec {
+    min_replicas = 50
+    max_replicas = 100
+
+    scale_target_ref {
+      api_version = "apps/v1"
+      kind        = "Deployment"
+      name        = "TerraformAccTest"
+    }
+
+    metric {
+      type = "ContainerResource"
+      container_resource {
+        name      = "cpu"
+        container = "test"
+        target {
+          type                = "Utilization"
+          average_utilization = "75"
         }
       }
     }

--- a/kubernetes/schema_horizontal_pod_autoscaler.go
+++ b/kubernetes/schema_horizontal_pod_autoscaler.go
@@ -110,6 +110,30 @@ func externalMetricSourceFields() *schema.Resource {
 	}
 }
 
+func containerResourceMetricSourceFields() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"container": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "name of the container in the pods of the scaling target",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "name of the resource in question",
+			},
+			"target": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        metricTargetFields(),
+				Description: "target specifies the target value for the given metric",
+			},
+		},
+	}
+}
+
 func crossVersionObjectReferenceFields() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -163,6 +187,13 @@ func objectMetricSourceFields() *schema.Resource {
 func metricSpecFields() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"container_resource": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        containerResourceMetricSourceFields(),
+				Description: "",
+			},
 			"external": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -194,7 +225,7 @@ func metricSpecFields() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `type is the type of metric source. It should be one of "Object", "Pods", "External" or "Resource", each mapping to a matching field in the object.`,
+				Description: `type is the type of metric source. It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled`,
 			},
 		},
 	}

--- a/kubernetes/schema_horizontal_pod_autoscaler.go
+++ b/kubernetes/schema_horizontal_pod_autoscaler.go
@@ -1,6 +1,11 @@
 package kubernetes
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+)
 
 func metricTargetFields() *schema.Resource {
 	return &schema.Resource{
@@ -226,6 +231,13 @@ func metricSpecFields() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `type is the type of metric source. It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled`,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(autoscalingv2beta2.ContainerResourceMetricSourceType),
+					string(autoscalingv2beta2.ExternalMetricSourceType),
+					string(autoscalingv2beta2.ObjectMetricSourceType),
+					string(autoscalingv2beta2.PodsMetricSourceType),
+					string(autoscalingv2beta2.ResourceMetricSourceType),
+				}, false),
 			},
 		},
 	}

--- a/kubernetes/structure_horizontal_pod_autoscaler_v2.go
+++ b/kubernetes/structure_horizontal_pod_autoscaler_v2.go
@@ -148,6 +148,24 @@ func expandV2ObjectMetricSource(m map[string]interface{}) *autoscalingv2beta2.Ob
 	return source
 }
 
+func expandV2ContainerResourceMetricSource(m map[string]interface{}) *autoscalingv2beta2.ContainerResourceMetricSource {
+	source := &autoscalingv2beta2.ContainerResourceMetricSource{}
+
+	if v, ok := m["container"].(string); ok {
+		source.Container = v
+	}
+
+	if v, ok := m["name"].(string); ok {
+		source.Name = v1.ResourceName(v)
+	}
+
+	if v, ok := m["target"].([]interface{}); ok && len(v) == 1 {
+		source.Target = expandV2MetricTarget(v[0].(map[string]interface{}))
+	}
+
+	return source
+}
+
 func expandV2MetricSpec(m map[string]interface{}) autoscalingv2beta2.MetricSpec {
 	spec := autoscalingv2beta2.MetricSpec{}
 
@@ -169,6 +187,10 @@ func expandV2MetricSpec(m map[string]interface{}) autoscalingv2beta2.MetricSpec 
 
 	if v, ok := m["object"].([]interface{}); ok && len(v) == 1 {
 		spec.Object = expandV2ObjectMetricSource(v[0].(map[string]interface{}))
+	}
+
+	if v, ok := m["container_resource"].([]interface{}); ok && len(v) == 1 {
+		spec.ContainerResource = expandV2ContainerResourceMetricSource(v[0].(map[string]interface{}))
 	}
 
 	return spec
@@ -321,6 +343,15 @@ func flattenV2ObjectMetricSource(object *autoscalingv2beta2.ObjectMetricSource) 
 	return []interface{}{m}
 }
 
+func flattenV2ContainerResourceMetricSource(cr *autoscalingv2beta2.ContainerResourceMetricSource) []interface{} {
+	m := map[string]interface{}{
+		"name":      cr.Name.String(),
+		"container": cr.Container,
+		"target":    flattenV2MetricTarget(cr.Target),
+	}
+	return []interface{}{m}
+}
+
 func flattenV2ResourceMetricSource(resource *autoscalingv2beta2.ResourceMetricSource) []interface{} {
 	m := map[string]interface{}{
 		"name":   resource.Name,
@@ -348,6 +379,10 @@ func flattenV2MetricSpec(spec autoscalingv2beta2.MetricSpec) map[string]interfac
 
 	if spec.Object != nil {
 		m["object"] = flattenV2ObjectMetricSource(spec.Object)
+	}
+
+	if spec.ContainerResource != nil {
+		m["container_resource"] = flattenV2ContainerResourceMetricSource(spec.ContainerResource)
 	}
 
 	return m

--- a/website/docs/r/horizontal_pod_autoscaler_v2beta2.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler_v2beta2.html.markdown
@@ -148,11 +148,20 @@ The following arguments are supported:
 
 #### Arguments
 
-* `type` - (Required) The type of metric. It can be one of "Object", "Pods", "Resource", or "External".
+* `type` - (Required) The type of metric. It can be one of "Object", "Pods", "Resource", "External", or "ContainerResource".
 * `object` - (Optional) A metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
 * `pods` - (Optional) A metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
 * `resource` - (Optional) A resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 * `external` - (Optional) A global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+* `container_resource` - (Optional) A resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+
+### Metric Type: `container_resource`
+
+#### Arguments
+
+* `container` - (Required) Name of the container in the pods of the scaling target.
+* `name` - (Required) Name of the resource in question.
+* `target` - (Required) The target for the given metric.
 
 ### Metric Type: `external`
 


### PR DESCRIPTION
### Description

This PR adds support for HPA Container Resource metrics. More details in Kubernetes [documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics).

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run ^TestAccKubernetesHorizontalPodAutoscalerV2Beta2*'

=== RUN   TestAccKubernetesHorizontalPodAutoscalerV2Beta2_basic
--- PASS: TestAccKubernetesHorizontalPodAutoscalerV2Beta2_basic (12.44s)
=== RUN   TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource
--- PASS: TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource (5.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	18.748s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add a new metric type `container_resource` in resource `kubernetes_horizontal_pod_autoscaler_v2beta2`.
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/1637

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
