### PR TITLE
Add `app_protocol` attribute to `kubernetes_service`

### DIFF
--- a/kubernetes/data_source_kubernetes_service.go
+++ b/kubernetes/data_source_kubernetes_service.go
@@ -62,6 +62,11 @@ func dataSourceKubernetesService() *schema.Resource {
 							Computed:    true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"app_protocol": {
+										Type:        schema.TypeString,
+										Description: "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+										Optional:    true,
+									},
 									"name": {
 										Type:        schema.TypeString,
 										Description: "The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.",

--- a/kubernetes/data_source_kubernetes_service_test.go
+++ b/kubernetes/data_source_kubernetes_service_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestAccKubernetesDataSourceService_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_service.test"
+	dataSourceName := "data.kubernetes_service.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -18,42 +20,44 @@ func TestAccKubernetesDataSourceService_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesDataSourceServiceConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("kubernetes_service.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_service.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_service.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_service.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.port.#", "1"),
-					resource.TestCheckResourceAttrSet("kubernetes_service.test", "spec.0.cluster_ip"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.port.0.name", ""),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.port.0.node_port", "0"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.port.0.port", "8080"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.port.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.port.0.target_port", "80"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.session_affinity", "None"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.type", "ClusterIP"),
-					resource.TestCheckResourceAttr("kubernetes_service.test", "spec.0.health_check_node_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "spec.0.cluster_ip"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.name", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.node_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.target_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.app_protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.session_affinity", "None"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.type", "ClusterIP"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.health_check_node_port", "0"),
 				),
 			},
 			{
 				Config: testAccKubernetesDataSourceServiceConfig_basic(name) +
 					testAccKubernetesDataSourceServiceConfig_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.#", "1"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.#", "1"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "spec.0.cluster_ip"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.name", ""),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.node_port", "0"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.port", "8080"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.target_port", "80"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.session_affinity", "None"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.type", "ClusterIP"),
-					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.health_check_node_port", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spec.0.cluster_ip"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.name", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.node_port", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.port", "8080"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.target_port", "80"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.app_protocol", "http"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.session_affinity", "None"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.type", "ClusterIP"),
+					resource.TestCheckResourceAttr(dataSourceName, "spec.0.health_check_node_port", "0"),
 				),
 			},
 		},
