### PR TITLE
correct kube to kubectl, minor formatting

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -736,10 +736,10 @@ Commercial support is available at
 Alternatively, look for the hostIP associated with a running Nginx pod and combine it with the NodePort to assemble the URL:
 
 ```
-$ kubectl get pod nginx-86c669bff4-zgjkv -n nginx -o json |jq .status.hostIP
+$ kubectl get pod nginx-86c669bff4-zgjkv -n nginx -o json | jq .status.hostIP
 "192.168.39.189"
 
-$ kube get services -n nginx
+$ kubectl get services -n nginx
 NAME    TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
 nginx   NodePort   10.109.205.23   <none>        80:30201/TCP   19m
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ no] Have you added an acceptance test for the functionality being added?
- [ no] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
minor spelling
```

### References

[#1707](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1707)
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
