### PR TITLE
Modify delete operation for namespaces

### DIFF
--- a/.changelog/1898.txt
+++ b/.changelog/1898.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Make kubernetes_namespace delete idempotent
+```

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -119,6 +119,9 @@ func resourceKubernetesNamespaceDelete(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[INFO] Deleting namespace: %#v", name)
 	err = conn.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Description

This PR adds a check to the delete function of the kubernetes_namespace resource to make the delete option idempotent. 

Partially Fixes #1822 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
