### PR TITLE
Preemption_policy attribute

### DIFF
--- a/.changelog/1846.txt
+++ b/.changelog/1846.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added "preemption_policy" attribute to the priority_class resource. 
+```

--- a/kubernetes/resource_kubernetes_priority_class_test.go
+++ b/kubernetes/resource_kubernetes_priority_class_test.go
@@ -38,6 +38,7 @@ func TestAccKubernetesPriorityClass_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_priority_class.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_priority_class.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "value", "100"),
+					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "preemption_policy", "Never"),
 				),
 			},
 			{
@@ -62,6 +63,7 @@ func TestAccKubernetesPriorityClass_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_priority_class.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_priority_class.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "value", "100"),
+					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "preemption_policy", "Never"),
 				),
 			},
 			{
@@ -77,6 +79,7 @@ func TestAccKubernetesPriorityClass_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "value", "100"),
 					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "description", "Foobar"),
 					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "global_default", "true"),
+					resource.TestCheckResourceAttr("kubernetes_priority_class.test", "preemption_policy", "Never"),
 				),
 			},
 		},
@@ -178,6 +181,7 @@ func testAccKubernetesPriorityClassConfig_basic(name string) string {
   }
 
   value = 100
+  preemption_policy = "Never"
 }
 `, name)
 }
@@ -200,6 +204,7 @@ func testAccKubernetesPriorityClassConfig_metaModified(name string) string {
   }
 
   value = 100
+  preemption_policy = "Never"
 }
 `, name)
 }
@@ -213,6 +218,7 @@ func testAccKubernetesPriorityClassConfig_modified(name string) string {
   value          = 100
   description    = "Foobar"
   global_default = true
+  preemption_policy = "Never"
 }
 `, name)
 }

--- a/website/docs/r/priority_class.html.markdown
+++ b/website/docs/r/priority_class.html.markdown
@@ -30,6 +30,8 @@ The following arguments are supported:
 * `value` - (Required, Forces new resource) The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
 * `description` - (Optional) An arbitrary string that usually provides guidelines on when this priority class should be used.
 * `global_default` - (Optional) Boolean that specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class.
+* `preemption_policy` - PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+
 
 ## Nested Blocks
 

--- a/website/docs/r/priority_class_v1.html.markdown
+++ b/website/docs/r/priority_class_v1.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `generation` - A sequence number representing a specific generation of the desired state.
 * `resource_version` - An opaque value that represents the internal version of this resource quota that can be used by clients to determine when resource quota has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
 * `uid` - The unique in time and space value for this resource quota. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
-* `preemption_policy - PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+* `preemption_policy` - PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
 
 ## Import
 

--- a/website/docs/r/priority_class_v1.html.markdown
+++ b/website/docs/r/priority_class_v1.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 * `generation` - A sequence number representing a specific generation of the desired state.
 * `resource_version` - An opaque value that represents the internal version of this resource quota that can be used by clients to determine when resource quota has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
 * `uid` - The unique in time and space value for this resource quota. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+* `preemption_policy - PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
 
 ## Import
 
@@ -60,3 +61,4 @@ Priority Class can be imported using its name, e.g.
 ```
 $ terraform import kubernetes_priority_class_v1.example terraform-example
 ```
+


### PR DESCRIPTION
### Description

This PR adds the `preemption_policy` attribute to `kubernetes_priority_class` resource

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Fixes #1299 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
