### PR TITLE
Fix conversion of big.Float to float64 in kubernetes_manifest

### DIFF
--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -20,7 +20,8 @@ jobs:
         terraform_version:
           - "0.14.10"
           - "0.15.5"
-          - "1.0.6"
+          - "1.0.11"
+          - "1.1.7"
     env:
       TF_X_KUBERNETES_MANIFEST_RESOURCE: 1
       KUBE_CONFIG_PATH: "~/.kube/config"

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -23,7 +23,8 @@ jobs:
           # and there is no image available for the latest v1.19.x
           # - v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
         terraform_version:
-          - 1.0.8
+          - 1.1.7
+          - 1.0.11
           - 0.15.5
           - 0.14.11
     steps:

--- a/manifest/payload/from_value.go
+++ b/manifest/payload/from_value.go
@@ -38,10 +38,7 @@ func FromTFValue(in tftypes.Value, th map[string]string, ap *tftypes.AttributePa
 			}
 			return inv, nil
 		}
-		fnv, acc := nv.Float64()
-		if acc != big.Exact {
-			return nil, ap.NewErrorf("[%s] inexact float approximation when converting number value", ap.String())
-		}
+		fnv, _ := nv.Float64()
 		return fnv, err
 	case in.Type().Is(tftypes.String):
 		var sv string

--- a/manifest/payload/from_value_test.go
+++ b/manifest/payload/from_value_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestFromTFValue(t *testing.T) {
+	// this mimics how terraform-plugin-go decodes floats that terraform sends over msgpack without a precision marker
+	fv, _, err := big.ParseFloat("98.765", 10, 512, big.ToNearestEven)
+	if err != nil {
+		t.Fatalf("cannot create test float value out of string: %s", err)
+	}
 	samples := map[string]struct {
 		In  tftypes.Value
 		Th  map[string]string
@@ -18,9 +23,13 @@ func TestFromTFValue(t *testing.T) {
 			In:  tftypes.NewValue(tftypes.String, "hello"),
 			Out: "hello",
 		},
-		"float-primitive": {
-			In:  tftypes.NewValue(tftypes.Number, big.NewFloat(100.2)),
-			Out: 100.2,
+		"float-primitive-native-big": {
+			In:  tftypes.NewValue(tftypes.Number, big.NewFloat(98.765)),
+			Out: float64(98.765),
+		},
+		"float-primitive-from-string": {
+			In:  tftypes.NewValue(tftypes.Number, fv),
+			Out: float64(98.765),
 		},
 		"boolean-primitive": {
 			In:  tftypes.NewValue(tftypes.Bool, true),

--- a/manifest/test/acceptance/customresource_test.go
+++ b/manifest/test/acceptance/customresource_test.go
@@ -5,6 +5,7 @@ package acceptance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -86,6 +87,7 @@ func TestKubernetesManifest_CustomResource(t *testing.T) {
 		"kubernetes_manifest.test.object.metadata.name":      name,
 		"kubernetes_manifest.test.object.metadata.namespace": namespace,
 		"kubernetes_manifest.test.object.data":               "this is a test",
+		"kubernetes_manifest.test.object.refs":               json.Number("98.765"),
 		"kubernetes_manifest.test.object.stuff.0":            map[string]interface{}{"foo": interface{}(nil)},
 		"kubernetes_manifest.test.object.limits": map[string]interface{}{
 			"foo": interface{}("bar"),

--- a/manifest/test/acceptance/testdata/CustomResource/custom_resource.tf
+++ b/manifest/test/acceptance/testdata/CustomResource/custom_resource.tf
@@ -9,6 +9,7 @@ resource "kubernetes_manifest" "test" {
       name      = var.name
     }
     data = "this is a test"
+    refs = 98.765
     stuff = [
       {
         foo = null

--- a/manifest/test/acceptance/testdata/CustomResource/terraform.tfvars
+++ b/manifest/test/acceptance/testdata/CustomResource/terraform.tfvars
@@ -1,4 +1,0 @@
-name          = "testcr"
-namespace     = "default"
-group_version = "terraform.io/v1"
-kind          = "Jqgmbnpb"


### PR DESCRIPTION
### Description

This change adjusts the conversion from big.Float to float64 to not fail on precision differences.

In [terraform-plugin-go](https://github.com/hashicorp/terraform-plugin-go), a `tftypes.Number` value is represented internally as a Go standard lib `big.Float` which can be constructed in a few different ways. When constructed from a primitve float64 value, the conversion back to float64 happens with exact precision. However, when parsed from a string, using a precision higher than 53, the converstion back to float64 happens imprecisly and does not yield a `big.Exact` precision indicator. This is because primitive float64 values only go up to 53 bits precision, while big.Float can do better precision.

The logic that is handling `tftypes.Number` values in `kubernetes_manifest` was based on the assumption that the big.Float values obtained from Terraform via terraform-plugin-go would always convert exactly to float64. 

It turns out, terraform doesn't always pass a precision indicator into the msgpack encoded floats as seen here: https://github.com/hashicorp/terraform-plugin-go/blob/4f323c9cd630bcc2238434bbee9176418746d015/tftypes/value_msgpack.go#L108 In this case the conversion back to float64 will be lossy.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1659

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
