### PR TITLE
[TK-1443] Add `wait_for_service_account_token` option for the resource `kubernetes_secret(_v1)`

### DIFF
--- a/.changelog/1833.txt
+++ b/.changelog/1833.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/kubernetes_secret: Add a new attribute `wait_for_service_account_token` and corresponding `create` timeout
+resource/kubernetes_secret_v1: Add a new attribute `wait_for_service_account_token` and corresponding `create` timeout
+```

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -135,7 +135,7 @@ func resourceKubernetesSecretCreate(ctx context.Context, d *schema.ResourceData,
 	d.SetId(buildId(out.ObjectMeta))
 
 	if out.Type == corev1.SecretTypeServiceAccountToken && d.Get("wait_for_service_account_token").(bool) {
-		log.Printf("[DEBUG] Waiting for service token account creation")
+		log.Printf("[DEBUG] Waiting for secret service account token to be created")
 
 		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			secret, err := conn.CoreV1().Secrets(out.Namespace).Get(ctx, out.Name, metav1.GetOptions{})
@@ -146,12 +146,12 @@ func resourceKubernetesSecretCreate(ctx context.Context, d *schema.ResourceData,
 
 			log.Printf("[INFO] Received secret: %#v", secret.Name)
 			if _, ok := secret.Data["token"]; ok {
-				log.Println("[INFO] Secret service token account created")
+				log.Println("[INFO] Secret service account token created")
 				return nil
 			}
 
 			return resource.RetryableError(fmt.Errorf(
-				"Waiting for secret %q to create a service token account", d.Id()))
+				"Waiting for secret %q to create service account token", d.Id()))
 		})
 		if err != nil {
 			lastWarnings, wErr := getLastWarningsForObject(ctx, conn, out.ObjectMeta, "Secret", 3)

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -2,12 +2,15 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	api "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgApi "k8s.io/apimachinery/pkg/types"
@@ -69,10 +72,19 @@ func resourceKubernetesSecret() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Description: "Type of secret",
-				Default:     string(api.SecretTypeOpaque),
+				Default:     string(corev1.SecretTypeOpaque),
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"wait_for_service_account_token": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Terraform will wait for the service account token to be created.",
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
 		},
 	}
 }
@@ -84,7 +96,7 @@ func resourceKubernetesSecretCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	secret := api.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metadata,
 	}
 
@@ -106,7 +118,7 @@ func resourceKubernetesSecretCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if v, ok := d.GetOk("type"); ok {
-		secret.Type = api.SecretType(v.(string))
+		secret.Type = corev1.SecretType(v.(string))
 	}
 
 	if v, ok := d.GetOkExists("immutable"); ok {
@@ -121,6 +133,34 @@ func resourceKubernetesSecretCreate(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[INFO] Submitting new secret: %#v", out)
 	d.SetId(buildId(out.ObjectMeta))
+
+	if out.Type == corev1.SecretTypeServiceAccountToken && d.Get("wait_for_service_account_token").(bool) {
+		log.Printf("[DEBUG] Waiting for service token account creation")
+
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			secret, err := conn.CoreV1().Secrets(out.Namespace).Get(ctx, out.Name, metav1.GetOptions{})
+			if err != nil {
+				log.Printf("[DEBUG] Received error: %#v", err)
+				return resource.NonRetryableError(err)
+			}
+
+			log.Printf("[INFO] Received secret: %#v", secret.Name)
+			if _, ok := secret.Data["token"]; ok {
+				log.Println("[INFO] Secret service token account created")
+				return nil
+			}
+
+			return resource.RetryableError(fmt.Errorf(
+				"Waiting for secret %q to create a service token account", d.Id()))
+		})
+		if err != nil {
+			lastWarnings, wErr := getLastWarningsForObject(ctx, conn, out.ObjectMeta, "Secret", 3)
+			if wErr != nil {
+				return diag.FromErr(wErr)
+			}
+			return diag.Errorf("%s%s", err, stringifyEvents(lastWarnings))
+		}
+	}
 
 	return resourceKubernetesSecretRead(ctx, d, meta)
 }

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -49,7 +49,7 @@ func TestAccKubernetesSecret_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_service_account_token"},
 			},
 			{
 				Config: testAccKubernetesSecretConfig_basic(name),
@@ -157,7 +157,7 @@ func TestAccKubernetesSecret_immutable(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_service_account_token"},
 			},
 			// changing the data for the immutable secret will force recreate
 			{
@@ -213,7 +213,7 @@ func TestAccKuberNetesSecret_dotInName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_service_account_token"},
 			},
 		},
 	})
@@ -247,7 +247,7 @@ func TestAccKubernetesSecret_generatedName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "wait_for_service_account_token"},
 			},
 		},
 	})

--- a/manifest/payload/to_value.go
+++ b/manifest/payload/to_value.go
@@ -12,13 +12,13 @@ import (
 // ToTFValue converts a Kubernetes dynamic client unstructured value
 // into a Terraform specific tftypes.Value type object
 // Arguments:
-//  * in : the actual raw unstructured value to be converted
-//  * st : the expected type of the converted value
-//  * th : type hints (optional, describes ambigous encodings such as
-//         IntOrString values in more detail).
-//         Pass in empty map when not using hints.
-//  * at : attribute path which recursively tracks the conversion.
-//         Pass in empty tftypes.AttributePath{}
+//   - in : the actual raw unstructured value to be converted
+//   - st : the expected type of the converted value
+//   - th : type hints (optional, describes ambigous encodings such as
+//     IntOrString values in more detail).
+//     Pass in empty map when not using hints.
+//   - at : attribute path which recursively tracks the conversion.
+//     Pass in empty tftypes.AttributePath{}
 func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftypes.AttributePath) (tftypes.Value, error) {
 	if st == nil {
 		return tftypes.Value{}, at.NewErrorf("[%s] type cannot be nil", at.String())

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -105,6 +105,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
 * `immutable` - (Optional) Ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time.
+* `wait_for_service_account_token` - (Optional) Terraform will wait for the service account token to be created. Defaults to `true`.
 
 ## Nested Blocks
 
@@ -129,6 +130,12 @@ The following arguments are supported:
 * `generation` - A sequence number representing a specific generation of the desired state.
 * `resource_version` - An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
 * `uid` - The unique in time and space value for this secret. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+### Timeouts
+
+`kubernetes_secret` provides the following configuration options:
+
+- `create` - Default `1 minute`
 
 ## Import
 

--- a/website/docs/r/secret_v1.html.markdown
+++ b/website/docs/r/secret_v1.html.markdown
@@ -133,7 +133,7 @@ The following arguments are supported:
 
 ### Timeouts
 
-`kubernetes_secret` provides the following configuration options:
+`kubernetes_secret_v1` provides the following configuration options:
 
 - `create` - Default `1 minute`
 

--- a/website/docs/r/secret_v1.html.markdown
+++ b/website/docs/r/secret_v1.html.markdown
@@ -105,6 +105,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `type` - (Optional) The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)
 * `immutable` - (Optional) Ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time.
+* `wait_for_service_account_token` - (Optional) Terraform will wait for the service account token to be created. Defaults to `true`.
 
 ## Nested Blocks
 
@@ -129,6 +130,12 @@ The following arguments are supported:
 * `generation` - A sequence number representing a specific generation of the desired state.
 * `resource_version` - An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
 * `uid` - The unique in time and space value for this secret. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+### Timeouts
+
+`kubernetes_secret` provides the following configuration options:
+
+- `create` - Default `1 minute`
 
 ## Import
 


### PR DESCRIPTION
### Description

This PR adds two new attributes for the resource `kubernetes_secret(_v1)`:
 - `wait_for_service_account_token` -- the provider will wait for the creation of the service account token, default is `true`.
 - `create`(timeout) -- the provider will wait for the creation of the secret with the type `kubernetes.io/service-account-token`, default is `1m`.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS="-count 1 -run ^TestAccKubernetesSecret_*"
...
=== RUN   TestAccKubernetesSecret_basic
--- PASS: TestAccKubernetesSecret_basic (9.07s)
=== RUN   TestAccKubernetesSecret_immutable
--- PASS: TestAccKubernetesSecret_immutable (7.40s)
=== RUN   TestAccKubernetesSecret_generatedName
--- PASS: TestAccKubernetesSecret_generatedName (2.37s)
=== RUN   TestAccKubernetesSecret_binaryData
--- PASS: TestAccKubernetesSecret_binaryData (5.42s)
=== RUN   TestAccKubernetesSecret_service_account_token
--- PASS: TestAccKubernetesSecret_service_account_token (2.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	27.843s
```

### References
[1830](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1830)

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