@@ -76,8 +80,9 @@ func testAccKubernetesDataSourceServiceConfig_basic(name string) string {
   }
   spec {
     port {
-      port        = 8080
-      target_port = 80
+      port         = 8080
+      target_port  = 80
+      app_protocol = "http"
     }
   }
 }

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -109,6 +109,11 @@ func resourceKubernetesServiceSchemaV1() map[string]*schema.Schema {
 						MinItems:    1,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
+								"app_protocol": {
+									Type:        schema.TypeString,
+									Description: "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+									Optional:    true,
+								},
 								"name": {
 									Type:        schema.TypeString,
 									Description: "The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.",

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -366,6 +366,8 @@ func TestAccKubernetesService_nodePort(t *testing.T) {
 	var conf api.Service
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "kubernetes_service.test"
+	appProtocolFirst := "ssh"
+	appProtocolSecond := "terraform.io/kubernetes"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -391,27 +393,31 @@ func TestAccKubernetesService_nodePort(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.port", "10222"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.target_port", "22"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.app_protocol", appProtocolFirst),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.name", "second"),
 					resource.TestCheckResourceAttrSet(resourceName, "spec.0.port.1.node_port"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.port", "10333"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.target_port", "33"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.app_protocol", appProtocolSecond),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.selector.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.selector.App", "MyApp"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.session_affinity", "ClientIP"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.type", "NodePort"),
 					testAccCheckServicePorts(&conf, []api.ServicePort{
 						{
-							Name:       "first",
-							Port:       int32(10222),
-							Protocol:   api.ProtocolTCP,
-							TargetPort: intstr.FromInt(22),
+							AppProtocol: &appProtocolFirst,
+							Name:        "first",
+							Port:        int32(10222),
+							Protocol:    api.ProtocolTCP,
+							TargetPort:  intstr.FromInt(22),
 						},
 						{
-							Name:       "second",
-							Port:       int32(10333),
-							Protocol:   api.ProtocolTCP,
-							TargetPort: intstr.FromInt(33),
+							AppProtocol: &appProtocolSecond,
+							Name:        "second",
+							Port:        int32(10333),
+							Protocol:    api.ProtocolTCP,
+							TargetPort:  intstr.FromInt(33),
 						},
 					}),
 				),
@@ -1165,15 +1171,17 @@ func testAccKubernetesServiceConfig_nodePort(name string) string {
     session_affinity = "ClientIP"
 
     port {
-      name        = "first"
-      port        = 10222
-      target_port = 22
+      name         = "first"
+      port         = 10222
+      target_port  = 22
+      app_protocol = "ssh"
     }
 
     port {
-      name        = "second"
-      port        = 10333
-      target_port = 33
+      name         = "second"
+      port         = 10333
+      target_port  = 33
+      app_protocol = "terraform.io/kubernetes"
     }
 
     type = "NodePort"

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -366,8 +366,6 @@ func TestAccKubernetesService_nodePort(t *testing.T) {
 	var conf api.Service
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "kubernetes_service.test"
-	appProtocolFirst := "ssh"
-	appProtocolSecond := "terraform.io/kubernetes"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -393,27 +391,27 @@ func TestAccKubernetesService_nodePort(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.port", "10222"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.target_port", "22"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.app_protocol", appProtocolFirst),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.app_protocol", "ssh"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.name", "second"),
 					resource.TestCheckResourceAttrSet(resourceName, "spec.0.port.1.node_port"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.port", "10333"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.target_port", "33"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.app_protocol", appProtocolSecond),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.port.1.app_protocol", "terraform.io/kubernetes"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.selector.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.selector.App", "MyApp"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.session_affinity", "ClientIP"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.type", "NodePort"),
 					testAccCheckServicePorts(&conf, []api.ServicePort{
 						{
-							AppProtocol: &appProtocolFirst,
+							AppProtocol: ptrToString("ssh"),
 							Name:        "first",
 							Port:        int32(10222),
 							Protocol:    api.ProtocolTCP,
 							TargetPort:  intstr.FromInt(22),
 						},
 						{
-							AppProtocol: &appProtocolSecond,
+							AppProtocol: ptrToString("terraform.io/kubernetes"),
 							Name:        "second",
 							Port:        int32(10333),
 							Protocol:    api.ProtocolTCP,

--- a/kubernetes/structure_service_spec.go
+++ b/kubernetes/structure_service_spec.go
@@ -14,6 +14,7 @@ func flattenServicePort(in []v1.ServicePort) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
+		m["app_protocol"] = n.AppProtocol
 		m["name"] = n.Name
 		m["protocol"] = string(n.Protocol)
 		m["port"] = int(n.Port)
@@ -95,6 +96,9 @@ func expandServicePort(l []interface{}, removeNodePort bool) []v1.ServicePort {
 		obj[i] = v1.ServicePort{
 			Port:       int32(cfg["port"].(int)),
 			TargetPort: intstr.Parse(cfg["target_port"].(string)),
+		}
+		if v, ok := cfg["app_protocol"].(string); ok && v != "" {
+			obj[i].AppProtocol = &v
 		}
 		if v, ok := cfg["name"].(string); ok {
 			obj[i].Name = v

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 
 #### Attributes
 
+* `app_protocol` - (Optional) The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per [RFC-6335](https://datatracker.ietf.org/doc/html/rfc6335) and [IANA standard service names](http://www.iana.org/assignments/service-names)). Non-standard protocols should use prefixed names such as `mycompany.com/my-custom-protocol`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)
 * `name` - The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
 * `node_port` - The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#type--nodeport)
 * `port` - The port that will be exposed by this service.

--- a/website/docs/d/service_v1.html.markdown
+++ b/website/docs/d/service_v1.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 
 #### Attributes
 
+* `app_protocol` - (Optional) The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per [RFC-6335](https://datatracker.ietf.org/doc/html/rfc6335) and [IANA standard service names](http://www.iana.org/assignments/service-names)). Non-standard protocols should use prefixed names such as `mycompany.com/my-custom-protocol`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)
 * `name` - The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
 * `node_port` - The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#type--nodeport)
 * `port` - The port that will be exposed by this service.

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -170,6 +170,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `app_protocol` - (Optional) The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per [RFC-6335](https://datatracker.ietf.org/doc/html/rfc6335) and [IANA standard service names](http://www.iana.org/assignments/service-names)). Non-standard protocols should use prefixed names such as `mycompany.com/my-custom-protocol`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)
 * `name` - (Optional) The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
 * `node_port` - (Optional) The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#type--nodeport)
 * `port` - (Required) The port that will be exposed by this service.

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -170,6 +170,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `app_protocol` - (Optional) The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per [RFC-6335](https://datatracker.ietf.org/doc/html/rfc6335) and [IANA standard service names](http://www.iana.org/assignments/service-names)). Non-standard protocols should use prefixed names such as `mycompany.com/my-custom-protocol`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)
 * `name` - (Optional) The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
 * `node_port` - (Optional) The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/services#type--nodeport)
 * `port` - (Required) The port that will be exposed by this service.


### PR DESCRIPTION
### Description

This PR adds a new attribute `app_protocol` to the resource and data source of `kubernetes_service`.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

Data source:
```
$ make testacc TESTARGS='-run ^TestAccKubernetesDataSourceService_basic'

=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (3.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	4.488s
```

Resource:

```
$ make testacc TESTARGS='-run ^TestAccKubernetesService_nodePort'

=== RUN   TestAccKubernetesService_nodePort
--- PASS: TestAccKubernetesService_nodePort (4.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	5.355s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Add `app_protocol` attribute to `kubernetes_service`
```

### References

Resolves:
- https://github.com/hashicorp/terraform-provider-kubernetes/issues/1554

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
