### PR TITLE
[TK-1373] Update resource and data of 'kubernetes_(default_)service_account' to handle deprecated 'default_secret_name' in Kubernetes 1.24.0+

### DIFF
--- a/kubernetes/data_source_kubernetes_service_account.go
+++ b/kubernetes/data_source_kubernetes_service_account.go
@@ -50,7 +50,7 @@ func dataSourceKubernetesServiceAccount() *schema.Resource {
 			"default_secret_name": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty and deprecated in future",
+				Deprecated: "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty",
 			},
 		},
 	}

--- a/kubernetes/data_source_kubernetes_service_account.go
+++ b/kubernetes/data_source_kubernetes_service_account.go
@@ -48,8 +48,9 @@ func dataSourceKubernetesServiceAccount() *schema.Resource {
 				Computed:    true,
 			},
 			"default_secret_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty and deprecated in future",
 			},
 		},
 	}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/go-cty/cty"
+	gversion "github.com/hashicorp/go-version"
 	"github.com/mitchellh/go-homedir"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -632,4 +633,27 @@ func useAdmissionregistrationV1beta1(conn *kubernetes.Clientset) (bool, error) {
 	log.Printf("[INFO] Using %s/v1beta1", group)
 	useadmissionregistrationv1beta1 = ptrToBool(true)
 	return true, nil
+}
+
+func getServerVersion(connection *kubernetes.Clientset) (*gversion.Version, error) {
+	sv, err := connection.ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	return gversion.NewVersion(sv.String())
+}
+
+func serverVersionGreaterThanOrEqual(connection *kubernetes.Clientset, version string) (bool, error) {
+	sv, err := getServerVersion(connection)
+	if err != nil {
+		return false, err
+	}
+	// server version that we need to compare with
+	cv, err := gversion.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	return sv.GreaterThanOrEqual(cv), nil
 }

--- a/kubernetes/resource_kubernetes_default_service_account.go
+++ b/kubernetes/resource_kubernetes_default_service_account.go
@@ -55,7 +55,6 @@ func resourceKubernetesDefaultServiceAccountCreate(ctx context.Context, d *schem
 		log.Printf("[INFO] Default service account exists: %s", metadata.Namespace)
 		return nil
 	})
-
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -442,7 +442,7 @@ func resourceKubernetesServiceUpdate(ctx context.Context, d *schema.ResourceData
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
-		serverVersion, err := conn.ServerVersion()
+		serverVersion, err := getServerVersion(conn)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -69,8 +69,9 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 				Default:     true,
 			},
 			"default_secret_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty and deprecated in future",
 			},
 		},
 	}
