### PR TITLE
Add support for CronJob to kubernetes_env resource

### DIFF
--- a/.changelog/1869.txt
+++ b/.changelog/1869.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add Support for CronJobs in resource_kubernetes_env
+```

--- a/kubernetes/resource_kubernetes_annotations.go
+++ b/kubernetes/resource_kubernetes_annotations.go
@@ -146,7 +146,8 @@ func resourceKubernetesAnnotationsRead(ctx context.Context, d *schema.ResourceDa
 	configuredAnnotations := d.Get("annotations").(map[string]interface{})
 
 	// strip out the annotations not managed by Terraform
-	managedAnnotations, err := getManagedAnnotations(res.GetManagedFields(), defaultFieldManagerName)
+	fieldManagerName := d.Get("field_manager").(string)
+	managedAnnotations, err := getManagedAnnotations(res.GetManagedFields(), fieldManagerName)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -100,7 +100,8 @@ func resourceKubernetesConfigMapV1DataRead(ctx context.Context, d *schema.Resour
 	configuredData := d.Get("data").(map[string]interface{})
 
 	// strip out the data not managed by Terraform
-	managedConfigMapData, err := getManagedConfigMapData(res.GetManagedFields(), defaultFieldManagerName)
+	fieldManagerName := d.Get("field_manager").(string)
+	managedConfigMapData, err := getManagedConfigMapData(res.GetManagedFields(), fieldManagerName)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -336,12 +336,18 @@ func getManagedEnvs(managedFields []v1.ManagedFieldsEntry, manager string, d *sc
 			return nil, err
 		}
 
-		spec, _, err := unstructured.NestedMap(u.Object, "spec", "template", "spec")
-		containers := spec["containers"].([]interface{})
+		spec, _, err := unstructured.NestedMap(u.Object, "f:spec", "f:template", "f:spec")
+		var containers []interface{}
 		if "CronJob" == kind {
-			spec, _, _ = unstructured.NestedMap(u.Object, "f:spec", "f:jobTemplate", "f:spec", "f:template", "f:spec")
-			containers = spec["f:containers"].([]interface{})
+			spec, _, err = unstructured.NestedMap(u.Object, "f:spec", "f:jobTemplate", "f:spec", "f:template", "f:spec")
 		}
+
+		if err == nil {
+			return nil, err
+			//panic(fmt.Sprintf("There is no spec here"))
+		}
+
+		containers = spec["f:containers"].([]interface{})
 		containerName := fmt.Sprintf(`k:{"name":%q}`, d.Get("container").(string))
 
 		for _, c := range containers {

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -59,13 +59,13 @@ func resourceKubernetesEnv() *schema.Resource {
 			},
 			"api_version": {
 				Type:        schema.TypeString,
-				Description: "API Version of Field Manager",
+				Description: "Resource API version",
 				Required:    true,
 			},
 			"kind": {
 				Type:         schema.TypeString,
-				Description:  "Type of resource being used",
-				ValidateFunc: validation.StringInSlice([]string{"cronjob", "deployment", "pod", "daemonset", "replicationcontroller", "statefulset", "replicaset"}, true),
+				Description:  "Resource Kind",
+				ValidateFunc: validation.StringInSlice([]string{"CronJob", "Deployment", "Pod", "DaemonSet", "replicationcontroller", "StatefulSet", "ReplicaSet"}, true),
 				Required:     true,
 			},
 			"env": {

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAccKubernetesEnv_Deploymentbasic(t *testing.T) {
+func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	namespace := "default"
 	secretName := acctest.RandomWithPrefix("tf-acc-test")

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAccKubernetesEnv_basic(t *testing.T) {
+func TestAccKubernetesEnv_Deploymentbasic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	namespace := "default"
 	secretName := acctest.RandomWithPrefix("tf-acc-test")
@@ -37,7 +37,7 @@ func TestAccKubernetesEnv_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesEnv_basic(secretName, configMapName, name, namespace),
+				Config: testAccKubernetesEnv_Deploymentbasic(secretName, configMapName, name, namespace),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
 					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
@@ -294,7 +294,7 @@ func confirmExistingCronJobEnvs(name, namespace string) error {
 	return err
 }
 
-func testAccKubernetesEnv_basic(secretName, configMapName, name, namespace string) string {
+func testAccKubernetesEnv_Deploymentbasic(secretName, configMapName, name, namespace string) string {
 	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
   metadata {
     name = "%s"

--- a/kubernetes/resource_kubernetes_labels.go
+++ b/kubernetes/resource_kubernetes_labels.go
@@ -146,7 +146,8 @@ func resourceKubernetesLabelsRead(ctx context.Context, d *schema.ResourceData, m
 	configuredLabels := d.Get("labels").(map[string]interface{})
 
 	// strip out the labels not managed by Terraform
-	managedLabels, err := getManagedLabels(res.GetManagedFields(), defaultFieldManagerName)
+	fieldManagerName := d.Get("field_manager").(string)
+	managedLabels, err := getManagedLabels(res.GetManagedFields(), fieldManagerName)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Adds support for adding Environment Variables to CronJobs. Part of `resource_kubernetes_env`

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run TestAccKubernetesEnv_CronJobBasic"
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/mau/Dev/terraform-provider-kubernetes/kubernetes" -v -run TestAccKubernetesEnv_CronJobBasic -timeout 3h
=== RUN   TestAccKubernetesEnv_CronJobBasic
--- PASS: TestAccKubernetesEnv_CronJobBasic (9.73s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   10.301s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add Support for CronJobs in resource_kubernetes_env
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
