### PR TITLE
Add kubernetes_annotations resource

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -299,7 +299,8 @@ func Provider() *schema.Provider {
 			"kubernetes_csi_driver_v1":    resourceKubernetesCSIDriverV1(),
 
 			// provider helper resources
-			"kubernetes_labels": resourceKubernetesLabels(),
+			"kubernetes_labels":      resourceKubernetesLabels(),
+			"kubernetes_annotations": resourceKubernetesAnnotations(),
 		},
 	}
 

--- a/kubernetes/resource_kubernetes_annotations.go
+++ b/kubernetes/resource_kubernetes_annotations.go
@@ -1,0 +1,282 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-kubernetes/util"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+)
+
+func resourceKubernetesAnnotations() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKubernetesAnnotationsCreate,
+		ReadContext:   resourceKubernetesAnnotationsRead,
+		UpdateContext: resourceKubernetesAnnotationsUpdate,
+		DeleteContext: resourceKubernetesAnnotationsDelete,
+		Schema: map[string]*schema.Schema{
+			"api_version": {
+				Type:        schema.TypeString,
+				Description: "The apiVersion of the resource to annotate.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"kind": {
+				Type:        schema.TypeString,
+				Description: "The kind of the resource to annotate.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"metadata": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "The name of the resource.",
+							Required:    true,
+							ForceNew:    true,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Description: "The namespace of the resource.",
+							Optional:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"annotations": {
+				Type:        schema.TypeMap,
+				Description: "A map of annotations to apply to the resource.",
+				Required:    true,
+			},
+			"force": {
+				Type:        schema.TypeBool,
+				Description: "Force overwriting annotations that were created or edited outside of Terraform.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func resourceKubernetesAnnotationsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	d.SetId(buildIdWithVersionKind(metadata,
+		d.Get("api_version").(string),
+		d.Get("kind").(string)))
+	diag := resourceKubernetesAnnotationsUpdate(ctx, d, m)
+	if diag.HasError() {
+		d.SetId("")
+	}
+	return diag
+}
+
+func resourceKubernetesAnnotationsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	conn, err := m.(KubeClientsets).DynamicClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	gvk, name, namespace, err := util.ParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// figure out which resource client to use
+	dc, err := m.(KubeClientsets).DiscoveryClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	agr, err := restmapper.GetAPIGroupResources(dc)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	restMapper := restmapper.NewDiscoveryRESTMapper(agr)
+	mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// determine if the resource is namespaced or not
+	var r dynamic.ResourceInterface
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		if namespace == "" {
+			namespace = "default"
+		}
+		r = conn.Resource(mapping.Resource).Namespace(namespace)
+	} else {
+		r = conn.Resource(mapping.Resource)
+	}
+
+	// get the resource annotations
+	res, err := r.Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "Resource deleted",
+				Detail:   fmt.Sprintf("The underlying resource %q has been deleted. You should recreate the underlying resource, or remove it from your configuration.", name),
+			}}
+		}
+		return diag.FromErr(err)
+	}
+
+	configuredAnnotations := d.Get("annotations").(map[string]interface{})
+
+	// strip out the annotations not managed by Terraform
+	managedAnnotations, err := getManagedAnnotations(res.GetManagedFields(), defaultFieldManagerName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	annotations := res.GetAnnotations()
+	for k := range annotations {
+		_, managed := managedAnnotations["f:"+k]
+		_, configured := configuredAnnotations[k]
+		if !managed && !configured {
+			delete(annotations, k)
+		}
+	}
+
+	d.Set("annotations", annotations)
+	return nil
+}
+
+// getManagedAnnotations reads the field manager metadata to discover which fields we're managing
+func getManagedAnnotations(managedFields []v1.ManagedFieldsEntry, manager string) (map[string]interface{}, error) {
+	var annotations map[string]interface{}
+	for _, m := range managedFields {
+		if m.Manager != manager {
+			continue
+		}
+		var mm map[string]interface{}
+		err := json.Unmarshal(m.FieldsV1.Raw, &mm)
+		if err != nil {
+			return nil, err
+		}
+		metadata := mm["f:metadata"].(map[string]interface{})
+		if l, ok := metadata["f:annotations"].(map[string]interface{}); ok {
+			annotations = l
+		}
+	}
+	return annotations, nil
+}
+
+func resourceKubernetesAnnotationsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	conn, err := m.(KubeClientsets).DynamicClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	apiVersion := d.Get("api_version").(string)
+	kind := d.Get("kind").(string)
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	name := metadata.GetName()
+	namespace := metadata.GetNamespace()
+
+	// figure out which resource client to use
+	dc, err := m.(KubeClientsets).DiscoveryClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	agr, err := restmapper.GetAPIGroupResources(dc)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	restMapper := restmapper.NewDiscoveryRESTMapper(agr)
+	gv, err := k8sschema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return diag.FromErr(err)
+
+	}
+	mapping, err := restMapper.RESTMapping(gv.WithKind(kind).GroupKind(), gv.Version)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// determine if the resource is namespaced or not
+	var r dynamic.ResourceInterface
+	namespacedResource := mapping.Scope.Name() == meta.RESTScopeNameNamespace
+	if namespacedResource {
+		if namespace == "" {
+			namespace = "default"
+		}
+		r = conn.Resource(mapping.Resource).Namespace(namespace)
+	} else {
+		r = conn.Resource(mapping.Resource)
+	}
+
+	// check the resource exists before we try and patch it
+	_, err = r.Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		if d.Id() == "" {
+			// if we are deleting then there is nothing to do
+			// if the resource is gone
+			return nil
+		}
+		return diag.Errorf("The resource %q does not exist", name)
+	}
+
+	// craft the patch to update the annotations
+	annotations := d.Get("annotations")
+	if d.Id() == "" {
+		// if we're deleting then just we just patch
+		// with an empty annotations map
+		annotations = map[string]interface{}{}
+	}
+	patchmeta := map[string]interface{}{
+		"name":        name,
+		"annotations": annotations,
+	}
+	if namespacedResource {
+		patchmeta["namespace"] = namespace
+	}
+	patchobj := map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   patchmeta,
+	}
+	patch := unstructured.Unstructured{}
+	patch.Object = patchobj
+	patchbytes, err := patch.MarshalJSON()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// apply the patch
+	_, err = r.Patch(ctx,
+		name,
+		types.ApplyPatchType,
+		patchbytes,
+		v1.PatchOptions{
+			FieldManager: defaultFieldManagerName,
+			Force:        ptrToBool(d.Get("force").(bool)),
+		},
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Id() == "" {
+		// don't try to read if we're deleting
+		return nil
+	}
+	return resourceKubernetesAnnotationsRead(ctx, d, m)
+}
+
+func resourceKubernetesAnnotationsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.SetId("")
+	return resourceKubernetesAnnotationsUpdate(ctx, d, m)
+}

