### PR TITLE
Fix AWS acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,7 +62,7 @@ testacc: fmtcheck vet
 	mkdir -p /tmp/.terraform.d/localhost/test/kubernetes/9.9.9/$(OS_ARCH) || true
 	ls $(EXT_PROV_BIN) || go build -o $(EXT_PROV_BIN)
 	cd $(EXT_PROV_DIR) && TF_CLI_CONFIG_FILE=$(EXT_PROV_DIR)/.terraformrc TF_PLUGIN_CACHE_DIR=$(EXT_PROV_DIR)/.terraform terraform init -upgrade
-	TF_CLI_CONFIG_FILE=$(EXT_PROV_DIR)/.terraformrc TF_PLUGIN_CACHE_DIR=$(EXT_PROV_DIR)/.terraform TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_CLI_CONFIG_FILE=$(EXT_PROV_DIR)/.terraformrc TF_PLUGIN_CACHE_DIR=$(EXT_PROV_DIR)/.terraform TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 3h
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -155,7 +155,7 @@ func TestAccKubernetesService_loadBalancer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.selector.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.selector.App", "MyApp"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.type", "LoadBalancer"),
-					resource.TestCheckResourceAttrSet(resourceName, "status.0.load_balancer.0.ingress.0.ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "status.0.load_balancer.0.ingress.0.hostname"),
 					testAccCheckServicePorts(&conf, []api.ServicePort{
 						{
 							Port:       int32(8888),

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -175,6 +175,11 @@ func isInternalKey(annotationKey string) bool {
 		return false
 	}
 
+	// allow AWS load balancer configuration annotations
+	if u.Hostname() == "service.beta.kubernetes.io" {
+		return false
+	}
+
 	// internal *.kubernetes.io keys
 	if strings.HasSuffix(u.Hostname(), "kubernetes.io") {
 		return true

--- a/kubernetes/structures_test.go
+++ b/kubernetes/structures_test.go
@@ -14,6 +14,7 @@ func TestIsInternalKey(t *testing.T) {
 		{"anyKey", false},
 		{"any.hostname.io", false},
 		{"any.hostname.com/with/path", false},
+		{"service.beta.kubernetes.io/aws-load-balancer-backend-protocol", false},
 		{"app.kubernetes.io", false},
 		{"kubernetes.io", true},
 		{"kubectl.kubernetes.io", true},


### PR DESCRIPTION
### Description

This PR fixes a couple of tests that were failing against AWS:
- TestAccKubernetesService_loadBalancer was failing because we were checking the status field for `ip` instead of `hostname`
- TestAccKubernetesService_loadBalancer_annotations_aws was failing because the aws load balancer annotations were being stripped from the config as internal keys 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ 
=== RUN   TestAccKubernetesService_loadBalancer
--- PASS: TestAccKubernetesService_loadBalancer (80.09s)
=== RUN   TestAccKubernetesService_loadBalancer_annotations_aws
--- PASS: TestAccKubernetesService_loadBalancer_annotations_aws (86.49s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix AWS acceptance tests
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
