### PR TITLE
Do not remove server side fields for datasources

### DIFF
--- a/.changelog/1802.txt
+++ b/.changelog/1802.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+The kubernetes status field is now available in the `kubernetes_resource` datasource
+```

--- a/manifest/provider/datasource.go
+++ b/manifest/provider/datasource.go
@@ -105,7 +105,7 @@ func (s *RawProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.R
 	}
 	rcl := client.Resource(gvr)
 
-	objectType, th, err := s.TFTypeFromOpenAPI(ctx, gvk, false)
+	objectType, th, err := s.TFTypeFromOpenAPI(ctx, gvk, true)
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
@@ -148,8 +148,7 @@ func (s *RawProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.R
 		return resp, nil
 	}
 
-	fo := RemoveServerSideFields(res.Object)
-	nobj, err := payload.ToTFValue(fo, objectType, th, tftypes.NewAttributePath())
+	nobj, err := payload.ToTFValue(res.Object, objectType, th, tftypes.NewAttributePath())
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,

--- a/manifest/test/acceptance/datasource_resource_status_test.go
+++ b/manifest/test/acceptance/datasource_resource_status_test.go
@@ -46,7 +46,6 @@ func TestDataSourceKubernetesResourceStatus_Deployment(t *testing.T) {
 	tf.Init(ctx)
 	tf.Apply(ctx)
 
-
 	k8shelper.AssertNamespacedResourceExists(t, "apps/v1", "deployments", namespace, name)
 
 	state, err := tf.State(ctx)

--- a/manifest/test/acceptance/datasource_resource_status_test.go
+++ b/manifest/test/acceptance/datasource_resource_status_test.go
@@ -1,0 +1,84 @@
+//go:build acceptance
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
+)
+
+func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
+	ctx := context.Background()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
+	name := randName()
+	namespace := randName()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+
+	// STEP 1: Create a Deployment to use as a data source
+	tf := tfhelper.RequireNewWorkingDir(ctx, t)
+	tf.SetReattachInfo(ctx, reattachInfo)
+	defer func() {
+		tf.Destroy(ctx)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+	}()
+
+	tfvars := TFVARS{
+		"name":      name,
+		"namespace": namespace,
+	}
+	tfconfig := loadTerraformConfig(t, "datasource-resource-status/step1.tf", tfvars)
+	tf.SetConfig(ctx, tfconfig)
+	tf.Init(ctx)
+	tf.Apply(ctx)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "deployments", namespace, name)
+
+	state, err := tf.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform state: %q", err)
+	}
+	tfstate := tfstatehelper.NewHelper(state)
+
+	// STEP 2: Read the Deployment from step 1 using a kubernetes_resource data source
+	reattachInfo2, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create additional provider instance: %q", err)
+	}
+	step2 := tfhelper.RequireNewWorkingDir(ctx, t)
+	step2.SetReattachInfo(ctx, reattachInfo2)
+	defer func() {
+		step2.Destroy(ctx)
+		step2.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "deployments", namespace, name2)
+	}()
+
+	tfconfig = loadTerraformConfig(t, "datasource-resource-status/step2.tf", tfvars)
+	step2.SetConfig(ctx, string(tfconfig))
+	step2.Init(ctx)
+	step2.Apply(ctx)
+
+	s2, err := step2.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform state: %q", err)
+	}
+	tfstate := tfstatehelper.NewHelper(s2)
+
+	// check that the data source has the status field defined
+	tfstate.AssertAttributeNotEmpty(t, "data.kubernetes_resource.test_deploy.object.status")
+}

--- a/manifest/test/acceptance/datasource_resource_status_test.go
+++ b/manifest/test/acceptance/datasource_resource_status_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
 )
 
-func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
+func TestDataSourceKubernetesResourceStatus_Deployment(t *testing.T) {
 	ctx := context.Background()
 
 	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
@@ -35,7 +34,7 @@ func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
 	defer func() {
 		tf.Destroy(ctx)
 		tf.Close()
-		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "apps/v1", "deployments", namespace, name)
 	}()
 
 	tfvars := TFVARS{
@@ -47,7 +46,8 @@ func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
 	tf.Init(ctx)
 	tf.Apply(ctx)
 
-	k8shelper.AssertNamespacedResourceExists(t, "v1", "deployments", namespace, name)
+
+	k8shelper.AssertNamespacedResourceExists(t, "apps/v1", "deployments", namespace, name)
 
 	state, err := tf.State(ctx)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
 	defer func() {
 		step2.Destroy(ctx)
 		step2.Close()
-		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "deployments", namespace, name2)
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "apps/v1", "deployments", namespace, name)
 	}()
 
 	tfconfig = loadTerraformConfig(t, "datasource-resource-status/step2.tf", tfvars)
@@ -77,7 +77,7 @@ func TestDataSourceKubernetesResource_ConfigMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to retrieve terraform state: %q", err)
 	}
-	tfstate := tfstatehelper.NewHelper(s2)
+	tfstate = tfstatehelper.NewHelper(s2)
 
 	// check that the data source has the status field defined
 	tfstate.AssertAttributeNotEmpty(t, "data.kubernetes_resource.test_deploy.object.status")

--- a/manifest/test/acceptance/testdata/datasource-resource-status/step1.tf
+++ b/manifest/test/acceptance/testdata/datasource-resource-status/step1.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_deployment" "test_deploy" {
+  api_version = "v1"
+
+  metadata = {
+    name = var.name
+    namespace = var.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        test = "test-status"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "test-status"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.21.6"
+          name  = "test"
+          }
+        }
+      }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/datasource-resource-status/step1.tf
+++ b/manifest/test/acceptance/testdata/datasource-resource-status/step1.tf
@@ -1,32 +1,32 @@
-resource "kubernetes_deployment" "test_deploy" {
-  api_version = "v1"
-
-  metadata = {
-    name = var.name
-    namespace = var.namespace
-  }
-
-  spec {
-    replicas = 1
-
-    selector {
-      match_labels = {
-        test = "test-status"
-      }
+resource "kubernetes_manifest" "test_deploy" {
+  manifest = {
+    "apiVersion" = "apps/v1"
+    "kind"       = "Deployment"
+    "metadata" = {
+      "name" = var.name
+      "namespace" = var.namespace
     }
-
-    template {
-      metadata {
-        labels = {
-          test = "test-status"
+    "spec" = {
+      "selector" = {
+        "matchLabels" = {
+          "test" = "MyExampleApp"
         }
       }
 
-      spec {
-        container {
-          image = "nginx:1.21.6"
-          name  = "test"
+      "template" = {
+        "metadata" = {
+          "labels" = {
+            "test" = "MyExampleApp"
           }
+        }
+
+        "spec" = {
+          "containers" = [
+            {
+               "image" = "nginx:1.21.6"
+               "name"  = "example"
+            }
+          ]
         }
       }
     }

--- a/manifest/test/acceptance/testdata/datasource-resource-status/step2.tf
+++ b/manifest/test/acceptance/testdata/datasource-resource-status/step2.tf
@@ -1,5 +1,5 @@
 data "kubernetes_resource" "test_deploy" {
-  api_version = "v1"
+  api_version = "apps/v1"
   kind = "Deployment"
   metadata {
     name = var.name

--- a/manifest/test/acceptance/testdata/datasource-resource-status/step2.tf
+++ b/manifest/test/acceptance/testdata/datasource-resource-status/step2.tf
@@ -1,0 +1,8 @@
+data "kubernetes_resource" "test_deploy" {
+  api_version = "v1"
+  kind = "Deployment"
+  metadata {
+    name = var.name
+    namespace = var.namespace
+  }
+}

--- a/manifest/test/acceptance/testdata/datasource-resource-status/variables.tf
+++ b/manifest/test/acceptance/testdata/datasource-resource-status/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it.
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars)
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
Server side fields for datasources should not be deleted.

This allows reading the status field for the generic `kubernetes_resource`
datasource. Thus this PR Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1699