### PR TITLE
Incorrect conversion between integer types

### DIFF
--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -106,7 +106,7 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 	obj.Template = *template
 
 	if v, ok := in["ttl_seconds_after_finished"].(string); ok && v != "" {
-		i, err := strconv.ParseInt(v,10,32)
+		i, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {
 			return obj, err
 		}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Changed function used to convert string to integer

Atoi -> ParseInt

Removes Scanning Alert
https://github.com/hashicorp/terraform-provider-kubernetes/security/code-scanning/1
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
NONE
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
