### PR TITLE
sdk lints: use `WaitForStateContext` vs deprecated `WaitForState`

### DIFF
--- a/kubernetes/resource_kubernetes_certificate_signing_request.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request.go
@@ -173,7 +173,7 @@ func resourceKubernetesCertificateSigningRequestCreate(ctx context.Context, d *s
 			return out, csrStatus, nil
 		},
 	}
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -241,7 +241,7 @@ func resourceKubernetesPersistentVolumeCreate(ctx context.Context, d *schema.Res
 			return out, statusPhase, nil
 		},
 	}
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -126,7 +126,7 @@ func resourceKubernetesPersistentVolumeClaimCreate(ctx context.Context, d *schem
 				return out, statusPhase, nil
 			},
 		}
-		_, err = stateConf.WaitForState()
+		_, err = stateConf.WaitForStateContext(ctx)
 		if err != nil {
 			var lastWarnings []api.Event
 			var wErr error

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -229,7 +229,7 @@ func resourceKubernetesStorageClassDelete(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.StorageV1().StorageClasses().Get(ctx, d.Id(), metav1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {


### PR DESCRIPTION
### Description

This updates a couple use of the deprecated `WaitForState` to use `WaitForStateContext` as recommended, and one instance of `Retry` → `RetryContext`.

[Per the docs on `WaitForState`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#StateChangeConf.WaitForState):

> Deprecated: Please use `WaitForStateContext` to ensure proper plugin shutdown

This allows these waiters to be cancelled, for example in the case of waiting for a misconfigured PV to become available that never will, or a PVC that cannot be bound.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Ensure proper shutdown on cancelled creation or deletion requests for several resource types.
```

### References

 * https://cs.opensource.google/go/go/+/refs/tags/go1.18.4:src/context/context.go;l=208
 * https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#StateChangeConf.WaitForState
 * https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.19.0/helper/resource/state.go#L54

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
