### PR TITLE
Fix the issue when provider crashes after introducing new fields on the provider level

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -360,8 +360,6 @@ type kubeClientsets struct {
 	dynamicClient       dynamic.Interface
 	discoveryClient     discovery.DiscoveryInterface
 
-	configData *schema.ResourceData
-
 	IgnoreAnnotations []string
 	IgnoreLabels      []string
 }
@@ -462,7 +460,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		config:              cfg,
 		mainClientset:       nil,
 		aggregatorClientset: nil,
-		configData:          d,
 		IgnoreAnnotations:   ignoreAnnotations,
 		IgnoreLabels:        ignoreLabels,
 	}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -361,6 +361,9 @@ type kubeClientsets struct {
 	discoveryClient     discovery.DiscoveryInterface
 
 	configData *schema.ResourceData
+
+	IgnoreAnnotations []string
+	IgnoreLabels      []string
 }
 
 func (k kubeClientsets) MainClientset() (*kubernetes.Clientset, error) {
@@ -445,11 +448,23 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		}
 	}
 
+	ignoreAnnotations := []string{}
+	ignoreLabels := []string{}
+
+	if v, ok := d.Get("ignore_annotations").([]interface{}); ok {
+		ignoreAnnotations = expandStringSlice(v)
+	}
+	if v, ok := d.Get("ignore_labels").([]interface{}); ok {
+		ignoreLabels = expandStringSlice(v)
+	}
+
 	m := kubeClientsets{
 		config:              cfg,
 		mainClientset:       nil,
 		aggregatorClientset: nil,
 		configData:          d,
+		IgnoreAnnotations:   ignoreAnnotations,
+		IgnoreLabels:        ignoreLabels,
 	}
 	return m, diag.Diagnostics{}
 }

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -125,25 +125,17 @@ func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData, providerMet
 	if len(metaPrefix) > 0 {
 		prefix = metaPrefix[0]
 	}
+
 	configAnnotations := d.Get(prefix + "metadata.0.annotations").(map[string]interface{})
-
-	var ignoreAnnotations []string
-	if v, ok := providerMetadata.(kubeClientsets).configData.Get("ignore_annotations").([]interface{}); ok {
-		ignoreAnnotations = expandStringSlice(v)
-	}
-
+	ignoreAnnotations := providerMetadata.(kubeClientsets).IgnoreAnnotations
 	annotations := removeInternalKeys(meta.Annotations, configAnnotations)
 	m["annotations"] = removeKeys(annotations, configAnnotations, ignoreAnnotations)
 	if meta.GenerateName != "" {
 		m["generate_name"] = meta.GenerateName
 	}
+
 	configLabels := d.Get(prefix + "metadata.0.labels").(map[string]interface{})
-
-	var ignoreLabels []string
-	if v, ok := providerMetadata.(kubeClientsets).configData.Get("ignore_labels").([]interface{}); ok {
-		ignoreLabels = expandStringSlice(v)
-	}
-
+	ignoreLabels := providerMetadata.(kubeClientsets).IgnoreLabels
 	labels := removeInternalKeys(meta.Labels, configLabels)
 	m["labels"] = removeKeys(labels, configLabels, ignoreLabels)
 	m["name"] = meta.Name


### PR DESCRIPTION
### Description

This PR fixes an issue when provider crashes intermittently on version `v2.12.0` due to new fields that were added on the provider level:
- `ignore_annotations`
- `ignore_labels`

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix an issue when provider crashes intermittently in version `v2.12.0`
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1762
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
