### PR TITLE
Fix crash when multiple `match_expression` are used in `kubernetes_resource_quota`

### DIFF
--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -402,7 +402,7 @@ func flattenResourceQuotaScopeSelectorMatchExpressions(in []api.ScopedResourceSe
 	if len(in) == 0 {
 		return []interface{}{}
 	}
-	out := make([]interface{}, 1)
+	out := make([]interface{}, len(in))
 
 	for i, l := range in {
 		m := make(map[string]interface{}, 0)


### PR DESCRIPTION
### Description

This PR fixes a crash when multiple `match_expression` are used in `kubernetes_resource_quota`

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccKubernetesResourceQuota*'

=== RUN   TestAccKubernetesResourceQuota_basic
--- PASS: TestAccKubernetesResourceQuota_basic (7.64s)
=== RUN   TestAccKubernetesResourceQuota_generatedName
--- PASS: TestAccKubernetesResourceQuota_generatedName (3.17s)
=== RUN   TestAccKubernetesResourceQuota_withScopes
--- PASS: TestAccKubernetesResourceQuota_withScopes (5.63s)
=== RUN   TestAccKubernetesResourceQuota_scopeSelector
--- PASS: TestAccKubernetesResourceQuota_scopeSelector (6.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	24.756s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Fix crash when multiple `match_expression` are used in `kubernetes_resource_quota`
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/1561

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
