### PR TITLE
[TK-78009] Fix propagation of non-fatal Diagnostics in the type morphing logic

### DIFF
--- a/_examples/kubernetes_manifest/deployment/deployment.tf
+++ b/_examples/kubernetes_manifest/deployment/deployment.tf
@@ -34,6 +34,18 @@ resource "kubernetes_manifest" "test-deployment" {
                   "protocol"      = "TCP"
                 },
               ]
+              "volumeMounts" = [
+                {
+                  "mountPath" = "/foobar/"
+                  "name"      = "vol-foobar"
+                },
+              ]
+            },
+          ],
+          "volumes" = [
+            {
+              "emptyDir" = {}
+              "name"     = "vol-foobar"
             },
           ]
         }

--- a/manifest/morph/morph_test.go
+++ b/manifest/morph/morph_test.go
@@ -651,6 +651,39 @@ func TestMorphValueToTypeDiagnostics(t *testing.T) {
 				},
 			},
 		},
+		"object -> object (deep)": {
+			In: sampleInType{
+				V: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"two": tftypes.String,
+					"three": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"foo": tftypes.String,
+						"bar": tftypes.Number,
+					}},
+				}}, map[string]tftypes.Value{
+					"two": tftypes.NewValue(tftypes.String, "stuff"),
+					"three": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"foo": tftypes.String,
+						"bar": tftypes.Number,
+					}}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "fourtytwo"),
+						"bar": tftypes.NewValue(tftypes.Number, 42),
+					}),
+				}),
+				T: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"one":   tftypes.Number,
+					"two":   tftypes.String,
+					"three": tftypes.Object{AttributeTypes: map[string]tftypes.Type{"foo": tftypes.String}},
+				}},
+			},
+			Diags: []*tfprotov5.Diagnostic{
+				{
+					Severity:  tfprotov5.DiagnosticSeverityWarning,
+					Summary:   "Attribute not found in schema",
+					Detail:    "Unable to find schema type for attribute:\nthree.bar",
+					Attribute: tftypes.NewAttributePath().WithAttributeName("three"),
+				},
+			},
+		},
 	}
 	for n, s := range samples {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
### Description
We recently [rolled out a fix](https://github.com/hashicorp/terraform-provider-kubernetes/pull/1780/commits/0e7fbd0c302f135128557e27e156b974e6668714) to `kubernetes_manifest` that was designed to treat attributes disappearing from schemas of resources already present in the state as non-fatal errors. This was to enable the state upgrade logic to just discard deprecated attributes and upgrade the state of existing manifest resources to newer type schemas.

Unfortunately, this only behaved correctly when attributes were present at the first level of nesting under `object`. Attributes further down would still generate a non-fatal diagnostic, but the parent attributes would still generate fatal warnings when aggregating the diagnostics of all descendant attributes.

This change intends to fix the omission described above and allow toleration of such non-fatal diagnostics.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Script for acceptance testing:

```shell
#!/bin/sh

cd _examples/kubernetes_manifest/deployment

kind create cluster --kubeconfig testconfig --image kindest/node:v1.20.15 --name "1.20"
kind create cluster --kubeconfig testconfig --image kindest/node:v1.21.12 --name "1.21"

export KUBE_CONFIG_PATH=$PWD/testconfig
export KUBECONFIG=$PWD/testconfig

KUBE_CTX=kind-1.20 terraform apply -auto-approve

kubectl --context kind-1.20 get deployments.apps test-foobar -oyaml | kubectl --context kind-1.21 apply -f -

KUBE_CTX=kind-1.21 terraform plan

# Should display:
# ╷
# │ Warning: Attribute not found in schema
# │
# │   with kubernetes_manifest.test-deployment,
# │   on deployment.tf line 1, in resource "kubernetes_manifest" "test-deployment":
# │    1: resource "kubernetes_manifest" "test-deployment" {
# │
# │ Unable to find schema type for attribute:
# │ spec.template.spec.volumes[0].ephemeral.readOnly

KUBE_CTX=kind-1.21 terraform refresh
KUBE_CTX=kind-1.21 terraform plan

# Should display:
#
# kubernetes_manifest.test-deployment: Refreshing state...
#
# No changes. Your infrastructure matches the configuration.

kind get clusters | grep '1.2' | xargs kind delete clusters
rm terraform.tfstate* testconfig
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
[BUG FIXES]
* State migration of `kubernetes_manifest` resources will not fail when encountering deprecated (missing) attributes in the new resource schema.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