@@ -106,12 +107,21 @@ func resourceKubernetesServiceAccountCreate(ctx context.Context, d *schema.Resou
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	return resourceKubernetesServiceAccountRead(ctx, d, meta)
 }
 
 func getServiceAccountDefaultSecret(ctx context.Context, name string, config api.ServiceAccount, timeout time.Duration, conn *kubernetes.Clientset) (*api.Secret, error) {
+	b, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
+	if err != nil {
+		return &api.Secret{}, err
+	}
+	if b {
+		return &api.Secret{}, nil
+	}
+
 	var svcAccTokens []api.Secret
-	err := resource.RetryContext(ctx, timeout, func() *resource.RetryError {
+	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
 		resp, err := conn.CoreV1().ServiceAccounts(config.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return resource.NonRetryableError(err)
@@ -166,6 +176,20 @@ func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn
 	   https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/controller/serviceaccount/tokens_controller.go#L384
 	*/
 	ds := make([]string, 0)
+
+	b, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
+	if err != nil {
+		return "", diag.FromErr(err)
+	}
+	if b {
+		return "", diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above",
+				Detail:   "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty",
+			},
+		}
+	}
 
 	for _, saSecret := range sa.Secrets {
 		if !strings.HasPrefix(saSecret.Name, fmt.Sprintf("%s-token-", sa.Name)) {
@@ -237,6 +261,9 @@ func diffObjectReferences(origOrs []api.ObjectReference, ors []api.ObjectReferen
 }
 
 func resourceKubernetesServiceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	var diagMessages []diag.Diagnostic
+
 	exists, err := resourceKubernetesServiceAccountExists(ctx, d, meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -284,6 +311,17 @@ func resourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resourc
 	}
 
 	defaultSecretName := d.Get("default_secret_name").(string)
+	b, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if b {
+		diagMessages = append(diagMessages, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above",
+			Detail:   "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty",
+		})
+	}
 	log.Printf("[DEBUG] Default secret name is %q", defaultSecretName)
 	secrets := flattenServiceAccountSecrets(svcAcc.Secrets, defaultSecretName)
 	log.Printf("[DEBUG] Flattened secrets: %#v", secrets)
@@ -292,7 +330,7 @@ func resourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	return nil
+	return diagMessages
 }
 
 func resourceKubernetesServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -415,6 +453,7 @@ func resourceKubernetesServiceAccountImportState(ctx context.Context, d *schema.
 	if err != nil {
 		return nil, fmt.Errorf("Unable to set default_secret_name: %s", err)
 	}
+
 	d.SetId(buildId(sa.ObjectMeta))
 
 	return []*schema.ResourceData{d}, nil

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -71,7 +71,7 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 			"default_secret_name": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty and deprecated in future",
+				Deprecated: "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty",
 			},
 		},
 	}

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -112,11 +112,11 @@ func resourceKubernetesServiceAccountCreate(ctx context.Context, d *schema.Resou
 }
 
 func getServiceAccountDefaultSecret(ctx context.Context, name string, config api.ServiceAccount, timeout time.Duration, conn *kubernetes.Clientset) (*api.Secret, error) {
-	b, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
+	sv, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
 	if err != nil {
 		return &api.Secret{}, err
 	}
-	if b {
+	if sv {
 		return &api.Secret{}, nil
 	}
 
@@ -177,16 +177,16 @@ func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn
 	*/
 	ds := make([]string, 0)
 
-	b, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
+	sv, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
 	if err != nil {
 		return "", diag.FromErr(err)
 	}
-	if b {
+	if sv {
 		return "", diag.Diagnostics{
 			diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  "'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above",
-				Detail:   "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty",
+				Summary:  `"default_secret_name" is no longer applicable for Kubernetes v1.24.0 and above`,
+				Detail:   `Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, "default_secret_name" will be empty`,
 			},
 		}
 	}
@@ -311,15 +311,15 @@ func resourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resourc
 	}
 
 	defaultSecretName := d.Get("default_secret_name").(string)
-	b, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
+	sv, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if b {
+	if sv {
 		diagMessages = append(diagMessages, diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  "'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above",
-			Detail:   "Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty",
+			Summary:  `"default_secret_name" is no longer applicable for Kubernetes v1.24.0 and above`,
+			Detail:   `Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, "default_secret_name" will be empty`,
 		})
 	}
 	log.Printf("[DEBUG] Default secret name is %q", defaultSecretName)

--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -219,7 +219,7 @@ func TestAccKubernetesServiceAccount_update(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "image_pull_secret.#", "0"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "true"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{}),
-					testAccCheckServiceAccountDefaultSecrets(&conf, []*regexp.Regexp{
+					testAccCheckServiceAccountSecrets(&conf, []*regexp.Regexp{
 						regexp.MustCompile("^" + name + "-token-[a-z0-9]+$"),
 					}),
 				),
@@ -251,7 +251,7 @@ func TestAccKubernetesServiceAccount_generatedName(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "true"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{}),
-					testAccCheckServiceAccountDefaultSecrets(&conf, []*regexp.Regexp{
+					testAccCheckServiceAccountSecrets(&conf, []*regexp.Regexp{
 						regexp.MustCompile("^" + prefix + "[a-z0-9]+-token-[a-z0-9]+$"),
 					}),
 				),
@@ -287,17 +287,11 @@ func matchLocalObjectReferenceName(lor []api.LocalObjectReference, expected []*r
 	return false
 }
 
-func testAccCheckServiceAccountDefaultSecrets(m *api.ServiceAccount, expected []*regexp.Regexp) resource.TestCheckFunc {
-	if clusterVersionGreaterThanOrEqual("1.24.0") {
-		return func(s *terraform.State) error {
-			return nil
-		}
-	}
-	return testAccCheckServiceAccountSecrets(m, expected)
-}
-
 func testAccCheckServiceAccountSecrets(m *api.ServiceAccount, expected []*regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		if clusterVersionGreaterThanOrEqual("1.24.0") {
+			return nil
+		}
 		if len(expected) == 0 && len(m.Secrets) == 0 {
 			return nil
 		}

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `image_pull_secret` - A list of image pull secrets associated with the service account.
 * `secret` - A list of secrets associated with the service account.
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
 
 ### `image_pull_secret`
 

--- a/website/docs/d/service_account_v1.html.markdown
+++ b/website/docs/d/service_account_v1.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `image_pull_secret` - A list of image pull secrets associated with the service account.
 * `secret` - A list of secrets associated with the service account.
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
 
 ### `image_pull_secret`
 

--- a/website/docs/r/default_service_account.html.markdown
+++ b/website/docs/r/default_service_account.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
 
 ## Destroying
 

--- a/website/docs/r/default_service_account_v1.html.markdown
+++ b/website/docs/r/default_service_account_v1.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
 
 ## Destroying
 

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
 
 ## Import
 

--- a/website/docs/r/service_account_v1.html.markdown
+++ b/website/docs/r/service_account_v1.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
 
 ## Import
 


### PR DESCRIPTION
### Description

Starting from the version `1.24.0` Kubernetes does not generate a token for a service account by default([link](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes) to the change log). In this case, the concept of `default_secret_name` is not applicable anymore for the Kubernetes clusters `v1.24.0+`. This PR updates the provider's behavior accordingly to the cluster version.

#### Affected resource
- `r/kubernetes_default_service_account`
- `d/kubernetes_service_account`
- `r/kubernetes_service_account`

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:
`1.24.0+` [1.24.2-gke.300]
```
$ make testacc TESTARGS='-run ^.*ServiceAccount.*'

=== RUN   TestAccKubernetesDataSourceServiceAccount_basic
--- PASS: TestAccKubernetesDataSourceServiceAccount_basic (10.21s)
=== RUN   TestAccKubernetesDataSourceServiceAccount_default_secret
    provider_test.go:225: This test does not run on cluster versions 1.24.0 and above
--- SKIP: TestAccKubernetesDataSourceServiceAccount_default_secret (0.06s)
=== RUN   TestAccKubernetesDefaultServiceAccount_basic
--- PASS: TestAccKubernetesDefaultServiceAccount_basic (13.19s)
=== RUN   TestAccKubernetesDefaultServiceAccount_secrets
--- PASS: TestAccKubernetesDefaultServiceAccount_secrets (12.79s)
=== RUN   TestAccKubernetesDefaultServiceAccount_automountServiceAccountToken
--- PASS: TestAccKubernetesDefaultServiceAccount_automountServiceAccountToken (13.20s)
=== RUN   TestAccKubernetesServiceAccount_basic
--- PASS: TestAccKubernetesServiceAccount_basic (6.58s)
=== RUN   TestAccKubernetesServiceAccount_default_secret
    provider_test.go:225: This test does not run on cluster versions 1.24.0 and above
--- SKIP: TestAccKubernetesServiceAccount_default_secret (0.06s)
=== RUN   TestAccKubernetesServiceAccount_automount
--- PASS: TestAccKubernetesServiceAccount_automount (5.64s)
=== RUN   TestAccKubernetesServiceAccount_update
--- PASS: TestAccKubernetesServiceAccount_update (13.58s)
=== RUN   TestAccKubernetesServiceAccount_generatedName
--- PASS: TestAccKubernetesServiceAccount_generatedName (5.08s)
PASS
```

`pre-1.24.0` [1.23.8-gke.400]
```
$ make testacc TESTARGS='-run ^.*ServiceAccount.*'

=== RUN   TestAccKubernetesDataSourceServiceAccount_basic
--- PASS: TestAccKubernetesDataSourceServiceAccount_basic (8.83s)
=== RUN   TestAccKubernetesDataSourceServiceAccount_default_secret
--- PASS: TestAccKubernetesDataSourceServiceAccount_default_secret (8.08s)
=== RUN   TestAccKubernetesDefaultServiceAccount_basic
--- PASS: TestAccKubernetesDefaultServiceAccount_basic (12.[30](https://github.com/hashicorp/terraform-provider-kubernetes/runs/7520903353?check_suite_focus=true#step:11:31)s)
=== RUN   TestAccKubernetesDefaultServiceAccount_secrets
--- PASS: TestAccKubernetesDefaultServiceAccount_secrets (11.76s)
=== RUN   TestAccKubernetesDefaultServiceAccount_automountServiceAccountToken
--- PASS: TestAccKubernetesDefaultServiceAccount_automountServiceAccountToken (12.11s)
=== RUN   TestAccKubernetesServiceAccount_basic
--- PASS: TestAccKubernetesServiceAccount_basic (5.86s)
=== RUN   TestAccKubernetesServiceAccount_default_secret
--- PASS: TestAccKubernetesServiceAccount_default_secret (5.[36](https://github.com/hashicorp/terraform-provider-kubernetes/runs/7520903353?check_suite_focus=true#step:11:37)s)
=== RUN   TestAccKubernetesServiceAccount_automount
--- PASS: TestAccKubernetesServiceAccount_automount (5.21s)
=== RUN   TestAccKubernetesServiceAccount_update
--- PASS: TestAccKubernetesServiceAccount_update (12.14s)
=== RUN   TestAccKubernetesServiceAccount_generatedName
--- PASS: TestAccKubernetesServiceAccount_generatedName (4.81s)
PASS
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
Fixes: [1724](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724)

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
