### PR TITLE
Add kubernetes_config_map_v1_data resource

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -299,8 +299,9 @@ func Provider() *schema.Provider {
 			"kubernetes_csi_driver_v1":    resourceKubernetesCSIDriverV1(),
 
 			// provider helper resources
-			"kubernetes_labels":      resourceKubernetesLabels(),
-			"kubernetes_annotations": resourceKubernetesAnnotations(),
+			"kubernetes_labels":             resourceKubernetesLabels(),
+			"kubernetes_annotations":        resourceKubernetesAnnotations(),
+			"kubernetes_config_map_v1_data": resourceKubernetesConfigMapV1Data(),
 		},
 	}
 

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -214,6 +214,7 @@ func Provider() *schema.Provider {
 			"kubernetes_default_service_account_v1": resourceKubernetesDefaultServiceAccount(),
 			"kubernetes_config_map":                 resourceKubernetesConfigMap(),
 			"kubernetes_config_map_v1":              resourceKubernetesConfigMap(),
+			"kubernetes_config_map_v1_data":         resourceKubernetesConfigMapV1Data(),
 			"kubernetes_secret":                     resourceKubernetesSecret(),
 			"kubernetes_secret_v1":                  resourceKubernetesSecret(),
 			"kubernetes_pod":                        resourceKubernetesPod(),
@@ -299,9 +300,8 @@ func Provider() *schema.Provider {
 			"kubernetes_csi_driver_v1":    resourceKubernetesCSIDriverV1(),
 
 			// provider helper resources
-			"kubernetes_labels":             resourceKubernetesLabels(),
-			"kubernetes_annotations":        resourceKubernetesAnnotations(),
-			"kubernetes_config_map_v1_data": resourceKubernetesConfigMapV1Data(),
+			"kubernetes_labels":      resourceKubernetesLabels(),
+			"kubernetes_annotations": resourceKubernetesAnnotations(),
 		},
 	}
 

