### PR TITLE
Enable AWS test infra to scale across variable number of AZ

### DIFF
--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -1,16 +1,19 @@
 name: Acceptance Tests (EKS)
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
     inputs:
-      region: 
-        description: The AWS region 
+      region:
+        description: The AWS region
         default: us-east-1
+      azSpan:
+        description: The number of AZs to spread cluster nodes across
+        default: 2
       clusterVersion:
         description: The EKS cluster version
         default: 1.23
-      nodeCount:
-        description: The number of cluster nodes to provision 
+      nodesPerAz:
+        description: The number of cluster nodes in each AZ
         default: 2
       instanceType:
         description: The type of EC2 instance to use for cluster nodes
@@ -19,13 +22,14 @@ on:
         description: The regex passed to the -run option of `go test`
         default: ".*"
       terraformVersion:
-        description: Terraform version 
+        description: Terraform version
         default: 1.3.1
 
 env:
-  TF_VAR_region: ${{ github.event.inputs.region }}
+  AWS_REGION: ${{ github.event.inputs.region }}
+  TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion }}
-  TF_VAR_node_count: ${{ github.event.inputs.nodeCount }}
+  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType }}
 
 jobs:
@@ -65,7 +69,7 @@ jobs:
           TF_ACC_TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion }}
           TESTARGS: -run '${{ github.event.inputs.runTests }}'
           KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/eks/kubeconfig
-        run: | 
+        run: |
           make testacc
       - name: Destroy EKS cluster
         if: always() # we should destroy the cluster even if the tests fail

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -6,8 +6,12 @@ resource "random_string" "rand" {
 
 locals {
   cluster_name    = "test-cluster-${random_string.rand.result}"
-  cluster_version = var.cluster_version
-  region          = var.region
+  cidr            = "10.0.0.0/16"
+  az_count        = min(var.az_span, length(data.aws_availability_zones.available.names))
+  azs             = slice(data.aws_availability_zones.available.names, 0, local.az_count)
+  private_subnets = [for i, z in local.azs : cidrsubnet(local.cidr, 8, i)]
+  public_subnets  = [for i, z in local.azs : cidrsubnet(local.cidr, 8, i + local.az_count)]
+  node_count      = var.nodes_per_az * local.az_count
 
   tags = {
     team        = "terraform-kubernetes-providers"
@@ -15,16 +19,16 @@ locals {
   }
 }
 
-provider "aws" {
-  region = local.region
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "~> 18.11"
 
   cluster_name                    = local.cluster_name
-  cluster_version                 = local.cluster_version
+  cluster_version                 = var.cluster_version
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 
@@ -34,8 +38,8 @@ module "eks" {
   eks_managed_node_group_defaults = {
     instance_types = [var.instance_type]
     min_size       = 1
-    max_size       = var.node_count
-    desired_size   = var.node_count
+    max_size       = local.node_count
+    desired_size   = local.node_count
   }
 
   eks_managed_node_groups = {
@@ -53,13 +57,13 @@ module "vpc" {
   version = "~> 3.0"
 
   name = local.cluster_name
-  cidr = "10.0.0.0/16"
+  cidr = local.cidr
 
-  azs             = ["${local.region}a", "${local.region}b"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
-  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24"]
+  azs             = local.azs
+  private_subnets = local.private_subnets
+  public_subnets  = local.public_subnets
 
-  create_egress_only_igw  = true
+  create_egress_only_igw = true
 
   enable_nat_gateway   = true
   single_nat_gateway   = true
@@ -77,10 +81,6 @@ module "vpc" {
   }
 
   tags = local.tags
-}
-
-data "aws_eks_cluster_auth" "this" {
-  name = module.eks.cluster_id
 }
 
 locals {
@@ -105,12 +105,9 @@ locals {
     users = [{
       name = "terraform"
       user = {
-        token = data.aws_eks_cluster_auth.this.token
-      }
-      user = {
         exec = {
           apiVersion = "client.authentication.k8s.io/v1alpha1"
-          command = "aws"
+          command    = "aws"
           args = [
             "eks", "get-token", "--cluster-name", local.cluster_name
           ]
@@ -121,6 +118,6 @@ locals {
 }
 
 resource "local_file" "kubeconfig" {
-  content = local.kubeconfig
+  content  = local.kubeconfig
   filename = "${path.module}/kubeconfig"
 }

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -106,7 +106,7 @@ locals {
       name = "terraform"
       user = {
         exec = {
-          apiVersion = "client.authentication.k8s.io/v1alpha1"
+          apiVersion = "client.authentication.k8s.io/v1beta1"
           command    = "aws"
           args = [
             "eks", "get-token", "--cluster-name", local.cluster_name

--- a/kubernetes/test-infra/eks/variables.tf
+++ b/kubernetes/test-infra/eks/variables.tf
@@ -1,15 +1,21 @@
 variable "cluster_version" {
-  default = "1.21"
+  default = "1.23"
 }
 
-variable "region" {
-  default = "us-east-1"
-}
-
-variable "node_count" {
-  default = 2
+variable "nodes_per_az" {
+  default = 1
+  type    = number
 }
 
 variable "instance_type" {
   default = "m5.large"
+}
+
+variable "az_span" {
+  type    = number
+  default = 3
+  validation {
+    condition     = var.az_span > 1
+    error_message = "Cluster must span at least 2 AZs"
+  }
 }


### PR DESCRIPTION
### Description

Not all AWS regions offer the same number of availability zones. Some regions don't even guarantee a continuous sequence of suffixes (starting from "a") for AZs. The current AWS infra setup is hardcoded to two AZs and cannot easily accommodate broader AZ spans.

This change makes the configuration elastic, allowing it to scale to the requested number of AZs.

Instead of requesting a total number of nodes, the inputs now require a number of AZs to span and number of nodes per AZ. The resulting cluster will accommodate as many nodes as possible from this request, or fewer if not enough AZs are available in the region.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
