### PR TITLE
Fix cluster role aggregation rules selectors

### DIFF
--- a/kubernetes/structures_rbac.go
+++ b/kubernetes/structures_rbac.go
@@ -88,8 +88,10 @@ func expandClusterRoleAggregationRule(in []interface{}) *api.AggregationRule {
 	m := in[0].(map[string]interface{})
 
 	if v, ok := m["cluster_role_selectors"].([]interface{}); ok && len(v) > 0 {
-		crs := make([]metav1.LabelSelector, 0)
-		crs = append(crs, *expandLabelSelector(v))
+		crs := make([]metav1.LabelSelector, len(v))
+		for i, w := range v {
+			crs[i] = *expandLabelSelector([]interface{}{w})
+		}
 		ref.ClusterRoleSelectors = crs
 	}
 
@@ -142,9 +144,11 @@ func flattenClusterRoleAggregationRule(in *api.AggregationRule) []interface{} {
 	att := make(map[string]interface{})
 
 	if len(in.ClusterRoleSelectors) > 0 {
-		for _, crs := range in.ClusterRoleSelectors {
-			att["cluster_role_selectors"] = flattenLabelSelector(&crs)
+		crs := make([]interface{}, 0)
+		for _, v := range in.ClusterRoleSelectors {
+			crs = append(crs, flattenLabelSelector(&v)...)
 		}
+		att["cluster_role_selectors"] = crs
 	}
 
 	return []interface{}{att}

--- a/kubernetes/structures_rbac_test.go
+++ b/kubernetes/structures_rbac_test.go
@@ -1,0 +1,133 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	api "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExpandClusterRoleAggregationRule(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *api.AggregationRule
+	}{
+		{
+			[]interface{}{},
+			&api.AggregationRule{},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"cluster_role_selectors": []interface{}{
+						map[string]interface{}{
+							"match_labels": map[string]interface{}{"key": "value"},
+						},
+					},
+				},
+			},
+			&api.AggregationRule{
+				ClusterRoleSelectors: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{"key": "value"},
+					},
+				},
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"cluster_role_selectors": []interface{}{
+						map[string]interface{}{
+							"match_labels": map[string]interface{}{"key": "value"},
+						},
+						map[string]interface{}{
+							"match_labels": map[string]interface{}{"foo": "bar"},
+						},
+					},
+				},
+			},
+			&api.AggregationRule{
+				ClusterRoleSelectors: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{"key": "value"},
+					},
+					{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandClusterRoleAggregationRule(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenClusterRoleAggregationRule(t *testing.T) {
+	cases := []struct {
+		Input          *api.AggregationRule
+		ExpectedOutput []interface{}
+	}{
+		{
+			&api.AggregationRule{},
+			[]interface{}{map[string]interface{}{}},
+		},
+		{
+			&api.AggregationRule{
+				ClusterRoleSelectors: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{"key": "value"},
+					},
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"cluster_role_selectors": []interface{}{
+						map[string]interface{}{
+							"match_labels": map[string]string{"key": "value"},
+						},
+					},
+				},
+			},
+		},
+		{
+			&api.AggregationRule{
+				ClusterRoleSelectors: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{"key": "value"},
+					},
+					{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"cluster_role_selectors": []interface{}{
+						map[string]interface{}{
+							"match_labels": map[string]string{"key": "value"},
+						},
+						map[string]interface{}{
+							"match_labels": map[string]string{"foo": "bar"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenClusterRoleAggregationRule(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

This PR fixes the behaviour when adding multiple `cluster_role_selectors` to the `kubernetes_cluster_role.aggregation_rule` so that all are processed rather than only the first one.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

I'm on Windows and the make configuration doesn't look to be multi platform, I have WSL but my Go toolchain isn't up to date (VPN issues) so I ran the relevant tests manually and they passed.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix not handling multiple `cluster_role_selectors` on a `kubernetes_cluster_role`
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Closes #1360.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