--- a/kubernetes/resource_kubernetes_annotations.go
+++ b/kubernetes/resource_kubernetes_annotations.go
@@ -266,6 +266,13 @@ func resourceKubernetesAnnotationsUpdate(ctx context.Context, d *schema.Resource
 		},
 	)
 	if err != nil {
+		if errors.IsConflict(err) {
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Field manager conflict",
+				Detail:   fmt.Sprintf(`Another client is managing a field Terraform tried to update. Set "force" to true to override: %v`, err),
+			}}
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -1,0 +1,213 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func resourceKubernetesConfigMapV1Data() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKubernetesConfigMapV1DataCreate,
+		ReadContext:   resourceKubernetesConfigMapV1DataRead,
+		UpdateContext: resourceKubernetesConfigMapV1DataUpdate,
+		DeleteContext: resourceKubernetesConfigMapV1DataDelete,
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "The name of the ConfigMap.",
+							Required:    true,
+							ForceNew:    true,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Description: "The namespace of the ConfigMap.",
+							Optional:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"data": {
+				Type:        schema.TypeMap,
+				Description: "The data we want to add to the ConfigMap.",
+				Required:    true,
+			},
+			"force": {
+				Type:        schema.TypeBool,
+				Description: "Force overwriting data that is managed outside of Terraform.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func resourceKubernetesConfigMapV1DataCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	d.SetId(buildId(metadata))
+	diag := resourceKubernetesConfigMapV1DataUpdate(ctx, d, m)
+	if diag.HasError() {
+		d.SetId("")
+	}
+	return diag
+}
+
+func resourceKubernetesConfigMapV1DataRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	conn, err := m.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	// get the configmap data
+	res, err := conn.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "ConfigMap deleted",
+				Detail:   fmt.Sprintf("The underlying configmap %q has been deleted. You should recreate the underlying configmap, or remove it from your configuration.", name),
+			}}
+		}
+		return diag.FromErr(err)
+	}
+
+	configuredData := d.Get("data").(map[string]interface{})
+
+	// strip out the data not managed by Terraform
+	managedConfigMapData, err := getManagedConfigMapData(res.GetManagedFields(), defaultFieldManagerName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	data := res.Data
+	for k := range data {
+		_, managed := managedConfigMapData["f:"+k]
+		_, configured := configuredData[k]
+		if !managed && !configured {
+			delete(data, k)
+		}
+	}
+
+	d.Set("data", data)
+	return nil
+}
+
+// getManagedConfigMapData reads the field manager metadata to discover which fields we're managing
+func getManagedConfigMapData(managedFields []v1.ManagedFieldsEntry, manager string) (map[string]interface{}, error) {
+	var data map[string]interface{}
+	for _, m := range managedFields {
+		if m.Manager != manager {
+			continue
+		}
+		var mm map[string]interface{}
+		err := json.Unmarshal(m.FieldsV1.Raw, &mm)
+		if err != nil {
+			return nil, err
+		}
+		if l, ok := mm["f:data"].(map[string]interface{}); ok {
+			data = l
+		}
+	}
+	return data, nil
+}
+
+func resourceKubernetesConfigMapV1DataUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	conn, err := m.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	name := metadata.GetName()
+	namespace := metadata.GetNamespace()
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	// check the resource exists before we try and patch it
+	_, err = conn.CoreV1().ConfigMaps(namespace).Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		if d.Id() == "" {
+			// if we are deleting then there is nothing to do
+			// if the resource is gone
+			return nil
+		}
+		return diag.Errorf("The configmap %q does not exist", name)
+	}
+
+	// craft the patch to update the data
+	data := d.Get("data")
+	if d.Id() == "" {
+		// if we're deleting then just we just patch
+		// with an empty data map
+		data = map[string]interface{}{}
+	}
+	patchobj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"data": data,
+	}
+	patch := unstructured.Unstructured{}
+	patch.Object = patchobj
+	patchbytes, err := patch.MarshalJSON()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// apply the patch
+	_, err = conn.CoreV1().ConfigMaps(namespace).Patch(ctx,
+		name,
+		types.ApplyPatchType,
+		patchbytes,
+		v1.PatchOptions{
+			FieldManager: defaultFieldManagerName,
+			Force:        ptrToBool(d.Get("force").(bool)),
+		},
+	)
+	if err != nil {
+		if errors.IsConflict(err) {
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Field manager conflict",
+				Detail:   fmt.Sprintf(`Another client is managing a field Terraform tried to update. Set "force" to true to override: %v`, err),
+			}}
+		}
+		return diag.FromErr(err)
+	}
+
+	if d.Id() == "" {
+		// don't try to read if we're deleting
+		return nil
+	}
+	return resourceKubernetesConfigMapV1DataRead(ctx, d, m)
+}
+
+func resourceKubernetesConfigMapV1DataDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.SetId("")
+	return resourceKubernetesConfigMapV1DataUpdate(ctx, d, m)
+}

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -80,7 +79,7 @@ func resourceKubernetesConfigMapV1DataRead(ctx context.Context, d *schema.Resour
 	}
 
 	// get the configmap data
