### PR TITLE
Add kubernetes_ingress_v1 timeouts

### DIFF
--- a/.changelog/1936.txt
+++ b/.changelog/1936.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/kubernetes_ingress_v1`: add create and delete timeouts
+```

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -250,7 +250,7 @@ func skipIfNotRunningInGke(t *testing.T) {
 		t.Skip("The Kubernetes endpoint must come from GKE for this test to run - skipping")
 	}
 	for _, ev := range []string{"GOOGLE_PROJECT", "GOOGLE_REGION", "GOOGLE_ZONE"} {
-		if os.Getenv("ev") == "" {
+		if os.Getenv(ev) == "" {
 			t.Skipf("%s must be set for GoogleCloud tests", ev)
 		}
 	}

--- a/kubernetes/resource_kubernetes_ingress_v1.go
+++ b/kubernetes/resource_kubernetes_ingress_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	networking "k8s.io/api/networking/v1"
@@ -25,6 +26,10 @@ func resourceKubernetesIngressV1() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: resourceKubernetesIngressV1Schema(),
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
 	}
 }
 

--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -593,6 +593,12 @@ func testAccKubernetesIngressV1Config_waitForLoadBalancer(name string) string {
       protocol    = "TCP"
     }
   }
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["cloud.google.com/neg"],
+      metadata[0].annotations["cloud.google.com/neg-status"],
+    ]
+  }
 }
 
 resource "kubernetes_deployment" "test" {

--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -414,6 +414,9 @@ func testAccKubernetesIngressV1Config_serviceBackend(name string) string {
       }
     }
   }
+  timeouts {
+    create = "45m"
+  }
 }`, name)
 }
 
@@ -641,6 +644,9 @@ resource "kubernetes_ingress_v1" "test" {
     }
   }
   wait_for_load_balancer = true
+  timeouts {
+    create = "45m"
+  }
 }`, name, name, name, name, name, name, name)
 }
 

--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -589,7 +589,7 @@ func testAccKubernetesIngressV1Config_waitForLoadBalancer(name string) string {
     }
     port {
       port        = 8000
-      target_port = 80
+      target_port = 8080
       protocol    = "TCP"
     }
   }
@@ -621,9 +621,10 @@ resource "kubernetes_deployment" "test" {
         container {
           name  = "test"
           image = "gcr.io/google-samples/hello-app:2.0"
+
           env {
             name  = "PORT"
-            value = "80"
+            value = "8080"
           }
         }
       }

--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -10,7 +10,6 @@ description: |-
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 
-
 ## Example Usage
 
 ```hcl
@@ -306,6 +305,13 @@ The following arguments are supported:
 * `ip` -  IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers).
 * `hostname` - Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers).
 
+## Timeouts
+
+The following [Timeout](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) 
+configuration options are available for the `kubernetes_ingress_v1` resource:
+
+* `create` - ingress load balancer creation timeout (default `20 minutes`).
+* `delete` - ingress load balancer deletion timeout (default `20 minutes`).
 
 ## Import
 

--- a/website/docs/r/ingress_v1.html.markdown
+++ b/website/docs/r/ingress_v1.html.markdown
@@ -307,8 +307,7 @@ The following arguments are supported:
 
 ## Timeouts
 
-The following [Timeout](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) 
-configuration options are available for the `kubernetes_ingress_v1` resource:
+The following [Timeout](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) configuration options are available for the `kubernetes_ingress_v1` resource:
 
 * `create` - ingress load balancer creation timeout (default `20 minutes`).
 * `delete` - ingress load balancer deletion timeout (default `20 minutes`).


### PR DESCRIPTION
### Description

The `kubernetes_ingress_v1` resource has [timeouts](https://github.com/Tensho/terraform-provider-kubernetes/blob/main/kubernetes/resource_kubernetes_ingress_v1.go#L191) support, but it's not specified in resource schema definition and not reflected in the documentation.

### Release Note

```release-note:enhancement
`resource/kubernetes_ingress_v1`: add create and delete timeouts
```

### Test Outpus

Run basic test against **kind** cluster:

```
$ make testacc TESTARGS='-run=TestAccKubernetesIngressV1_serviceBackend'
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/tensho/Projects/oss/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesIngressV1_serviceBackend -timeout 3h
=== RUN   TestAccKubernetesIngressV1_serviceBackend
--- PASS: TestAccKubernetesIngressV1_serviceBackend (4.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	5.211s
```

Run wait for load balancer test against **GKE** cluster:

```
$ make testacc TESTARGS='-run=TestAccKubernetesIngressV1_WaitForLoadBalancer'
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/tensho/Projects/oss/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesIngressV1_WaitForLoadBalancer -timeout 3h
=== RUN   TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud
--- PASS: TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud (1089.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	1089.782s
```

### References

- [Resources - Retries and Customizable Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts)

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
