### PR TITLE
Fix type morphing of nested tuples

### DIFF
--- a/manifest/morph/morph.go
+++ b/manifest/morph/morph.go
@@ -186,6 +186,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 				return tftypes.Value{}, elp.NewErrorf("[%s] failed to morph tuple element into tuple element: %v", elp.String(), err)
 			}
 			lvals[i] = nv
+			eltypes[i] = nv.Type()
 		}
 		return tftypes.NewValue(tftypes.Tuple{ElementTypes: eltypes}, lvals), nil
 	case t.Is(tftypes.List{}):

--- a/manifest/morph/morph_test.go
+++ b/manifest/morph/morph_test.go
@@ -139,7 +139,7 @@ func TestMorphValueToType(t *testing.T) {
 				}),
 				T: tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType}},
 			},
-			Out: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType, tftypes.DynamicPseudoType, tftypes.DynamicPseudoType}}, []tftypes.Value{
+			Out: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String, tftypes.String}}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, "foo"),
 				tftypes.NewValue(tftypes.String, "bar"),
 				tftypes.NewValue(tftypes.String, "baz"),
@@ -200,6 +200,90 @@ func TestMorphValueToType(t *testing.T) {
 				tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
 					map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, "baz")}),
 			}),
+		},
+		"tuple(object)->tuple(object)": {
+			In: sampleInType{
+				V: tftypes.NewValue(
+					tftypes.Tuple{ElementTypes: []tftypes.Type{
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{"first": tftypes.String}},
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{"second": tftypes.DynamicPseudoType}},
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{"third": tftypes.Tuple{ElementTypes: []tftypes.Type{
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{"bar": tftypes.String}},
+						}},
+						}},
+					}},
+					[]tftypes.Value{
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"first": tftypes.String}},
+							map[string]tftypes.Value{"first": tftypes.NewValue(tftypes.String, "foo")}),
+
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"second": tftypes.DynamicPseudoType}},
+							map[string]tftypes.Value{"second": tftypes.NewValue(tftypes.DynamicPseudoType, nil)}),
+
+						tftypes.NewValue(
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"third": tftypes.Tuple{ElementTypes: []tftypes.Type{
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{"bar": tftypes.String}},
+								}},
+							}},
+							map[string]tftypes.Value{
+								"third": tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{"bar": tftypes.String}},
+								}}, []tftypes.Value{
+									tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}}, map[string]tftypes.Value{"foo": tftypes.NewValue(tftypes.String, "some")}),
+									tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"bar": tftypes.String}}, map[string]tftypes.Value{"bar": tftypes.NewValue(tftypes.String, "other")}),
+								}),
+							},
+						),
+					},
+				),
+				T: tftypes.Tuple{ElementTypes: []tftypes.Type{
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"first": tftypes.String}},
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"second": tftypes.DynamicPseudoType}},
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"third": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}}}}}},
+				}},
+			},
+
+			Out: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{
+				tftypes.Object{AttributeTypes: map[string]tftypes.Type{"first": tftypes.String}},
+				tftypes.Object{AttributeTypes: map[string]tftypes.Type{"second": tftypes.DynamicPseudoType}},
+				tftypes.Object{AttributeTypes: map[string]tftypes.Type{"third": tftypes.Tuple{ElementTypes: []tftypes.Type{
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+				}}}},
+			}},
+				[]tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"first": tftypes.String}},
+						map[string]tftypes.Value{"first": tftypes.NewValue(tftypes.String, "foo")}),
+
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"second": tftypes.DynamicPseudoType}},
+						map[string]tftypes.Value{"second": tftypes.NewValue(tftypes.String, nil)}),
+
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"third": tftypes.Tuple{ElementTypes: []tftypes.Type{
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+					}}}},
+						map[string]tftypes.Value{"third": tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+						}},
+							[]tftypes.Value{
+								tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+									map[string]tftypes.Value{
+										"foo": tftypes.NewValue(tftypes.String, "some"),
+										"bar": tftypes.NewValue(tftypes.String, nil),
+									}),
+								tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String, "bar": tftypes.String}},
+									map[string]tftypes.Value{
+										"foo": tftypes.NewValue(tftypes.String, nil),
+										"bar": tftypes.NewValue(tftypes.String, "other"),
+									}),
+							},
+						)},
+					),
+				}),
 		},
 		"set->tuple": {
 			In: sampleInType{
@@ -410,9 +494,9 @@ func TestMorphValueToType(t *testing.T) {
 				}},
 			},
 			Out: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
-				"one": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType, tftypes.DynamicPseudoType}},
+				"one": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String}},
 			}}, map[string]tftypes.Value{
-				"one": tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType, tftypes.DynamicPseudoType}},
+				"one": tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String}},
 					[]tftypes.Value{
 						tftypes.NewValue(tftypes.String, "bar"),
 						tftypes.NewValue(tftypes.String, "baz"),


### PR DESCRIPTION
This changes type morphing mechanism for Tuples, to make use of the resulting type of the already-morphed sub-elements when composing the final Tuple type as opposed to using the element type as extracted from OpenAPI.

As sub-elements get morphed first to their corresponding OpenAPI equivalent type, they already carry all the necessary type information plus any adaptations such as nested Tuples getting expanded to the number of elements found in actual configuration (which also changes those tuples' type signature).

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
This fixes issues like: #1734 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
