### PR TITLE
update resources/verbs docs to represent all

### DIFF
--- a/website/docs/r/cluster_role_v1.html.markdown
+++ b/website/docs/r/cluster_role_v1.html.markdown
@@ -89,8 +89,8 @@ The following arguments are supported:
 * `api_groups` - (Optional) APIGroups is the name of the APIGroup that contains the resources. If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
 * `non_resource_urls` - (Optional) NonResourceURLs is a set of partial urls that a user should have access to. \*s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"), but not both.
 * `resource_names` - (Optional) ResourceNames is an optional white list of names that the rule applies to. An empty set means that everything is allowed.
-* `resources` - (Optional) Resources is a list of resources this rule applies to. ResourceAll represents all resources.
-* `verbs` - (Required) Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+* `resources` - (Optional) Resources is a list of resources this rule applies to. '\*' represents all resources.
+* `verbs` - (Required) Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '\*' represents all kinds.
 
 ### `aggregation_rule`
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Update Docs in Cluster Role so that it matches documentation found in [Kubernetes Cluster Role Doc](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role#resources)

Fix #1742 

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.



### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
