### PR TITLE
Update `kubernetes_resources` docs with missing examples

### DIFF
--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -6,14 +6,14 @@ description: |-
   This data source is a generic way to query for a list of resources from the Kubernetes API and filter them. 
 ---
 
-# kubernetes_resource
+# kubernetes_resources
 
 This data source is a generic way to query for a list of Kubernetes resources and filter them using a label or field selector.
 
 ### Example: Get a list of namespaces excluding "kube-system"
 
 ```hcl
-data "kubernetes_resource" "example" {
+data "kubernetes_resources" "example" {
   api_version    = "v1"
   kind           = "Namespace"
   field_selector = "metadata.name!=kube-system"
@@ -29,4 +29,5 @@ The following arguments are supported:
 * `label_selector` - (Optional) A selector to restrict the list of returned objects by their labels.
 * `field_selector` - (Optional) A selector to restrict the list of returned objects by their fields.
 * `namespace` - (Optional) The namespace of the requested resource.
+* `object` - (Optional) The response returned from the API server.
 

--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -10,13 +10,31 @@ description: |-
 
 This data source is a generic way to query for a list of Kubernetes resources and filter them using a label or field selector.
 
-### Example: Get a list of namespaces excluding "kube-system"
+### Example: Get a list of namespaces excluding "kube-system" using `field_selector`
 
 ```hcl
 data "kubernetes_resources" "example" {
   api_version    = "v1"
   kind           = "Namespace"
   field_selector = "metadata.name!=kube-system"
+}
+
+output "test" {
+  value = length(data.kubernetes_resources.namespaces.objects)
+}
+```
+
+### Example: Get a list of namespaces excluding "kube-system" using `label_selector`
+
+```hcl
+data "kubernetes_resources" "example" {
+  api_version    = "v1"
+  kind           = "Namespace"
+  label_selector = "kubernetes.io/metadata.name!=kube-system"
+}
+
+output "test" {
+  value = length(data.kubernetes_resources.namespaces.objects)
 }
 ```
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Add example of label_selector as well as fixed some typos and missing `object` attribute

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
