### PR TITLE
[TK-1960] Mark attribute `default_secret_name` as deprecated in the documentation

### DIFF
--- a/.changelog/1883.txt
+++ b/.changelog/1883.txt
@@ -1,0 +1,7 @@
+```release-note:doc
+`resource/kubernetes_service_account`: mark attribute `default_secret_name` as deprecated
+```
+
+```release-note:doc
+`resource/kubernetes_service_account_v1`: mark attribute `default_secret_name` as deprecated
+```

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -53,8 +53,9 @@ The following arguments are supported:
 
 * `image_pull_secret` - A list of image pull secrets associated with the service account.
 * `secret` - A list of secrets associated with the service account.
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
+* `default_secret_name` - (Deprecated) Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
 
+  Starting from version `1.24.0` by default Kubernetes does not automatically generate tokens for service accounts. That leads to the situation when `default_secret_name` cannot be computed and thus will be an empty string. In order to create a service account token, please [use `kubernetes_secret_v1` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1#example-usage-service-account-token)
 ### `image_pull_secret`
 
 #### Attributes

--- a/website/docs/d/service_account_v1.html.markdown
+++ b/website/docs/d/service_account_v1.html.markdown
@@ -53,7 +53,9 @@ The following arguments are supported:
 
 * `image_pull_secret` - A list of image pull secrets associated with the service account.
 * `secret` - A list of secrets associated with the service account.
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
+* `default_secret_name` - (Deprecated) Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+
+  Starting from version `1.24.0` by default Kubernetes does not automatically generate tokens for service accounts. That leads to the situation when `default_secret_name` cannot be computed and thus will be an empty string. In order to create a service account token, please [use `kubernetes_secret_v1` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1#example-usage-service-account-token)
 
 ### `image_pull_secret`
 

--- a/website/docs/r/default_service_account.html.markdown
+++ b/website/docs/r/default_service_account.html.markdown
@@ -76,10 +76,11 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are
-exported:
+In addition to the arguments listed above, the following computed attributes are exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
+* `default_secret_name` - (Deprecated) Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+
+  Starting from version `1.24.0` by default Kubernetes does not automatically generate tokens for service accounts. That leads to the situation when `default_secret_name` cannot be computed and thus will be an empty string. In order to create a service account token, please [use `kubernetes_secret_v1` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1#example-usage-service-account-token)
 
 ## Destroying
 

--- a/website/docs/r/default_service_account_v1.html.markdown
+++ b/website/docs/r/default_service_account_v1.html.markdown
@@ -76,10 +76,11 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are
-exported:
+In addition to the arguments listed above, the following computed attributes are exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
+* `default_secret_name` - (Deprecated) Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+
+  Starting from version `1.24.0` by default Kubernetes does not automatically generate tokens for service accounts. That leads to the situation when `default_secret_name` cannot be computed and thus will be an empty string. In order to create a service account token, please [use `kubernetes_secret_v1` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1#example-usage-service-account-token)
 
 ## Destroying
 

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -78,10 +78,11 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are
-exported:
+In addition to the arguments listed above, the following computed attributes are exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
+* `default_secret_name` - (Deprecated) Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+
+  Starting from version `1.24.0` by default Kubernetes does not automatically generate tokens for service accounts. That leads to the situation when `default_secret_name` cannot be computed and thus will be an empty string. In order to create a service account token, please [use `kubernetes_secret_v1` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1#example-usage-service-account-token)
 
 ## Import
 

--- a/website/docs/r/service_account_v1.html.markdown
+++ b/website/docs/r/service_account_v1.html.markdown
@@ -78,10 +78,11 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are
-exported:
+In addition to the arguments listed above, the following computed attributes are exported:
 
-* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret. Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, `default_secret_name` will be empty.
+* `default_secret_name` - (Deprecated) Name of the default secret, containing service account token, created & managed by the service. By default, the provider will try to find the secret containing the service account token that Kubernetes automatically created for the service account. Where there are multiple tokens and the provider cannot determine which was created by Kubernetes, this attribute will be empty. When only one token is associated with the service account, the provider will return this single token secret.
+
+  Starting from version `1.24.0` by default Kubernetes does not automatically generate tokens for service accounts. That leads to the situation when `default_secret_name` cannot be computed and thus will be an empty string. In order to create a service account token, please [use `kubernetes_secret_v1` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1#example-usage-service-account-token)
 
 ## Import
 


### PR DESCRIPTION
### Description

Mark attribute `default_secret_name` as deprecated in the documentation.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/kubernetes_service_account`: mark attribute `default_secret_name` as deprecated
`resource/kubernetes_service_account_v1`: mark attribute `default_secret_name` as deprecated
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1878

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
