### PR TITLE
Adapt AKS infra for managed identity vs. explicit service acct

### DIFF
--- a/kubernetes/test-infra/aks/main.tf
+++ b/kubernetes/test-infra/aks/main.tf
@@ -78,13 +78,9 @@ resource "azurerm_kubernetes_cluster" "tf-k8s-acc" {
     vnet_subnet_id = azurerm_subnet.tf-k8s-acc.id
   }
 
-  service_principal {
-    client_id     = var.aks_client_id
-    client_secret = var.aks_client_secret
-  }
 
-  role_based_access_control {
-    enabled = true
+  identity {
+    type = "SystemAssigned"
   }
 
   network_profile {

--- a/kubernetes/test-infra/aks/outputs.tf
+++ b/kubernetes/test-infra/aks/outputs.tf
@@ -2,3 +2,6 @@ output "kubeconfig_path" {
   value = local_file.kubeconfig.filename
 }
 
+output "cluster_name" {
+  value = azurerm_kubernetes_cluster.tf-k8s-acc.name
+}

--- a/kubernetes/test-infra/aks/variables.tf
+++ b/kubernetes/test-infra/aks/variables.tf
@@ -22,14 +22,6 @@ variable "workers_type" {
   default = "Standard_DS4_v2"
 }
 
-variable "aks_client_id" {
-  description = "The Client ID for the Service Principal to use for this Managed Kubernetes Cluster"
-}
-
-variable "aks_client_secret" {
-  description = "The Client Secret for the Service Principal to use for this Managed Kubernetes Cluster"
-}
-
 # Uncomment to enable SSH access to nodes
 #
 # variable "public_ssh_key_path" {


### PR DESCRIPTION

### Description

This updates the templates for the AKS test environment to not require explicit service account secrets. Instead. it leverages managed identity for the cluster nodes.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
