### PR TITLE
pv+pvc: use API enum values for state constants

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -111,8 +111,8 @@ func resourceKubernetesPersistentVolumeClaimCreate(ctx context.Context, d *schem
 
 	if d.Get("wait_until_bound").(bool) {
 		stateConf := &resource.StateChangeConf{
-			Target:  []string{"Bound"},
-			Pending: []string{"Pending"},
+			Target:  []string{string(api.ClaimBound)},
+			Pending: []string{string(api.ClaimPending)},
 			Timeout: d.Timeout(schema.TimeoutCreate),
 			Refresh: func() (interface{}, string, error) {
 				out, err := conn.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, name, metav1.GetOptions{})

--- a/kubernetes/schema_persistent_volume_claim.go
+++ b/kubernetes/schema_persistent_volume_claim.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	api "k8s.io/api/core/v1"
 )
 
 func persistentVolumeClaimFields() map[string]*schema.Schema {
@@ -30,9 +31,9 @@ func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{
-					"ReadWriteOnce",
-					"ReadOnlyMany",
-					"ReadWriteMany",
+					string(api.ReadWriteOnce),
+					string(api.ReadOnlyMany),
+					string(api.ReadWriteMany),
 				}, false),
 			},
 			Set: schema.HashString,


### PR DESCRIPTION
### Description

Minor internal cleanup to the `persistent_volume` and `persistent_volume_claim` resources.

This updates literal strings to refer to their enum definitions, which makes it easier to trace back to the documentation and verify; avoids typos; and makes it straightforward to identify newly available values.

No functional change.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
