### PR TITLE
Add "field_manager" attribute 

### DIFF
--- a/.changelog/1831.txt
+++ b/.changelog/1831.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add "field_manager" attribute to kubernetes_labels, kubernetes_annotations, kubernetes_config_map_v1_data
+```

--- a/kubernetes/resource_kubernetes_annotations.go
+++ b/kubernetes/resource_kubernetes_annotations.go
@@ -69,6 +69,12 @@ func resourceKubernetesAnnotations() *schema.Resource {
 				Description: "Force overwriting annotations that were created or edited outside of Terraform.",
 				Optional:    true,
 			},
+			"field_manager": {
+				Type:        schema.TypeString,
+				Description: "Set the name of the field manager for the specified labels.",
+				Optional:    true,
+				Default:     defaultFieldManagerName,
+			},
 		},
 	}
 }
@@ -261,7 +267,7 @@ func resourceKubernetesAnnotationsUpdate(ctx context.Context, d *schema.Resource
 		types.ApplyPatchType,
 		patchbytes,
 		v1.PatchOptions{
-			FieldManager: defaultFieldManagerName,
+			FieldManager: d.Get("field_manager").(string),
 			Force:        ptrToBool(d.Get("force").(bool)),
 		},
 	)

--- a/kubernetes/resource_kubernetes_annotations.go
+++ b/kubernetes/resource_kubernetes_annotations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-kubernetes/util"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -70,10 +71,11 @@ func resourceKubernetesAnnotations() *schema.Resource {
 				Optional:    true,
 			},
 			"field_manager": {
-				Type:        schema.TypeString,
-				Description: "Set the name of the field manager for the specified labels.",
-				Optional:    true,
-				Default:     defaultFieldManagerName,
+				Type:         schema.TypeString,
+				Description:  "Set the name of the field manager for the specified labels.",
+				Optional:     true,
+				Default:      defaultFieldManagerName,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 		},
 	}

--- a/kubernetes/resource_kubernetes_annotations_test.go
+++ b/kubernetes/resource_kubernetes_annotations_test.go
@@ -32,6 +32,7 @@ func TestAccKubernetesAnnotations_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -43,6 +44,7 @@ func TestAccKubernetesAnnotations_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "annotations.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
 					resource.TestCheckResourceAttr(resourceName, "annotations.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -54,6 +56,7 @@ func TestAccKubernetesAnnotations_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "annotations.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
 					resource.TestCheckResourceAttr(resourceName, "annotations.test3", "three"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -63,6 +66,7 @@ func TestAccKubernetesAnnotations_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 		},
@@ -77,6 +81,7 @@ func testAccKubernetesAnnotations_empty(name string) string {
       name = %q
     }
     annotations = {}
+	field_manager = "tftest"
   }
 `, name)
 }
@@ -92,6 +97,7 @@ func testAccKubernetesAnnotations_basic(name string) string {
       "test1" = "one"
       "test2" = "two"
     }
+	field_manager = "tftest"
   }
 `, name)
 }
@@ -107,6 +113,7 @@ func testAccKubernetesAnnotations_modified(name string) string {
       "test1" = "one"
       "test3" = "three"
     }
+	field_manager = "tftest"
   }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -53,6 +53,12 @@ func resourceKubernetesConfigMapV1Data() *schema.Resource {
 				Description: "Force overwriting data that is managed outside of Terraform.",
 				Optional:    true,
 			},
+			"field_manager": {
+				Type:        schema.TypeString,
+				Description: "Set the name of the field manager for the specified labels.",
+				Optional:    true,
+				Default:     defaultFieldManagerName,
+			},
 		},
 	}
 }
@@ -179,7 +185,7 @@ func resourceKubernetesConfigMapV1DataUpdate(ctx context.Context, d *schema.Reso
 		types.ApplyPatchType,
 		patchbytes,
 		v1.PatchOptions{
-			FieldManager: defaultFieldManagerName,
+			FieldManager: d.Get("field_manager").(string),
 			Force:        ptrToBool(d.Get("force").(bool)),
 		},
 	)

--- a/kubernetes/resource_kubernetes_config_map_v1_data_test.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data_test.go
@@ -30,6 +30,7 @@ func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "data.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -39,6 +40,7 @@ func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "data.test1", "one"),
 					resource.TestCheckResourceAttr(resourceName, "data.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -48,6 +50,7 @@ func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "data.test1", "one"),
 					resource.TestCheckResourceAttr(resourceName, "data.test3", "three"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -55,6 +58,7 @@ func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "data.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 		},
@@ -67,6 +71,7 @@ func testAccKubernetesConfigMapV1Data_empty(name string) string {
       name = %q
     }
     data = {}
+	field_manager = "tftest"
   }
 `, name)
 }
@@ -80,6 +85,7 @@ func testAccKubernetesConfigMapV1Data_basic(name string) string {
       "test1" = "one"
       "test2" = "two"
     }