--- a/kubernetes/resource_kubernetes_annotations_test.go
+++ b/kubernetes/resource_kubernetes_annotations_test.go
@@ -1,0 +1,112 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccKubernetesAnnotations_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	namespace := "default"
+	resourceName := "kubernetes_annotations.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createConfigMap(name, namespace)
+		},
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return destroyConfigMap(name, namespace)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAnnotations_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test2", "two"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test3", "three"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesAnnotations_empty(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+    api_version = "v1"
+    kind        = "ConfigMap"
+    metadata {
+      name = %q
+    }
+    annotations = {}
+  }
+`, name)
+}
+
+func testAccKubernetesAnnotations_basic(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+    api_version = "v1"
+    kind        = "ConfigMap"
+    metadata {
+      name = %q
+    }
+    annotations = {
+      "test1" = "one"
+      "test2" = "two"
+    }
+  }
+`, name)
+}
+
+func testAccKubernetesAnnotations_modified(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+    api_version = "v1"
+    kind        = "ConfigMap"
+    metadata {
+      name = %q
+    }
+    annotations = {
+      "test1" = "one"
+      "test3" = "three"
+    }
+  }
+`, name)
+}

--- a/website/docs/r/annotations.html.markdown
+++ b/website/docs/r/annotations.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_annotations"
+description: |-
+  This resource allows Terraform to manage the annotations for a resource that already exists
+---
+
+# kubernetes_annotations
+
+This resource allows Terraform to manage the annotations for a resource that already exists. This resource uses [field management](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management) and [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to manage only the annotations that are defined in the Terraform configuration. Existing annotations not specified in the configuration will be ignored. If an annotation specified in the config and is already managed by another client it will cause a conflict which can be overridden by setting `force` to true. 
+
+
+## Example Usage
+
+```hcl
+resource "kubernetes_annotations" "example" {
+  api_version = "v1"
+  kind        = "ConfigMap"
+  metadata {
+    name = "my-config"
+  }
+  annotations = {
+    "owner" = "myteam"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_version` - (Required) The apiVersion of the resource to be annotated.
+* `kind` - (Required) The kind of the resource to be annotated.
+* `metadata` - (Required) Standard metadata of the resource to be annotated. 
+* `annotations` - (Required) A map of annotations to apply to the resource.
+* `force` - (Optional) Force management of annotations if there is a conflict.
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the resource to be annotated.
+* `namespace` - (Optional) Namespace of the resource to be annotated.
+
+## Import
+
+This resource does not support the `import` command. As this resource operates on Kubernetes resources that already exist, creating the resource is equivalent to importing it. 
+
+


### PR DESCRIPTION
### Description

This PR adds a `kubernetes_annotations` resource to go with `kubernetes_labels`. This is pretty much an exact copy of the implementation for `kubernetes_labels` but changed to annotations.

Closes #692 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add kubernetes_annotations resource
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
