### PR TITLE
Remove Computed boolean value from volume

### DIFF
--- a/.changelog/2006.txt
+++ b/.changelog/2006.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`kubernetes/schema_pod_spec.go`: Fix unexpected volumes appearing on plan
+```

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -474,7 +474,6 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 		"volume": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Computed:    true,
 			Description: "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes",
 			Elem:        volumeSchema(isUpdatable),
 		},


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #685 

Went through the `schema_pod_spec.go` and found that the Computed value was set to true. This resulted in volume appearing in plan. Setting to computed tells the user that a value should be expected after apply but this is not true whatsoever. 


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`kubernetes/schema_pod_spec.go`: Fix unexpected volumes appearing on plan
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
