### PR TITLE
[TK-1994] Fix timeouts for `StatefulSet`, `Deployment`, and `DaemonSet`

### DIFF
--- a/.changelog/1902.txt
+++ b/.changelog/1902.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix an issue with timeouts for `StatefulSet`, `Deployment`, and `DaemonSet` resources when in some cases changes of `Update` or `Create` timeout doesn't affect related actions.
+```

--- a/kubernetes/resource_kubernetes_daemonset.go
+++ b/kubernetes/resource_kubernetes_daemonset.go
@@ -159,7 +159,7 @@ func resourceKubernetesDaemonSetCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if d.Get("wait_for_rollout").(bool) {
-		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate),
 			waitForDaemonSetReplicasFunc(ctx, conn, metadata.Namespace, metadata.Name))
 		if err != nil {
 			return diag.FromErr(err)

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -302,7 +302,7 @@ func resourceKubernetesDeploymentUpdate(ctx context.Context, d *schema.ResourceD
 
 	if d.Get("wait_for_rollout").(bool) {
 		log.Printf("[INFO] Waiting for deployment %s/%s to rollout", out.ObjectMeta.Namespace, out.ObjectMeta.Name)
-		err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate),
+		err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
 			waitForDeploymentReplicasFunc(ctx, conn, out.GetNamespace(), out.GetName()))
 		if err != nil {
 			return diag.FromErr(err)

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -215,7 +215,7 @@ func resourceKubernetesStatefulSetUpdate(ctx context.Context, d *schema.Resource
 
 	if d.Get("wait_for_rollout").(bool) {
 		log.Printf("[INFO] Waiting for StatefulSet %s to rollout", d.Id())
-		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate),
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
 			retryUntilStatefulSetRolloutComplete(ctx, conn, namespace, name))
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
### Description

This PR fixes an issue with timeouts for `StatefulSet`, `Deployment`, and `DaemonSet` resources when in some cases changes of `Update` or `Create` timeout doesn't affect related actions.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Fix an issue with timeouts for `StatefulSet`, `Deployment`, and `DaemonSet` resources when in some cases changes of `Update` or `Create` timeout doesn't affect related actions.
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1896

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
