### PR TITLE
Add `template_annotations` field to `kubernetes_annotations` resource.

### DIFF
--- a/.changelog/1972.txt
+++ b/.changelog/1972.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add support for adding annotations to resources with pod templates
+```

--- a/kubernetes/resource_kubernetes_annotations_test.go
+++ b/kubernetes/resource_kubernetes_annotations_test.go
@@ -337,9 +337,9 @@ func testAccKubernetesAnnotations_template_empty(name string) string {
   metadata {
     name = %q
   }
-  annotations = {}
+  annotations          = {}
   template_annotations = {}
-  field_manager = "tftest"
+  field_manager        = "tftest"
 }
 `, name)
 }
@@ -355,7 +355,7 @@ func testAccKubernetesAnnotations_template_basic(name string) string {
     "test1" = "one"
   }
   template_annotations = {
-	"test2" = "two"
+    "test2" = "two"
   }
   field_manager = "tftest"
 }
@@ -390,7 +390,7 @@ func testAccKubernetesAnnotations_template_only(name string) string {
     name = %q
   }
   template_annotations = {
-	"test" = "test"
+    "test" = "test"
   }
   field_manager = "tftest"
 }
@@ -405,7 +405,7 @@ func testAccKubernetesAnnotations_resource_only(name string) string {
     name = %q
   }
   annotations = {
-	"test" = "test"
+    "test" = "test"
   }
   field_manager = "tftest"
 }
@@ -419,9 +419,9 @@ func testAccKubernetesAnnotations_template_deployment_empty(name string) string 
   metadata {
     name = %q
   }
-  annotations = {}
+  annotations          = {}
   template_annotations = {}
-  field_manager = "tftest"
+  field_manager        = "tftest"
 }
 `, name)
 }
@@ -437,7 +437,7 @@ func testAccKubernetesAnnotations_template_deployment_basic(name string) string 
     "test1" = "one"
   }
   template_annotations = {
-	"test2" = "two"
+    "test2" = "two"
   }
   field_manager = "tftest"
 }

--- a/kubernetes/resource_kubernetes_annotations_test.go
+++ b/kubernetes/resource_kubernetes_annotations_test.go
@@ -1,12 +1,17 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAccKubernetesAnnotations_basic(t *testing.T) {
@@ -74,6 +79,148 @@ func TestAccKubernetesAnnotations_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesAnnotations_template_cronjob(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	namespace := "default"
+	resourceName := "kubernetes_annotations.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createCronJob(name, namespace)
+		},
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return destroyCronJob(name, namespace)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAnnotations_template_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "batch/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "CronJob"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_template_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "batch/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "CronJob"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_template_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "batch/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "CronJob"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.test3", "three"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.test4", "four"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_template_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "batch/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "CronJob"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAnnotations_template_deployment(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	namespace := "default"
+	resourceName := "kubernetes_annotations.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createDeployment(name, namespace)
+		},
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return destroyDeployment(name, namespace)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAnnotations_template_deployment_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_template_deployment_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_template_deployment_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test1", "one"),
+					resource.TestCheckResourceAttr(resourceName, "annotations.test2", "two"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.test3", "three"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.test4", "four"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+			{
+				Config: testAccKubernetesAnnotations_template_deployment_empty(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_annotations.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
+				),
+			},
+		},
+	})
+}
+
 func testAccKubernetesAnnotations_empty(name string) string {
 	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
   api_version = "v1"
@@ -117,4 +264,204 @@ func testAccKubernetesAnnotations_modified(name string) string {
   field_manager = "tftest"
 }
 `, name)
