### PR TITLE
Stop forcing replacement of `kubernetes_manifest` resources when fields annotated with `x-kubernetes-preserve-unknown` are modified

### DIFF
--- a/.changelog/1975.txt
+++ b/.changelog/1975.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix issue when `kubernetes_manifest` resources would get replaced if there was a change in an attribute marked with `x-kubernetes-preserve-unknown` regardless of immutability
+```

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-kubernetes/manifest"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/payload"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -305,7 +304,7 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 	}
 
 	// Request a complete type for the resource from the OpenAPI spec
-	objectType, hints, err := s.TFTypeFromOpenAPI(ctx, gvk, false)
+	objectType, _, err := s.TFTypeFromOpenAPI(ctx, gvk, false)
 	if err != nil {
 		return resp, fmt.Errorf("failed to determine resource type ID: %s", err)
 	}
@@ -427,13 +426,6 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				}
 				nowCfg, restPath, err := tftypes.WalkAttributePath(ppMan, ap)
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
-				if hasChanged {
-					h, ok := hints[morph.ValueToTypePath(ap).String()]
-					if ok && h == manifest.PreserveUnknownFieldsLabel {
-						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
-						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
-					}
-				}
 				if isComputed {
 					if hasChanged {
 						return tftypes.NewValue(v.Type(), tftypes.UnknownValue), nil


### PR DESCRIPTION
Having a delta between the desired resource status and the current resource status should not trigger a replacement of the resource.

### Description

<!--- Please leave a helpful description of the pull request here. --->

The `kubernetes_manifest` is forcing replacement when fields are annotated with `x-kubernetes-preserve-unknown`, which I can't figure out the reasoning for, and is breaking my knative deployments

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
   No but it has tests on it that go through that part of the code
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Stop forcing replacement of `kubernetes_manifest` resources when fields annotated with `x-kubernetes-preserve-unknown` are modified
```

### References

#1893, #1974, #1646.
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
