### PR TITLE
🤖 Update copyright workflow

### DIFF
--- a/.github/workflows/hc-copywrite.yml
+++ b/.github/workflows/hc-copywrite.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Install copywrite
       uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce # v1.0.0
+      with:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Validate Header Compliance
       run: copywrite headers --plan


### PR DESCRIPTION
### Description

Add `GUTHUB_TOKEN` to avoid rate limit block.

### Acceptance tests

N/A.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
