### PR TITLE
🐛 Fix acceptance tests and GH workflows

### DIFF
--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -18,7 +18,10 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 	imageName := alpineImageVersion
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.25.0")
+		},
 		IDRefreshName:     "kubernetes_cron_job.test",
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,
@@ -79,7 +82,10 @@ func TestAccKubernetesCronJob_extra(t *testing.T) {
 	imageName := alpineImageVersion
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.25.0")
+		},
 		IDRefreshName:     "kubernetes_cron_job.test",
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,

--- a/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
@@ -18,7 +18,10 @@ func TestAccKubernetesPodDisruptionBudget_basic(t *testing.T) {
 	resourceName := "kubernetes_pod_disruption_budget.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.25.0")
+		},
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,


### PR DESCRIPTION
### Description

Fix `beta` resources acceptance tests to not run then on clusters `v1.25+` where they are not supported anymore.

### Acceptance tests

- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```

### Release Note

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
