### PR TITLE
Revert "add test for immutable attribute"

### DIFF
--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -36,11 +36,6 @@ func resourceKubernetesConfigMap() *schema.Resource {
 				Description: "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.",
 				Optional:    true,
 			},
-			"immutable": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.",
-			},
 		},
 	}
 }
@@ -51,16 +46,11 @@ func resourceKubernetesConfigMapCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	var im *bool
-	if im, ok := d.GetOkExists("immutable"); ok {
-		im = ptrToBool(im.(bool))
-	}
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	cfgMap := api.ConfigMap{
 		ObjectMeta: metadata,
 		BinaryData: expandBase64MapToByteMap(d.Get("binary_data").(map[string]interface{})),
 		Data:       expandStringMap(d.Get("data").(map[string]interface{})),
-		Immutable:  im,
 	}
 	log.Printf("[INFO] Creating new config map: %#v", cfgMap)
 	out, err := conn.CoreV1().ConfigMaps(metadata.Namespace).Create(ctx, &cfgMap, metav1.CreateOptions{})
@@ -105,7 +95,6 @@ func resourceKubernetesConfigMapRead(ctx context.Context, d *schema.ResourceData
 
 	d.Set("binary_data", flattenByteMapToBase64Map(cfgMap.BinaryData))
 	d.Set("data", cfgMap.Data)
-	d.Set("immutable", cfgMap.Immutable)
 
 	return nil
 }
@@ -132,13 +121,6 @@ func resourceKubernetesConfigMapUpdate(ctx context.Context, d *schema.ResourceDa
 		oldV, newV := d.GetChange("data")
 		diffOps := diffStringMap("/data/", oldV.(map[string]interface{}), newV.(map[string]interface{}))
 		ops = append(ops, diffOps...)
-	}
-
-	if d.HasChange("immutable") {
-		ops = append(ops, &ReplaceOperation{
-			Path:  "/immutable",
-			Value: ptrToBool(d.Get("immutable").(bool)),
-		})
 	}
 
 	data, err := ops.MarshalJSON()

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -41,7 +41,6 @@ func TestAccKubernetesConfigMap_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttr(resourceName, "data.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "immutable", "false"),
 				),
 			},
 			{
@@ -171,57 +170,6 @@ func TestAccKubernetesConfigMap_generatedName(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccKubernetesConfigMap_immutable(t *testing.T) {
-	var conf api.ConfigMap
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	resourceName := "kubernetes_config_map.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     resourceName,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckKubernetesConfigMapDestroy,
-		Steps: []resource.TestStep{
-			// create config_map with immutable set to true
-			{
-				Config: testAccKubernetesConfigMapConfig_immutable(name, true, "second"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesConfigMapExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data.one", "first"),
-					resource.TestCheckResourceAttr(resourceName, "data.two", "second"),
-					resource.TestCheckResourceAttr(resourceName, "immutable", "true"),
-				),
-			},
-			// change the immutable variable to false
-			{
-				Config: testAccKubernetesConfigMapConfig_immutable(name, false, "second"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesConfigMapExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "immutable", "false"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data.one", "first"),
-					resource.TestCheckResourceAttr(resourceName, "data.two", "second"),
-				),
-			},
-			// update data while immutable is false
-			{
-				Config: testAccKubernetesConfigMapConfig_immutable(name, false, "third"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesConfigMapExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "immutable", "false"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data.one", "first"),
-					resource.TestCheckResourceAttr(resourceName, "data.two", "third"),
-				),
 			},
 		},
 	})
@@ -440,31 +388,4 @@ func testAccKubernetesConfigMapConfig_binaryData2(prefix string) string {
   }
 }
 `, prefix)
-}
-
-func testAccKubernetesConfigMapConfig_immutable(name string, immutable bool, data string) string {
-	return fmt.Sprintf(`resource "kubernetes_config_map" "test" {
-  metadata {
-    annotations = {
-      TestAnnotationOne = "one"
-      TestAnnotationTwo = "two"
-    }
-
-    labels = {
-      TestLabelOne   = "one"
-      TestLabelTwo   = "two"
-      TestLabelThree = "three"
-    }
-
-    name = "%s"
-  }
-
-  immutable = %t
-
-  data = {
-    one = "first"
-    two = "%s"
-  }
-}
-`, name, immutable, data)
 }


### PR DESCRIPTION
This reverts commit 8de6c0ae7990879684939622ef766dbb11e5a053.

Revert "add immutable attribute to config_map resource"

This reverts commit 266e9b8c2399777987537313e714d533ee26c434.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
