### PR TITLE
Make Deleting PVs Idempotent

### DIFF
--- a/.changelog/1935.txt
+++ b/.changelog/1935.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 `resource/kubernetes_persistent_volume`: add additional validation on the delete operation to make it idempotent
 ```
+
+```release-note:enhancement
+`resource/kubernetes_persistent_volume_v1`: add additional validation on the delete operation to make it idempotent
+```

--- a/.changelog/1935.txt
+++ b/.changelog/1935.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/kubernetes_persistent_volume`: add additional validation on the delete operation to make it idempotent
+```

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -319,9 +319,6 @@ func resourceKubernetesPersistentVolumeUpdate(ctx context.Context, d *schema.Res
 func resourceKubernetesPersistentVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
-		if statusErr, ok := err.(*k8serrors.StatusError); ok && k8serrors.IsNotFound(statusErr) {
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 
@@ -329,6 +326,9 @@ func resourceKubernetesPersistentVolumeDelete(ctx context.Context, d *schema.Res
 	log.Printf("[INFO] Deleting persistent volume: %#v", name)
 	err = conn.CoreV1().PersistentVolumes().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*k8serrors.StatusError); ok && k8serrors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -319,6 +319,9 @@ func resourceKubernetesPersistentVolumeUpdate(ctx context.Context, d *schema.Res
 func resourceKubernetesPersistentVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
+		if statusErr, ok := err.(*k8serrors.StatusError); ok && k8serrors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Description

Add validation on the delete operation for PVs to make it idempotent. (extension of #1914 )

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add validation on the delete operation for PVs to make it idempotent.
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
