### PR TITLE
Fix waiter crash when conditions are not present

### DIFF
--- a/.changelog/2008.txt
+++ b/.changelog/2008.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+kubernetes_manifest: fix crash when waiting on conditions that are not yet present
+```

--- a/manifest/provider/waiter.go
+++ b/manifest/provider/waiter.go
@@ -343,7 +343,7 @@ func (w *ConditionsWaiter) Wait(ctx context.Context) error {
 		}
 
 		if status, ok := res.Object["status"].(map[string]interface{}); ok {
-			if conditions := status["conditions"].([]interface{}); ok && len(conditions) > 0 {
+			if conditions, ok := status["conditions"].([]interface{}); ok && len(conditions) > 0 {
 				conditionsMet := true
 				for _, c := range w.conditions {
 					var condition map[string]tftypes.Value

--- a/manifest/test/acceptance/testdata/Wait/wait_for_condition_invalid.tf
+++ b/manifest/test/acceptance/testdata/Wait/wait_for_condition_invalid.tf
@@ -1,0 +1,21 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Namespace"
+
+    metadata = {
+      name      = var.name
+    }
+  }
+
+  wait {
+    condition {
+      type = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "3s"
+  }
+}

--- a/manifest/test/acceptance/wait_test.go
+++ b/manifest/test/acceptance/wait_test.go
@@ -5,6 +5,7 @@ package acceptance
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -184,4 +185,38 @@ func TestKubernetesManifest_WaitCondition_Pod(t *testing.T) {
 		"kubernetes_manifest.test.wait.0.condition.1.type":   "ContainersReady",
 		"kubernetes_manifest.test.wait.0.condition.1.status": "True",
 	})
+}
+
+func TestKubernetesManifest_Wait_InvalidCondition(t *testing.T) {
+	// NOTE: this tests that specifying a condition for a resource that
+	// will never have one does not crash the provider
+
+	ctx := context.Background()
+
+	name := randName()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
+	tf := tfhelper.RequireNewWorkingDir(ctx, t)
+	tf.SetReattachInfo(ctx, reattachInfo)
+	defer func() {
+		tf.Destroy(ctx)
+		tf.Close()
+		k8shelper.AssertResourceDoesNotExist(t, "v1", "namespaces", name)
+	}()
+
+	tfvars := TFVARS{
+		"name": name,
+	}
+	tfconfig := loadTerraformConfig(t, "Wait/wait_for_condition_invalid.tf", tfvars)
+	tf.SetConfig(ctx, tfconfig)
+	tf.Init(ctx)
+
+	err = tf.Apply(ctx)
+	if err == nil || !strings.Contains(err.Error(), "Terraform timed out waiting on the operation to complete") {
+		t.Fatalf("Waiter should have timed out")
+	}
 }


### PR DESCRIPTION
### Description

This PR fixes a panic which occurs when the waiter tries to wait on conditions that are not present in the resource.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
