### PR TITLE
Add namespace_selector to pod's affinities

### DIFF
--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -154,6 +154,15 @@ func podAffinityTermFields() map[string]*schema.Schema {
 				Schema: labelSelectorFields(true),
 			},
 		},
+		"namespace_selector": {
+			Type:        schema.TypeList,
+			Description: "A label query over a set of namespaces.",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: namespaceSelectorFields(true),
+			},
+		},
 		"namespaces": {
 			Type:        schema.TypeSet,
 			Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'",

--- a/kubernetes/schema_namespace_selector.go
+++ b/kubernetes/schema_namespace_selector.go
@@ -1,0 +1,46 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func namespaceSelectorFields(updatable bool) map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"match_expressions": {
+			Type:        schema.TypeList,
+			Description: "A list of namespace selector requirements. The requirements are ANDed.",
+			Optional:    true,
+			ForceNew:    !updatable,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:        schema.TypeString,
+						Description: "The namespace key that the selector applies to.",
+						Optional:    true,
+						ForceNew:    !updatable,
+					},
+					"operator": {
+						Type:        schema.TypeString,
+						Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
+						Optional:    true,
+						ForceNew:    !updatable,
+					},
+					"values": {
+						Type:        schema.TypeSet,
+						Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
+						Optional:    true,
+						ForceNew:    !updatable,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
+					},
+				},
+			},
+		},
+		"match_labels": {
+			Type:        schema.TypeMap,
+			Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+			Optional:    true,
+			ForceNew:    !updatable,
+		},
+	}
+}

--- a/kubernetes/structures_affinity.go
+++ b/kubernetes/structures_affinity.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // Flatteners
@@ -85,6 +85,9 @@ func flattenPodAffinityTerms(in []v1.PodAffinityTerm) []interface{} {
 		m["topology_key"] = n.TopologyKey
 		if n.LabelSelector != nil {
 			m["label_selector"] = flattenLabelSelector(n.LabelSelector)
+		}
+		if n.NamespaceSelector != nil {
+			m["namespace_selector"] = flattenLabelSelector(n.NamespaceSelector)
 		}
 		att[i] = m
 	}
@@ -216,6 +219,9 @@ func expandPodAffinityTerms(t []interface{}) []v1.PodAffinityTerm {
 		in := n.(map[string]interface{})
 		if v, ok := in["label_selector"].([]interface{}); ok && len(v) > 0 {
 			obj[i].LabelSelector = expandLabelSelector(v)
+		}
+		if v, ok := in["namespace_selector"].([]interface{}); ok && len(v) > 0 {
+			obj[i].NamespaceSelector = expandLabelSelector(v)
 		}
 		if v, ok := in["namespaces"].(*schema.Set); ok {
 			obj[i].Namespaces = sliceOfString(v.List())

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -314,6 +314,7 @@ The following arguments are supported:
 #### Arguments
 
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
+* `namespace_selector` - (Optional) A label query over a set of namespaces.
 * `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
 * `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
 

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -314,6 +314,7 @@ The following arguments are supported:
 #### Arguments
 
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
+* `namespace_selector` - (Optional) A label query over a set of namespaces.
 * `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
 * `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
 


### PR DESCRIPTION
### Description

This change adds new attribute `namespace_selector` to the `kubernetes_pod` resource (affinities section).
See https://github.com/hashicorp/terraform-provider-kubernetes/issues/1826.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
