### PR TITLE
Fix typo on an example (#1843)

### DIFF
--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -172,7 +172,7 @@ resource "kubernetes_ingress_v1" "example" {
           path = "/*"
           backend {
             service {
-              name = kubernetes_service.example.metadata.0.name
+              name = kubernetes_service_v1.example.metadata.0.name
               port {
                 number = 80
               }


### PR DESCRIPTION
### Description

As mentioned in #1843. The example is mentioning a resource not being used (kubernetes_service) when the correct is kubernetes_service_v1.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

release-note
```
Fix typo in Nginx ingress controller example of `kubernetes_ingress_v1` (#1843)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
[Link to the example on terraform.io](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1#example-using-nginx-ingress-controller)

Issue reported in #1843 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
