### PR TITLE
Stop forcing lists containing dynamic values to be tftypes.Tuple

### DIFF
--- a/manifest/openapi/schema.go
+++ b/manifest/openapi/schema.go
@@ -125,11 +125,7 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 			if err != nil {
 				return nil, err
 			}
-			if !isTypeFullyKnown(et) {
-				t = tftypes.Tuple{ElementTypes: []tftypes.Type{et}}
-			} else {
-				t = tftypes.List{ElementType: et}
-			}
+			t = tftypes.List{ElementType: et}
 			if herr == nil {
 				typeCache.Store(h, t)
 			}


### PR DESCRIPTION
### Description

Terraform provider reports an error such as `AttributeName("name"): can't use tftypes.Tuple[...] as tftypes.Tuple[...]`

Full output example:

```
╷
│ Error: Failed to update proposed state from prior state
│
│   with kubernetes_manifest.api_knative,
│   on main.tf line 18, in resource "kubernetes_manifest" "api_knative":
│   18: resource "kubernetes_manifest" "api_knative" {
│
│ AttributeName("env"): can't use tftypes.Tuple[tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String,
│ "optional":tftypes.Bool], "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String,
│ "optional":tftypes.Bool]]], tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]]] as
│ tftypes.Tuple[tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]],
│ tftypes.Object["name":tftypes.String, "value":tftypes.String, "valueFrom":tftypes.Object["configMapKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool],
│ "fieldRef":tftypes.Object["apiVersion":tftypes.String, "fieldPath":tftypes.String], "resourceFieldRef":tftypes.DynamicPseudoType, "secretKeyRef":tftypes.Object["key":tftypes.String, "name":tftypes.String, "optional":tftypes.Bool]]]]
╵
```
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

https://github.com/txomon/terraform-provider-kubernetes/issues/1

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