+	field_manager = "tftest"
   }
 `, name)
 }
@@ -93,6 +99,7 @@ func testAccKubernetesConfigMapV1Data_modified(name string) string {
       "test1" = "one"
       "test3" = "three"
     }
+	field_manager = "tftest"
   }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_labels.go
+++ b/kubernetes/resource_kubernetes_labels.go
@@ -69,6 +69,12 @@ func resourceKubernetesLabels() *schema.Resource {
 				Description: "Force overwriting labels that were created or edited outside of Terraform.",
 				Optional:    true,
 			},
+			"field_manager": {
+				Type:        schema.TypeString,
+				Description: "Set the name of the field manager for the specified labels.",
+				Optional:    true,
+				Default:     defaultFieldManagerName,
+			},
 		},
 	}
 }
@@ -261,7 +267,7 @@ func resourceKubernetesLabelsUpdate(ctx context.Context, d *schema.ResourceData,
 		types.ApplyPatchType,
 		patchbytes,
 		v1.PatchOptions{
-			FieldManager: defaultFieldManagerName,
+			FieldManager: d.Get("field_manager").(string),
 			Force:        ptrToBool(d.Get("force").(bool)),
 		},
 	)

--- a/kubernetes/resource_kubernetes_labels.go
+++ b/kubernetes/resource_kubernetes_labels.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-kubernetes/util"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -70,10 +71,11 @@ func resourceKubernetesLabels() *schema.Resource {
 				Optional:    true,
 			},
 			"field_manager": {
-				Type:        schema.TypeString,
-				Description: "Set the name of the field manager for the specified labels.",
-				Optional:    true,
-				Default:     defaultFieldManagerName,
+				Type:         schema.TypeString,
+				Description:  "Set the name of the field manager for the specified labels.",
+				Optional:     true,
+				Default:      defaultFieldManagerName,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 		},
 	}

--- a/kubernetes/resource_kubernetes_labels_test.go
+++ b/kubernetes/resource_kubernetes_labels_test.go
@@ -35,6 +35,7 @@ func TestAccKubernetesLabels_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -46,6 +47,7 @@ func TestAccKubernetesLabels_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test1", "one"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -57,6 +59,7 @@ func TestAccKubernetesLabels_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test1", "one"),
 					resource.TestCheckResourceAttr(resourceName, "labels.test3", "three"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 			{
@@ -66,6 +69,7 @@ func TestAccKubernetesLabels_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
 			},
 		},
@@ -103,6 +107,7 @@ func testAccKubernetesLabels_empty(name string) string {
       name = %q
     }
     labels = {}
+	field_manager = "tftest"
   }
 `, name)
 }
@@ -118,6 +123,7 @@ func testAccKubernetesLabels_basic(name string) string {
       "test1" = "one"
       "test2" = "two"
     }
+	field_manager = "tftest"
   }
 `, name)
 }
@@ -133,6 +139,7 @@ func testAccKubernetesLabels_modified(name string) string {
       "test1" = "one"
       "test3" = "three"
     }
+	field_manager = "tftest"
   }
 `, name)
 }

--- a/website/docs/r/annotations.html.markdown
+++ b/website/docs/r/annotations.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard metadata of the resource to be annotated. 
 * `annotations` - (Required) A map of annotations to apply to the resource.
 * `force` - (Optional) Force management of annotations if there is a conflict.
+* `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.
 
 ## Nested Blocks
 

--- a/website/docs/r/config_map_v1_data.html.markdown
+++ b/website/docs/r/config_map_v1_data.html.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard metadata of the ConfigMap. 
 * `data` - (Required) A map of data to apply to the ConfigMap.
 * `force` - (Optional) Force management of the configured data if there is a conflict.
+* `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.
 
 ## Nested Blocks
 

--- a/website/docs/r/labels.html.markdown
+++ b/website/docs/r/labels.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard metadata of the resource to be labelled. 
 * `labels` - (Required) A map of labels to apply to the resource.
 * `force` - (Optional) Force management of labels if there is a conflict.
+* `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

Adds a "field_manager" attribute to the kubernetes_labels, kubernetes_annotations, and kubernetes_config_map_v1_data resources to allow configuring of the field manager name from the currently hard coded default of `Terraform`. 

This will allow users to specify the manager name if they wish to have multiple Terraform resources that manage different fields of the same Kubernetes resource. 

Fixes #1690 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test "/Users/john/dev/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count=1 -run 'TestAccKubernetes(Labels|Annotations|ConfigMapV1Data)' -timeout 3h
=== RUN   TestAccKubernetesAnnotations_basic
--- PASS: TestAccKubernetesAnnotations_basic (29.02s)
=== RUN   TestAccKubernetesConfigMapV1Data_basic
--- PASS: TestAccKubernetesConfigMapV1Data_basic (27.20s)
=== RUN   TestAccKubernetesLabels_basic
--- PASS: TestAccKubernetesLabels_basic (27.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	84.350s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add field_manager attribute
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
