### PR TITLE
kubernetes_node_taint: support import, dont fail if node missing

### DIFF
--- a/.changelog/2007.txt
+++ b/.changelog/2007.txt
@@ -1,0 +1,3 @@
+```release-node:doc
+`resource/kubernetes_node_taint`: Support imports, throw warning if node doesn't exist.
+```

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -22,6 +22,9 @@ func resourceKubernetesNodeTaint() *schema.Resource {
 		ReadContext:   resourceKubernetesNodeTaintRead,
 		UpdateContext: resourceKubernetesNodeTaintUpdate,
 		DeleteContext: resourceKubernetesNodeTaintDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		CustomizeDiff: func(ctx context.Context, rd *schema.ResourceDiff, i interface{}) error {
 			if !rd.HasChange("taint") {
 				return nil
@@ -100,6 +103,14 @@ func resourceKubernetesNodeTaintRead(ctx context.Context, d *schema.ResourceData
 
 	conn, err := m.(KubeClientsets).MainClientset()
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			// The node is gone so the resource should be deleted.
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "Node has been deleted",
+				Detail:   fmt.Sprintf("The underlying node %q has been deleted. You should remove it from your configuration.", nodeName),
+			}}
+		}
 		return diag.FromErr(err)
 	}
 	nodeApi := conn.CoreV1().Nodes()


### PR DESCRIPTION
### Description

Support importing node taints.

Throw a warning instead of an error if a node does not exist.

### Acceptance tests
N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/kubernetes_node_taint`: Support imports, throw warning if node doesn't exist.
```

### References

Closes #2094 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