+}
+
+func testAccKubernetesAnnotations_template_empty(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+  api_version = "batch/v1"
+  kind        = "CronJob"
+  metadata {
+    name = %q
+  }
+  annotations = {}
+  template_annotations = {}
+  field_manager = "tftest"
+}
+`, name)
+}
+
+func testAccKubernetesAnnotations_template_basic(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+  api_version = "batch/v1"
+  kind        = "CronJob"
+  metadata {
+    name = %q
+  }
+  annotations = {
+    "test1" = "one"
+  }
+  template_annotations = {
+	"test2" = "two"
+  }
+  field_manager = "tftest"
+}
+`, name)
+}
+
+func testAccKubernetesAnnotations_template_modified(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+  api_version = "batch/v1"
+  kind        = "CronJob"
+  metadata {
+    name = %q
+  }
+  annotations = {
+    "test1" = "one"
+    "test2" = "two"
+  }
+  template_annotations = {
+    "test3" = "three"
+    "test4" = "four"
+  }
+  field_manager = "tftest"
+}
+`, name)
+}
+
+func testAccKubernetesAnnotations_template_deployment_empty(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+  api_version = "apps/v1"
+  kind        = "Deployment"
+  metadata {
+    name = %q
+  }
+  annotations = {}
+  template_annotations = {}
+  field_manager = "tftest"
+}
+`, name)
+}
+
+func testAccKubernetesAnnotations_template_deployment_basic(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+  api_version = "apps/v1"
+  kind        = "Deployment"
+  metadata {
+    name = %q
+  }
+  annotations = {
+    "test1" = "one"
+  }
+  template_annotations = {
+	"test2" = "two"
+  }
+  field_manager = "tftest"
+}
+`, name)
+}
+
+func testAccKubernetesAnnotations_template_deployment_modified(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_annotations" "test" {
+  api_version = "apps/v1"
+  kind        = "Deployment"
+  metadata {
+    name = %q
+  }
+  annotations = {
+    "test1" = "one"
+    "test2" = "two"
+  }
+  template_annotations = {
+    "test3" = "three"
+    "test4" = "four"
+  }
+  field_manager = "tftest"
+}
+`, name)
+}
+
+func createCronJob(name, namespace string) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	cj := batchv1.CronJob{
+		Spec: batchv1.CronJobSpec{
+			Schedule: "0 * * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							RestartPolicy: v1.RestartPolicyNever,
+							Containers: []v1.Container{{
+								Name:  "test",
+								Image: "busybox",
+								Command: []string{
+									"echo", "hello world",
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cj.SetName(name)
+	cj.SetNamespace(namespace)
+	_, err = conn.BatchV1().CronJobs(namespace).Create(ctx, &cj, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+	return err
+}
+
+func destroyCronJob(name, namespace string) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	err = conn.BatchV1().CronJobs(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	return err
+}
+
+func createDeployment(name, namespace string) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	d := appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:  "test",
+						Image: "busybox",
+						Command: []string{
+							"echo", "hello world",
+						},
+					}},
+				},
+			},
+		},
+	}
+	d.SetName(name)
+	d.SetNamespace(namespace)
+	_, err = conn.AppsV1().Deployments(namespace).Create(ctx, &d, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+	return err
+}
+
+func destroyDeployment(name, namespace string) error {
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	err = conn.AppsV1().Deployments(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	return err
 }

--- a/website/docs/r/annotations.html.markdown
+++ b/website/docs/r/annotations.html.markdown
@@ -48,13 +48,15 @@ resource "kubernetes_annotations" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are supported: 
+
+~> NOTE: At least one of `annotations` or `template_annotations` is required. 
 
 * `api_version` - (Required) The apiVersion of the resource to be annotated.
 * `kind` - (Required) The kind of the resource to be annotated.
 * `metadata` - (Required) Standard metadata of the resource to be annotated. 
-* `annotations` - (Required) A map of annotations to apply to the resource.
-* `template_annotations` - (Required) A map of annotations to apply to the pod template within the resource.
+* `annotations` - (Optional) A map of annotations to apply to the resource.
+* `template_annotations` - (Optional) A map of annotations to apply to the pod template within the resource.
 * `force` - (Optional) Force management of annotations if there is a conflict.
 * `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.
 

--- a/website/docs/r/annotations.html.markdown
+++ b/website/docs/r/annotations.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard metadata of the resource to be annotated. 
 * `annotations` - (Optional) A map of annotations to apply to the resource.
 * `template_annotations` - (Optional) A map of annotations to apply to the pod template within the resource.
-* `force` - (Optional) Force management of annotations if there is a conflict.
+* `force` - (Optional) Force management of annotations if there is a conflict. Defaults to `false`.
 * `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.
 
 ## Nested Blocks

--- a/website/docs/r/annotations.html.markdown
+++ b/website/docs/r/annotations.html.markdown
@@ -26,6 +26,26 @@ resource "kubernetes_annotations" "example" {
 }
 ```
 
+## Example Usage: Patching resources which contain a pod template, e.g Deployment, Job
+
+```hcl
+resource "kubernetes_annotations" "example" {
+  api_version = "apps/v1"
+  kind        = "Deployment"
+  metadata {
+    name = "my-config"
+  }
+  # These annotations will be applied to the Deployment resource itself
+  annotations = {
+    "owner" = "myteam"
+  }
+  # These annotations will be applied to the Pods created by the Deployment
+  template_annotations = {
+    "owner" = "myteam"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -34,6 +54,7 @@ The following arguments are supported:
 * `kind` - (Required) The kind of the resource to be annotated.
 * `metadata` - (Required) Standard metadata of the resource to be annotated. 
 * `annotations` - (Required) A map of annotations to apply to the resource.
+* `template_annotations` - (Required) A map of annotations to apply to the pod template within the resource.
 * `force` - (Optional) Force management of annotations if there is a conflict.
 * `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.
 


### PR DESCRIPTION
### Description

This change adds a new attribute `template_annotations` to the `kubernetes_annotations` resource that allows patching of resources that contain a pod template. 

See https://github.com/hashicorp/terraform-provider-kubernetes/issues/723#issuecomment-1160285518

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
