### PR TITLE
🐛 Fix idempotent delete operation

### DIFF
--- a/.changelog/1999.txt
+++ b/.changelog/1999.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+`resource/kubernetes_network_policy`: Fix an issue when the delete operation may not be idempotent.
+```
+
+```release-note:bug
+`resource/kubernetes_network_policy_v1`: Fix an issue when the delete operation may not be idempotent.
+```
+
+```release-note:bug
+`resource/kubernetes_mutating_webhook_configuration`: Fix an issue when the delete operation may not be idempotent.
+```
+
+```release-note:bug
+`resource/kubernetes_persistent_volume_claim`: Fix an issue when the delete operation may not be idempotent.
+```
+
+```release-note:bug
+`resource/kubernetes_persistent_volume_claim_v1`: Fix an issue when the delete operation may not be idempotent.
+```

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
@@ -291,9 +291,6 @@ func resourceKubernetesMutatingWebhookConfigurationUpdate(ctx context.Context, d
 func resourceKubernetesMutatingWebhookConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
-		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 
@@ -310,6 +307,9 @@ func resourceKubernetesMutatingWebhookConfigurationDelete(ctx context.Context, d
 		err = conn.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
 	}
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_network_policy.go
+++ b/kubernetes/resource_kubernetes_network_policy.go
@@ -340,9 +340,6 @@ func resourceKubernetesNetworkPolicyUpdate(ctx context.Context, d *schema.Resour
 func resourceKubernetesNetworkPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
-		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 
@@ -353,6 +350,9 @@ func resourceKubernetesNetworkPolicyDelete(ctx context.Context, d *schema.Resour
 	log.Printf("[INFO] Deleting network policy: %#v", name)
 	err = conn.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -233,9 +233,6 @@ func resourceKubernetesPersistentVolumeClaimUpdate(ctx context.Context, d *schem
 func resourceKubernetesPersistentVolumeClaimDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
-		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 
@@ -247,6 +244,9 @@ func resourceKubernetesPersistentVolumeClaimDelete(ctx context.Context, d *schem
 	log.Printf("[INFO] Deleting persistent volume claim: %#v", name)
 	err = conn.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Description

Fix the delete operation handling to make it idempotent for the following resources:

- `kubernetes_network_policy`
- `kubernetes_network_policy_v1`
- `kubernetes_mutating_webhook_configuration`
- `kubernetes_persistent_volume_claim`
- `kubernetes_persistent_volume_claim_v1`

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note:bug
`resource/kubernetes_network_policy`: Fix an issue when the delete operation may not be idempotent.
`resource/kubernetes_network_policy_v1`: Fix an issue when the delete operation may not be idempotent.
`resource/kubernetes_mutating_webhook_configuration`: Fix an issue when the delete operation may not be idempotent.
`resource/kubernetes_persistent_volume_claim`: Fix an issue when the delete operation may not be idempotent.
`resource/kubernetes_persistent_volume_claim_v1`: Fix an issue when the delete operation may not be idempotent.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
