### PR TITLE
Modify delete operation for resources

### DIFF
--- a/.changelog/1914.txt
+++ b/.changelog/1914.txt
@@ -1,0 +1,33 @@
+```release-note:enhancement
+Add additional validation on the delete operation to make it idempotent. That affects the following resources:
+  - `kubernetes_api_service`
+  - `kubernetes_api_service_v1`
+  - `kubernetes_cluster_role`
+  - `kubernetes_cluster_role_v1`
+  - `kubernetes_cluster_role_binding`
+  - `kubernetes_cluster_role_binding_v1`
+  - `kubernetes_config_map`
+  - `kubernetes_config_map_v1`
+  - `kubernetes_daemonset`
+  - `kubernetes_daemon_set_v1`
+  - `kubernetes_deployment`
+  - `kubernetes_deployment_v1`
+  - `kubernetes_endpoints`
+  - `kubernetes_endpoints_v1`
+  - `kubernetes_horizontal_pod_autoscaler`
+  - `kubernetes_horizontal_pod_autoscaler_v1`
+  - `kubernetes_horizontal_pod_autoscaler_v2beta2`
+  - `kubernetes_horizontal_pod_autoscaler_v2`
+  - `kubernetes_mutating_webhook_configuration`
+  - `kubernetes_mutating_webhook_configuration_v1`
+  - `kubernetes_network_policy`
+  - `kubernetes_network_policy_v1`
+  - `kubernetes_persistent_volume_claim`
+  - `kubernetes_persistent_volume_claim_v1`
+  - `kubernetes_pod`
+  - `kubernetes_pod_v1`
+  - `kubernetes_pod_disruption_budget`
+  - `kubernetes_pod_disruption_budget_v1`
+  - `kubernetes_pod_security_policy`
+  - `kubernetes_pod_security_policy_v1beta1`
+```

--- a/kubernetes/resource_kubernetes_api_service.go
+++ b/kubernetes/resource_kubernetes_api_service.go
@@ -201,6 +201,9 @@ func resourceKubernetesAPIServiceDelete(ctx context.Context, d *schema.ResourceD
 	log.Printf("[INFO] Deleting API service: %#v", name)
 	err = conn.ApiregistrationV1().APIServices().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -169,6 +169,9 @@ func resourceKubernetesClusterRoleDelete(ctx context.Context, d *schema.Resource
 	log.Printf("[INFO] Deleting cluster role: %#v", name)
 	err = conn.RbacV1().ClusterRoles().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_cluster_role_binding.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding.go
@@ -155,6 +155,9 @@ func resourceKubernetesClusterRoleBindingDelete(ctx context.Context, d *schema.R
 	log.Printf("[INFO] Deleting ClusterRoleBinding: %#v", name)
 	err = conn.RbacV1().ClusterRoleBindings().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] ClusterRoleBinding %s deleted", name)

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -190,6 +190,9 @@ func resourceKubernetesConfigMapDelete(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[INFO] Deleting config map: %#v", name)
 	err = conn.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_daemonset.go
+++ b/kubernetes/resource_kubernetes_daemonset.go
@@ -284,6 +284,9 @@ func resourceKubernetesDaemonSetDelete(ctx context.Context, d *schema.ResourceDa
 
 	err = conn.AppsV1().DaemonSets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -372,6 +372,9 @@ func resourceKubernetesDeploymentDelete(ctx context.Context, d *schema.ResourceD
 
 	err = conn.AppsV1().Deployments(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_endpoints.go
+++ b/kubernetes/resource_kubernetes_endpoints.go
@@ -146,6 +146,9 @@ func resourceKubernetesEndpointsDelete(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[INFO] Deleting endpoints: %#v", name)
 	err = conn.CoreV1().Endpoints(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.Errorf("Failed to delete endpoints because: %s", err)
 	}
 	log.Printf("[INFO] Endpoints %s deleted", name)

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -160,6 +160,9 @@ func resourceKubernetesHorizontalPodAutoscalerDelete(ctx context.Context, d *sch
 	log.Printf("[INFO] Deleting horizontal pod autoscaler: %#v", name)
 	err = conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v1.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v1.go
@@ -194,6 +194,9 @@ func resourceKubernetesHorizontalPodAutoscalerV1Delete(ctx context.Context, d *s
 	log.Printf("[INFO] Deleting horizontal pod autoscaler: %#v", name)
 	err = conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2.go
@@ -139,6 +139,9 @@ func resourceKubernetesHorizontalPodAutoscalerV2Delete(ctx context.Context, d *s
 	log.Printf("[INFO] Deleting horizontal pod autoscaler: %#v", name)
 	err = conn.AutoscalingV2().HorizontalPodAutoscalers(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2.go
@@ -139,6 +139,9 @@ func resourceKubernetesHorizontalPodAutoscalerV2Beta2Delete(ctx context.Context,
 	log.Printf("[INFO] Deleting horizontal pod autoscaler: %#v", name)
 	err = conn.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
@@ -291,6 +291,9 @@ func resourceKubernetesMutatingWebhookConfigurationUpdate(ctx context.Context, d
 func resourceKubernetesMutatingWebhookConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
@@ -243,6 +243,9 @@ func resourceKubernetesMutatingWebhookConfigurationV1Delete(ctx context.Context,
 	log.Printf("[INFO] Deleting MutatingWebhookConfiguration: %#v", name)
 	err = conn.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_network_policy.go
+++ b/kubernetes/resource_kubernetes_network_policy.go
@@ -340,6 +340,9 @@ func resourceKubernetesNetworkPolicyUpdate(ctx context.Context, d *schema.Resour
 func resourceKubernetesNetworkPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -233,6 +233,9 @@ func resourceKubernetesPersistentVolumeClaimUpdate(ctx context.Context, d *schem
 func resourceKubernetesPersistentVolumeClaimDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -207,6 +207,9 @@ func resourceKubernetesPodDelete(ctx context.Context, d *schema.ResourceData, me
 	log.Printf("[INFO] Deleting pod: %#v", name)
 	err = conn.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget.go
@@ -186,6 +186,9 @@ func resourceKubernetesPodDisruptionBudgetDelete(ctx context.Context, d *schema.
 	log.Printf("[INFO] Deleting pod disruption budget %#v", name)
 	err = conn.PolicyV1beta1().PodDisruptionBudgets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_pod_disruption_budget_v1.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget_v1.go
@@ -186,6 +186,9 @@ func resourceKubernetesPodDisruptionBudgetV1Delete(ctx context.Context, d *schem
 	log.Printf("[INFO] Deleting pod disruption budget %#v", name)
 	err = conn.PolicyV1().PodDisruptionBudgets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_pod_security_policy.go
+++ b/kubernetes/resource_kubernetes_pod_security_policy.go
@@ -476,6 +476,9 @@ func resourceKubernetesPodSecurityPolicyDelete(ctx context.Context, d *schema.Re
 	log.Printf("[INFO] Deleting PodSecurityPolicy: %#v", name)
 	err = conn.PolicyV1beta1().PodSecurityPolicies().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	log.Printf("[INFO] PodSecurityPolicy %s deleted", name)


### PR DESCRIPTION
This PR adds a check to the delete function of the kubernetes_priority_class, kubernetes_replication_controller, kuberentes_resource_quota, kubernetes_role, kubernetes_role_binding, kubernetes_secret, kuberntes_service, kubernetes_service_account, kubernetes_stateful_set, kuberentes_storage_class, kubernetes_validating_webhook_configuration, and kubernetes_validating_webhook_configuration. 
 
Fixes #1822 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
