### PR TITLE
prevent "name" from crashing due to emtpy map

### DIFF
--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -635,13 +635,14 @@ func flattenLabelSelectorRequirementList(l []metav1.LabelSelectorRequirement) []
 }
 
 func flattenLocalObjectReferenceArray(in []api.LocalObjectReference) []interface{} {
-	att := make([]interface{}, len(in))
-	for i, v := range in {
-		m := map[string]interface{}{}
+	att := []interface{}{}
+	for _, v := range in {
 		if v.Name != "" {
-			m["name"] = v.Name
+			m := map[string]interface{}{
+				"name": v.Name,
+			}
+			att = append(att, m)
 		}
-		att[i] = m
 	}
 	return att
 }

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -642,7 +642,6 @@ func flattenLocalObjectReferenceArray(in []api.LocalObjectReference) []interface
 		}
 		att = append(att, m)
 	}
-
 	return att
 }
 
@@ -668,7 +667,9 @@ func flattenServiceAccountSecrets(in []api.ObjectReference, defaultSecretName st
 			continue
 		}
 		m := map[string]interface{}{}
-		m["name"] = v.Name
+		if v.Name != "" {
+			m["name"] = v.Name
+		}
 		att = append(att, m)
 	}
 	return att

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -637,12 +637,12 @@ func flattenLabelSelectorRequirementList(l []metav1.LabelSelectorRequirement) []
 func flattenLocalObjectReferenceArray(in []api.LocalObjectReference) []interface{} {
 	att := []interface{}{}
 	for _, v := range in {
-			m := map[string]interface{}{
-				"name": v.Name,
-			}
-			att = append(att, m)
+		m := map[string]interface{}{
+			"name": v.Name,
 		}
+		att = append(att, m)
 	}
+
 	return att
 }
 
@@ -668,7 +668,7 @@ func flattenServiceAccountSecrets(in []api.ObjectReference, defaultSecretName st
 			continue
 		}
 		m := map[string]interface{}{}
-			m["name"] = v.Name
+		m["name"] = v.Name
 		att = append(att, m)
 	}
 	return att

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -637,7 +637,6 @@ func flattenLabelSelectorRequirementList(l []metav1.LabelSelectorRequirement) []
 func flattenLocalObjectReferenceArray(in []api.LocalObjectReference) []interface{} {
 	att := []interface{}{}
 	for _, v := range in {
-		if v.Name != "" {
 			m := map[string]interface{}{
 				"name": v.Name,
 			}
@@ -669,9 +668,7 @@ func flattenServiceAccountSecrets(in []api.ObjectReference, defaultSecretName st
 			continue
 		}
 		m := map[string]interface{}{}
-		if v.Name != "" {
 			m["name"] = v.Name
-		}
 		att = append(att, m)
 	}
 	return att


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #1741 - name not able to be set to null

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
