### PR TITLE
[TK-1960] Update `container.resources` documentation for Pod, DaemonSet and Deployment kinds

### DIFF
--- a/website/docs/d/pod.html.markdown
+++ b/website/docs/d/pod.html.markdown
@@ -298,10 +298,21 @@ The `option` block supports the following:
 
 ### `resources`
 
-#### Attributes
+#### Arguments
 
-* `limits` -  Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
-* `requests` -  Describes the minimum amount of compute resources required.
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `requests` - (Optional) Describes the minimum amount of compute resources required.
+
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
 
 ### `requests`
 

--- a/website/docs/d/pod_v1.html.markdown
+++ b/website/docs/d/pod_v1.html.markdown
@@ -298,10 +298,21 @@ The `option` block supports the following:
 
 ### `resources`
 
-#### Attributes
+#### Arguments
 
-* `limits` -  Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
-* `requests` -  Describes the minimum amount of compute resources required.
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `requests` - (Optional) Describes the minimum amount of compute resources required.
+
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
 
 ### `requests`
 

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -640,6 +640,17 @@ The `option` block supports the following:
 * `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
+
 ### `resource_field_ref`
 
 #### Arguments

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -650,6 +650,17 @@ The `option` block supports the following:
 * `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
+
 ### `resource_field_ref`
 
 #### Arguments

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -661,6 +661,17 @@ The `option` block supports the following:
 * `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
+
 ### `resource_field_ref`
 
 #### Arguments

--- a/website/docs/r/deployment_v1.html.markdown
+++ b/website/docs/r/deployment_v1.html.markdown
@@ -651,6 +651,17 @@ The `option` block supports the following:
 * `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
+
 ### `resource_field_ref`
 
 #### Arguments

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -710,6 +710,17 @@ The `option` block supports the following:
 * `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
+
 ### `resource_field_ref`
 
 #### Arguments

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -700,6 +700,17 @@ The `option` block supports the following:
 * `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
+`resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.
+
+Please, look at the example below:
+
+```hcl
+resources {
+    limits = {}
+    requests = {}
+}
+```
+
 ### `resource_field_ref`
 
 #### Arguments


### PR DESCRIPTION
### Description

Update Pod related documentation with an explanation over `spec.container.resources`.

### Release Note
```release-note
NONE
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1880

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
