### PR TITLE
Fix job deletion fail ttl

### DIFF
--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -231,6 +231,9 @@ func resourceKubernetesJobDelete(ctx context.Context, d *schema.ResourceData, me
 	log.Printf("[INFO] Deleting job: %#v", name)
 	err = conn.BatchV1().Jobs(namespace).Delete(ctx, name, deleteOptions)
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.Errorf("Failed to delete Job! API error: %s", err)
 	}
 

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -27,8 +27,8 @@ resource "kubernetes_job" "demo" {
       spec {
         container {
           name    = "pi"
-          image   = "perl"
-          command = ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+          image   = "alpine"
+          command = ["sh", "-c", "sleep 10"]
         }
         restart_policy = "Never"
       }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fix issue job deletion bug where after TTL, outputs job is not available. Should just be skipped.

Fixes #1819 

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