-	res, err := conn.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	res, err := conn.CoreV1().ConfigMaps(namespace).Get(ctx, name, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return diag.Diagnostics{{

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -39,6 +39,7 @@ func resourceKubernetesConfigMapV1Data() *schema.Resource {
 							Description: "The namespace of the ConfigMap.",
 							Optional:    true,
 							ForceNew:    true,
+							Default:     "default",
 						},
 					},
 				},
@@ -76,9 +77,6 @@ func resourceKubernetesConfigMapV1DataRead(ctx context.Context, d *schema.Resour
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
-	}
-	if namespace == "" {
-		namespace = "default"
 	}
 
 	// get the configmap data
@@ -142,9 +140,6 @@ func resourceKubernetesConfigMapV1DataUpdate(ctx context.Context, d *schema.Reso
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	name := metadata.GetName()
 	namespace := metadata.GetNamespace()
-	if namespace == "" {
-		namespace = "default"
-	}
 
 	// check the resource exists before we try and patch it
 	_, err = conn.CoreV1().ConfigMaps(namespace).Get(ctx, name, v1.GetOptions{})

--- a/kubernetes/resource_kubernetes_config_map_v1_data_test.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data_test.go
@@ -1,0 +1,98 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	namespace := "default"
+	resourceName := "kubernetes_config_map_v1_data.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createConfigMap(name, namespace)
+		},
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return destroyConfigMap(name, namespace)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesConfigMapV1Data_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "0"),
+				),
+			},
+			{
+				Config: testAccKubernetesConfigMapV1Data_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "data.test2", "two"),
+				),
+			},
+			{
+				Config: testAccKubernetesConfigMapV1Data_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "data.test3", "three"),
+				),
+			},
+			{
+				Config: testAccKubernetesConfigMapV1Data_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesConfigMapV1Data_empty(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_config_map_v1_data" "test" {
+    metadata {
+      name = %q
+    }
+    data = {}
+  }
+`, name)
+}
+
+func testAccKubernetesConfigMapV1Data_basic(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_config_map_v1_data" "test" {
+    metadata {
+      name = %q
+    }
+    data = {
+      "test1" = "one"
+      "test2" = "two"
+    }
+  }
+`, name)
+}
+
+func testAccKubernetesConfigMapV1Data_modified(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_config_map_v1_data" "test" {
+    metadata {
+      name = %q
+    }
+    data = {
+      "test1" = "one"
+      "test3" = "three"
+    }
+  }
+`, name)
+}

--- a/kubernetes/resource_kubernetes_labels.go
+++ b/kubernetes/resource_kubernetes_labels.go
@@ -266,6 +266,13 @@ func resourceKubernetesLabelsUpdate(ctx context.Context, d *schema.ResourceData,
 		},
 	)
 	if err != nil {
+		if errors.IsConflict(err) {
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Field manager conflict",
+				Detail:   fmt.Sprintf(`Another client is managing a field Terraform tried to update. Set "force" to true to override: %v`, err),
+			}}
+		}
 		return diag.FromErr(err)
 	}
 

--- a/website/docs/r/config_map_v1_data.html.markdown
+++ b/website/docs/r/config_map_v1_data.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_config_map_v1_data"
+description: |-
+  This resource allows Terraform to manage the data for a ConfigMap that already exists
+---
+
+# kubernetes_config_map_v1_data
+
+This resource allows Terraform to manage data within a pre-existing ConfigMap. This resource uses [field management](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management) and [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to manage only the data that is defined in the Terraform configuration. Existing data not specified in the configuration will be ignored. If data specified in the config and is already managed by another client it will cause a conflict which can be overridden by setting `force` to true. 
+
+
+## Example Usage
+
+```hcl
+resource "kubernetes_config_map_v1_data" "example" {
+  metadata {
+    name = "my-config"
+  }
+  data = {
+    "owner" = "myteam"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard metadata of the ConfigMap. 
+* `data` - (Required) A map of data to apply to the ConfigMap.
+* `force` - (Optional) Force management of the configured data if there is a conflict.
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the ConfigMap.
+* `namespace` - (Optional) Namespace of the ConfigMap.
+
+## Import
+
+This resource does not support the `import` command. As this resource operates on Kubernetes resources that already exist, creating the resource is equivalent to importing it. 
+
+

--- a/website/docs/r/config_map_v1_data.html.markdown
+++ b/website/docs/r/config_map_v1_data.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "core/v1"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_config_map_v1_data"
 description: |-


### PR DESCRIPTION
### Description

This PR adds a resource which allows Terraform to use field manager to manage the data within a ConfigMap that already exists. The implementation of this resource is similar to kubernetes_annotations (#1660) and kubernetes_labels (#1616) but does not require the dynamic client, so does not need the user to specify the apiVersion and kind. 


### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccKubernetesConfigMapV1Data_basic
--- PASS: TestAccKubernetesConfigMapV1Data_basic (34.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	35.445s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add kubernetes_config_map_v1_data resource
```

### References

#723 – one of the frequent use cases in this issue is patching configmaps  

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
