### PR TITLE
Set correct type for ttl_seconds_after_finished

### DIFF
--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -1,9 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -149,17 +146,11 @@ func jobSpecFields(specUpdatable bool) map[string]*schema.Schema {
 		},
 		// This field can be edited in place.
 		"ttl_seconds_after_finished": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: false,
-			ValidateFunc: func(value interface{}, key string) ([]string, []error) {
-				v, err := strconv.Atoi(value.(string))
-				if err != nil {
-					return []string{}, []error{fmt.Errorf("%s is not a valid integer", key)}
-				}
-				return validateNonNegativeInteger(v, key)
-			},
-			Description: "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ForceNew:     false,
+			ValidateFunc: validateNonNegativeInteger,
+			Description:  "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
 		},
 	}
 

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"strconv"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	batchv1 "k8s.io/api/batch/v1"
 )
@@ -55,7 +53,7 @@ func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData, meta interface{}
 	att["template"] = podSpec
 
 	if in.TTLSecondsAfterFinished != nil {
-		att["ttl_seconds_after_finished"] = strconv.Itoa(int(*in.TTLSecondsAfterFinished))
+		att["ttl_seconds_after_finished"] = *in.TTLSecondsAfterFinished
 	}
 
 	return []interface{}{att}, nil
@@ -105,12 +103,8 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 	}
 	obj.Template = *template
 
-	if v, ok := in["ttl_seconds_after_finished"].(string); ok && v != "" {
-		i, err := strconv.Atoi(v)
-		if err != nil {
-			return obj, err
-		}
-		obj.TTLSecondsAfterFinished = ptrToInt32(int32(i))
+	if v, ok := in["ttl_seconds_after_finished"].(int); ok && v >= 0 {
+		obj.TTLSecondsAfterFinished = ptrToInt32(int32(v))
 	}
 
 	return obj, nil


### PR DESCRIPTION

### Description

Having that as string resulted in semantically wrong types in cdktf

Not sure if this breaks compatibility.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...  Correced `ttl_seconds_after_finished` to be an integer
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
