### PR TITLE
Move some resources and data source under the subcategory manifest

### DIFF
--- a/website/docs/d/resource.html.markdown
+++ b/website/docs/d/resource.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "manifest"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_resource"
 description: |-

--- a/website/docs/r/annotations.html.markdown
+++ b/website/docs/r/annotations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "manifest"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_annotations"
 description: |-

--- a/website/docs/r/labels.html.markdown
+++ b/website/docs/r/labels.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "manifest"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_labels"
 description: |-

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "manifest"
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_manifest"
 description: |-


### PR DESCRIPTION
### Description

This PR creates a new documentation subcategory `manifest`, moves resources `kubernetes_manifest`, `kubernetes_annotations`, `kubernetes_labels`, and data source `kubernetes_resource` under this category.
