### PR TITLE
Fix GKE acceptance tests

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -745,7 +745,7 @@ func testAccKubernetesPersistentVolumeClaimConfig_updateStorageGKE(name, request
     name = "test"
   }
   allow_volume_expansion = true
-  storage_provisioner    = "kubernetes.io/gce-pd"
+  storage_provisioner    = "pd.csi.storage.gke.io"
 }
 resource "kubernetes_persistent_volume_claim" "test" {
   wait_until_bound = true
@@ -1093,7 +1093,7 @@ func testAccKubernetesPersistentVolumeClaimConfig_storageClass(className, claimN
     name = "%s"
   }
 
-  storage_provisioner = "kubernetes.io/gce-pd"
+  storage_provisioner = "pd.csi.storage.gke.io"
 
   parameters = {
     type = "pd-standard"
@@ -1126,7 +1126,7 @@ func testAccKubernetesPersistentVolumeClaimConfig_storageClassUpdated(className,
     name = "%s"
   }
 
-  storage_provisioner = "kubernetes.io/gce-pd"
+  storage_provisioner = "pd.csi.storage.gke.io"
 
   parameters = {
     type = "pd-standard"
@@ -1138,7 +1138,7 @@ resource "kubernetes_storage_class" "second" {
     name = "%s-second"
   }
 
-  storage_provisioner = "kubernetes.io/gce-pd"
+  storage_provisioner = "pd.csi.storage.gke.io"
 
   parameters = {
     type = "pd-ssd"

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -1112,12 +1112,12 @@ func testAccKubernetesPersistentVolumeConfig_googleCloud_basic(name, diskName, z
             operator = "Exists"
           }
           match_expressions {
-            key      = "failure-domain.beta.kubernetes.io/zone"
+            key      = "topology.kubernetes.io/zone"
             operator = "In"
             values   = ["%s"]
           }
           match_expressions {
-            key      = "failure-domain.beta.kubernetes.io/region"
+            key      = "topology.kubernetes.io/region"
             operator = "In"
             values   = ["%s"]
           }

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -7,7 +7,7 @@ variable "workers_count" {
 }
 
 variable "node_machine_type" {
-  default = "e2-micro"
+  default = "e2-medium"
 }
 
 variable "enable_alpha" {


### PR DESCRIPTION
### Description

This PR fixes the following broken GKE acceptance tests:
- TestAccKubernetesPersistentVolume_googleCloud_basic
- TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch
- TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate
- TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud

+ change default value of `node_machine_type` in GKE test-infra code.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:
_TestAccKubernetesPersistentVolume_googleCloud_basic_
```
$ make testacc TESTARGS='-run ^TestAccKubernetesPersistentVolume_googleCloud_basic'

=== RUN   TestAccKubernetesPersistentVolume_googleCloud_basic
--- PASS: TestAccKubernetesPersistentVolume_googleCloud_basic (297.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	297.641s
```

_TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch_
```
$ make testacc TESTARGS='-run ^TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch'

=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch
--- PASS: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch (327.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	327.673s
```

_TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate_
```
$ make testacc TESTARGS='-run ^TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate'

=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate
--- PASS: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate (306.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	307.543s
```

_TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud_
```
$ make testacc TESTARGS='-run ^TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud'

=== RUN   TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud
--- PASS: TestAccKubernetesPersistentVolumeClaim_expansionGoogleCloud (108.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	110.408s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
