### PR TITLE
Added patch support to kubernetes_manifest resource

### DIFF
--- a/manifest/test/acceptance/exists_test.go
+++ b/manifest/test/acceptance/exists_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
 func TestKubernetesManifest_alreadyExists(t *testing.T) {
@@ -64,4 +65,56 @@ func TestKubernetesManifest_alreadyExists(t *testing.T) {
 		t.Errorf("Expected error to contain %q. Actual error:", errMsg)
 		t.Log(err)
 	}
+}
+
+func TestKubernetesManifest_alreadyExists_ForceConflicts(t *testing.T) {
+	ctx := context.Background()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t,
+			"v1", "configmaps", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "alreadyExists_ForceConflicts/configmap.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t,
+		"v1", "configmaps", namespace, name)
+
+	// Make a new working dir and apply again
+	tf2 := tfhelper.RequireNewWorkingDir(t)
+	tf2.SetReattachInfo(reattachInfo)
+	tfconfigModified := loadTerraformConfig(t, "alreadyExists_ForceConflicts/configmap.tf", tfvars)
+	tf2.RequireSetConfig(t, tfconfigModified)
+	err = tf2.Apply()
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.data.TEST":          "test",
+	})
+
+	tfstate.AssertAttributeEqual(t, "kubernetes_manifest.test.object.data.TEST", "test")
 }

--- a/manifest/test/acceptance/testdata/alreadyExists_ForceConflicts/configmap.tf
+++ b/manifest/test/acceptance/testdata/alreadyExists_ForceConflicts/configmap.tf
@@ -1,3 +1,7 @@
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "docker-desktop"
+}
 
 resource "kubernetes_manifest" "test" {
   manifest = {
@@ -13,7 +17,6 @@ resource "kubernetes_manifest" "test" {
   }
 
   field_manager {
-    name = "data"
     force_conflicts = true
   }
 }

--- a/manifest/test/acceptance/testdata/alreadyExists_ForceConflicts/configmap.tf
+++ b/manifest/test/acceptance/testdata/alreadyExists_ForceConflicts/configmap.tf
@@ -1,0 +1,19 @@
+
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    data = {
+      TEST = "test"
+    }
+  }
+
+  field_manager {
+    name = "data"
+    force_conflicts = true
+  }
+}

--- a/manifest/test/acceptance/testdata/alreadyExists_ForceConflicts/variables.tf
+++ b/manifest/test/acceptance/testdata/alreadyExists_ForceConflicts/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Modified the `kubernetes_manifest` resource so that the `field_manager.force_conflicts` applies to create in addition to update. It provides patch functionality for kubernetes resources that already exist.

### Related Issues
- #723 
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1901

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Check that existing test still works.

```
$ make testacc TESTARGS='-run=TestKubernetesManifest_alreadyExists'
go test -count=1 -tags acceptance "./test/acceptance" -v -run=TestKubernetesManifest_alreadyExists -timeout 120m
2022/03/30 08:34:57 Testing against Kubernetes API version: v1.22.5
=== RUN   TestKubernetesManifest_alreadyExists
--- PASS: TestKubernetesManifest_alreadyExists (5.48s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     6.482s
```

Create a new Acceptance test for the patch scenario. The resource should create with an already existing resource when `field_manager.force_conflicts = true`.

```
$ make testacc TESTARGS='-run=TestKubernetesManifest_alreadyExists_ForceConflicts'
2022/03/30 09:03:19 Testing against Kubernetes API version: v1.22.5
=== RUN   TestKubernetesManifest_alreadyExists_ForceConflicts
--- PASS: TestKubernetesManifest_alreadyExists_ForceConflicts (11.56s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     13.311s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Modified the kubernetes_manifest resource so that the field_manager.force_conflicts applies to create in addition to update. It provides patch functionality for kubernetes resources that already exist.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
