### PR TITLE
Update GKE test cluster infra code

### DIFF
--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -11,7 +11,7 @@ variable "node_machine_type" {
 }
 
 variable "enable_alpha" {
-  default = true
+  default = false
 }
 
 data "google_compute_zones" "available" {


### PR DESCRIPTION
### Description

Current GKE test cluster infra code provisions an alpha cluster which causes some issues with [PV dynamic provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes) and as the result, some tests are not working. This PR changes the default value of `enable_alpha` from `true` to `false` so Alpha features won't be enabled.

Fixes the following tests:
- `TestAccKubernetesStatefulSet_basic`
- `TestAccKubernetesStatefulSet_basic_idempotency `
- `TestAccKubernetesStatefulSet_Update`