### PR TITLE
Created a field for generate_name in secret data source

### DIFF
--- a/.changelog/2028.txt
+++ b/.changelog/2028.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`data_source/kubernetes_secret`: Fix an issue where data_source cannot read secret created with generate_name. 
+```
+
+```release-note:bug
+`data_source/kubernetes_secret_v1`: Fix an issue where data_source cannot read secret created with generate_name. 
+```

--- a/kubernetes/data_source_kubernetes_secret.go
+++ b/kubernetes/data_source_kubernetes_secret.go
@@ -16,7 +16,7 @@ func dataSourceKubernetesSecret() *schema.Resource {
 		ReadContext: dataSourceKubernetesSecretRead,
 
 		Schema: map[string]*schema.Schema{
-			"metadata": namespacedMetadataSchema("secret", false),
+			"metadata": namespacedMetadataSchema("secret", true),
 			"data": {
 				Type:        schema.TypeMap,
 				Description: "A map of the secret data.",


### PR DESCRIPTION
### Description

Fix kubernetes_secret_v1 data source to read secret with generate_name.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
- Fix https://github.com/hashicorp/terraform-provider-kubernetes/issues/1954 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
