### PR TITLE
chore: Default Timeout for KubernetesServiceAccount has been extended  to 1 minute.

### DIFF
--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -29,7 +29,7 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Second),
+			Create: schema.DefaultTimeout(1 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
### Description

All resources except KubernetesServiceAccount are more than 1 minute.
Only KubernetesServiceAccount is treated unequally, with a timeout of 30 seconds.
If the network is slowing down and you are applying to an environment that is physically far away, 30 seconds may cause a timeout.

Translated with www.DeepL.com/Translator (free version)
<img width="487" alt="スクリーンショット 2022-08-19 15 07 33" src="https://user-images.githubusercontent.com/22343391/185554077-9f969207-7cf6-435e-9c59-da41cec6e136.png">

Q: But why don't I just extend the timeout by myself?
A: Yes, but I don't understand why only KubernetesServiceAccount is given 30 seconds while all other resources except KubernetesServiceAccount are given more than 1 minute. KubernetesServiceAccount should be treated equally.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Default Timeout for KubernetesServiceAccount has been extended to 1 minute.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
