### PR TITLE
change topology_key to required

### DIFF
--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"regexp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -164,10 +162,9 @@ func podAffinityTermFields() map[string]*schema.Schema {
 			Set:         schema.HashString,
 		},
 		"topology_key": {
-			Type:         schema.TypeString,
-			Description:  "empty topology key is interpreted by the scheduler as 'all topologies'",
-			Optional:     true,
-			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.+$`), "value cannot be empty"),
+			Type:        schema.TypeString,
+			Description: "empty topology key is interpreted by the scheduler as 'all topologies'",
+			Required:    true,
 		},
 	}
 }

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -255,7 +255,7 @@ The following arguments are supported:
 
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
 * `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
-* `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
+* `topology_key` - (Required) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
 
 ### `preferred_during_scheduling_ignored_during_execution`
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Bug where `topology_key` field within PodAffinity is set to Optional when should be required. PR closes issue #1736 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Following error will now appear if no `topology_key` field is specified:
```
│ Error: Missing required argument
│ 
│   on main.tf line 67, in resource "kubernetes_deployment_v1" "overprovisioning-deployment":
│   67:             required_during_scheduling_ignored_during_execution {
│ 
│ The argument "topology_key" is required, but no definition was found.
```
### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
