### PR TITLE
Fix HCL formatting in docs and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       GO111MODULE: on
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -384,7 +384,7 @@ func testAccKubernetesClusterRoleBindingConfig_basic(name string) string {
 func testAccKubernetesClusterRoleBindingConfig_generateName(namePrefix string) string {
 	return fmt.Sprintf(`resource "kubernetes_cluster_role_binding" "test" {
   metadata {
-	generate_name = "%s"
+    generate_name = "%s"
   }
 
   role_ref {

--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -89,7 +89,7 @@ Another option is to use an oauth token, such as this example from a GKE cluster
 ```hcl
 data "google_client_config" "default" {}
 data "google_container_cluster" "my_cluster" {
-  name = "my-cluster"
+  name     = "my-cluster"
   location = "us-east1-a"
 }
 


### PR DESCRIPTION
### Description

This PR fixes HCL formatting in docs and tests to make all checks can be passed successfully. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
