### PR TITLE
Remove limit for taints in `kubernetes_node_taint` resource

### DIFF
--- a/.changelog/2046.txt
+++ b/.changelog/2046.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`kubernetes/resource_kubernetes_node_taint.go`: Remove MaxItems from taint attribute
+```

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -164,9 +164,9 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 			var updated bool
 			newNode, updated = addOrUpdateTaint(node, &newTaint)
 			if !updated {
-				return diag.Errorf("Node %s already has taint %+v", nodeName, newTaints)
+				log.Printf("Node %s already has taint %+v", nodeName, newTaints)
 			}
-			taintList = append(taintList, newNode.Spec.Taints...)
+			taintList = append(taintList, newNode.Spec.Taints[0])
 		}
 	}
 	//panic(fmt.Sprintf("%v", newNode.Spec.Taints))

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -74,7 +74,7 @@ func resourceKubernetesNodeTaint() *schema.Resource {
 
 func resourceKubernetesNodeTaintCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	d.SetId(nodeTaintToId(metadata.Name, d.Get("taint").([]interface{})))
+	d.SetId(fmt.Sprintf("%s-taints", &metadata.Name))
 	diag := resourceKubernetesNodeTaintUpdate(ctx, d, m)
 	if diag.HasError() {
 		d.SetId("")
@@ -196,7 +196,6 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 	if d.Id() == "" {
 		return nil
 	}
-	d.SetId(nodeTaintToId(nodeName, taints))
 	return resourceKubernetesNodeTaintRead(ctx, d, m)
 }
 
@@ -266,11 +265,6 @@ func expandNodeTaint(t map[string]interface{}) (*v1.Taint, error) {
 		Effect: taintEffect,
 	}
 	return taint, nil
-}
-
-func nodeTaintToId(nodeName string, taints []interface{}) string {
-	t := taints[0].(map[string]interface{})
-	return fmt.Sprintf("%s,%s=%s:%s", nodeName, t["key"], t["value"], t["effect"])
 }
 
 func idToNodeTaint(id string) (string, *v1.Taint, error) {

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -74,7 +74,7 @@ func resourceKubernetesNodeTaint() *schema.Resource {
 
 func resourceKubernetesNodeTaintCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	d.SetId(fmt.Sprintf("%v-taints", metadata.Name))
+	d.SetId(nodeTaintToId(fmt.Sprintf("%s", metadata.Name), d.Get("taint").([]interface{})))
 	diag := resourceKubernetesNodeTaintUpdate(ctx, d, m)
 	if diag.HasError() {
 		d.SetId("")
@@ -146,6 +146,7 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 	//////
 	var newNode *v1.Node
+	var taintList []v1.Taint
 	for _, newTaint := range newTaints {
 
 		if d.Id() == "" {
@@ -165,9 +166,10 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 			if !updated {
 				return diag.Errorf("Node %s already has taint %+v", nodeName, newTaints)
 			}
+			taintList = append(taintList, newNode.Spec.Taints...)
 		}
 	}
-	panic(fmt.Sprintf("%v", newNode.Spec.Taints))
+	//panic(fmt.Sprintf("%v", newNode.Spec.Taints))
 	patchObj := map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Node",
@@ -175,7 +177,7 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 			"name": nodeName,
 		},
 		"spec": map[string]interface{}{
-			"taints": flattenNodeTaints(newNode.Spec.Taints...),
+			"taints": flattenNodeTaints(taintList...),
 		},
 	}
 	patch := unstructured.Unstructured{
@@ -277,6 +279,15 @@ func expandNodeTaints(t []interface{}) ([]v1.Taint, error) {
 		taints = append(taints, *taint)
 	}
 	return taints, nil
+}
+
+func nodeTaintToId(nodeName string, taints []interface{}) string {
+	var id string = fmt.Sprintf("%s", nodeName)
+	for _, t := range taints {
+		taint := t.(map[string]interface{})
+		id += fmt.Sprintf(",%s=%s:%s", taint["key"], taint["value"], taint["effect"])
+	}
+	return id
 }
 
 func idToNodeTaint(id string) (string, *v1.Taint, error) {

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -70,7 +70,7 @@ func resourceKubernetesNodeTaint() *schema.Resource {
 
 func resourceKubernetesNodeTaintCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	d.SetId(nodeTaintToId(fmt.Sprintf("%s", metadata.Name), d.Get("taint").([]interface{})))
+	d.SetId(nodeTaintToId(metadata.Name, d.Get("taint").([]interface{})))
 	diag := resourceKubernetesNodeTaintUpdate(ctx, d, m)
 	if diag.HasError() {
 		d.SetId("")

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -64,7 +64,6 @@ func resourceKubernetesNodeTaint() *schema.Resource {
 			"taint": {
 				Type:     schema.TypeList,
 				Required: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: nodeTaintFields(),
 				},

--- a/kubernetes/resource_kubernetes_node_taint_test.go
+++ b/kubernetes/resource_kubernetes_node_taint_test.go
@@ -6,11 +6,14 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/util/taints"
 )
 
 const (
@@ -67,6 +70,44 @@ func TestAccKubernetesResourceNodeTaint_MultipleBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "taint.2.key", taintKey+"-3"),
 					resource.TestCheckResourceAttr(resourceName, "taint.2.value", taintValue),
 					resource.TestCheckResourceAttr(resourceName, "taint.2.effect", taintEffect),
+				),
+			},
+			{
+				Config: testAccKubernetesNodeTaintConfig_updateTaint(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccKubernetesNodeTaintExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.key", taintKey+"-1"),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.key", taintKey+"-2"),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "taint.2.key", taintKey+"-3"),
+					resource.TestCheckResourceAttr(resourceName, "taint.2.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.2.effect", taintEffect),
+				),
+			},
+			{
+				Config: testAccKubernetesNodeTaintConfig_removeTaint(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccKubernetesNodeTaintExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.key", taintKey+"-1"),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.key", taintKey+"-2"),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "taint.#", "2"),
+				),
+			},
+			{
+				Config: testAccKubernetesNodeTaintConfig_removeAllTaints(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccKubernetesNodeTaintExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "taint.#", "0"),
 				),
 			},
 		},
@@ -163,4 +204,91 @@ resource "kubernetes_node_taint" "test" {
   field_manager = "%s"
 }
 `, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, fieldManager)
+}
+
+func testAccKubernetesNodeTaintConfig_updateTaint() string {
+	return fmt.Sprintf(`
+data "kubernetes_nodes" "test" {}
+
+resource "kubernetes_node_taint" "test" {
+  metadata {
+    name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
+  }
+  taint {
+    key    = "%s-1"
+    value  = "%s"
+    effect = "%s"
+  }
+  taint {
+    key    = "%s-2"
+    value  = "%s"
+    effect = "%s"
+  }
+  taint {
+    key    = "%s-3"
+    value  = "%s"
+    effect = "%s"
+  }
+  field_manager = "%s"
+}
+`, taintKey, taintValue, "NoSchedule", taintKey, taintValue, "NoSchedule", taintKey, taintValue, taintEffect, fieldManager)
+}
+
+func testAccKubernetesNodeTaintConfig_removeTaint() string {
+	return fmt.Sprintf(`
+data "kubernetes_nodes" "test" {}
+
+resource "kubernetes_node_taint" "test" {
+  metadata {
+    name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
+  }
+  taint {
+    key    = "%s-1"
+    value  = "%s"
+    effect = "%s"
+  }
+  taint {
+    key    = "%s-2"
+    value  = "%s"
+    effect = "%s"
+  }
+  field_manager = "%s"
+}
+`, taintKey, taintValue, "NoSchedule", taintKey, taintValue, "NoSchedule", fieldManager)
+}
+
+func testAccKubernetesNodeTaintConfig_removeAllTaints() string {
+	return fmt.Sprintf(`
+data "kubernetes_nodes" "test" {}
+
+resource "kubernetes_node_taint" "test" {
+  metadata {
+    name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
+  }
+  field_manager = "%s"
+}
+`, fieldManager)
+}
+
+func hasTaint(taints []v1.Taint, taint *v1.Taint) bool {
+	for i := range taints {
+		if taint.MatchTaint(&taints[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func idToNodeTaint(id string) (string, *v1.Taint, error) {
+	idVals := strings.Split(id, ",")
+	nodeName := idVals[0]
+	taintStr := idVals[1]
+	taints, _, err := taints.ParseTaints([]string{taintStr})
+	if err != nil {
+		return "", nil, err
+	}
+	if len(taints) == 0 {
+		return "", nil, fmt.Errorf("failed to parse taint %s", taintStr)
+	}
+	return nodeName, &taints[0], nil
 }

--- a/kubernetes/resource_kubernetes_node_taint_test.go
+++ b/kubernetes/resource_kubernetes_node_taint_test.go
@@ -102,14 +102,6 @@ func TestAccKubernetesResourceNodeTaint_MultipleBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "taint.#", "2"),
 				),
 			},
-			{
-				Config: testAccKubernetesNodeTaintConfig_removeAllTaints(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccKubernetesNodeTaintExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.name"),
-					resource.TestCheckResourceAttr(resourceName, "taint.#", "0"),
-				),
-			},
 		},
 	})
 }
@@ -255,19 +247,6 @@ resource "kubernetes_node_taint" "test" {
   field_manager = %q
 }
 `, taintKey+"-1", taintValue, "NoSchedule", taintKey+"-2", taintValue, "NoSchedule", fieldManager)
-}
-
-func testAccKubernetesNodeTaintConfig_removeAllTaints() string {
-	return fmt.Sprintf(`
-data "kubernetes_nodes" "test" {}
-
-resource "kubernetes_node_taint" "test" {
-  metadata {
-    name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
-  }
-  field_manager = %q
-}
-`, fieldManager)
 }
 
 func hasTaint(taints []v1.Taint, taint *v1.Taint) bool {

--- a/kubernetes/resource_kubernetes_node_taint_test.go
+++ b/kubernetes/resource_kubernetes_node_taint_test.go
@@ -169,11 +169,11 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%q"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
-  field_manager = "%q"
+  field_manager = %q
 }
 `, taintKey, taintValue, taintEffect, fieldManager)
 }
@@ -187,23 +187,23 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%q-1"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
   taint {
-    key    = "%q-2"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
   taint {
-    key    = "%q-3"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
-  field_manager = "%q"
+  field_manager = %q
 }
-`, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, fieldManager)
+`, taintKey+"-1", taintValue, taintEffect, taintKey+"-2", taintValue, taintEffect, taintKey+"-3", taintValue, taintEffect, fieldManager)
 }
 
 func testAccKubernetesNodeTaintConfig_updateTaint() string {
@@ -215,23 +215,23 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%q-1"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
   taint {
-    key    = "%q-2"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
   taint {
-    key    = "%q-3"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
-  field_manager = "%q"
+  field_manager = %q
 }
-`, taintKey, taintValue, "NoSchedule", taintKey, taintValue, "NoSchedule", taintKey, taintValue, taintEffect, fieldManager)
+`, taintKey+"-1", taintValue, "NoSchedule", taintKey+"-2", taintValue, "NoSchedule", taintKey+"-3", taintValue, taintEffect, fieldManager)
 }
 
 func testAccKubernetesNodeTaintConfig_removeTaint() string {
@@ -243,18 +243,18 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%q-1"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
   taint {
-    key    = "%q-2"
-    value  = "%q"
-    effect = "%q"
+    key    = %q
+    value  = %q
+    effect = %q
   }
-  field_manager = "%q"
+  field_manager = %q
 }
-`, taintKey, taintValue, "NoSchedule", taintKey, taintValue, "NoSchedule", fieldManager)
+`, taintKey+"-1", taintValue, "NoSchedule", taintKey+"-2", taintValue, "NoSchedule", fieldManager)
 }
 
 func testAccKubernetesNodeTaintConfig_removeAllTaints() string {
@@ -265,7 +265,7 @@ resource "kubernetes_node_taint" "test" {
   metadata {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
-  field_manager = "%q"
+  field_manager = %q
 }
 `, fieldManager)
 }

--- a/kubernetes/resource_kubernetes_node_taint_test.go
+++ b/kubernetes/resource_kubernetes_node_taint_test.go
@@ -44,6 +44,35 @@ func TestAccKubernetesResourceNodeTaint_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesResourceNodeTaint_MultipleBasic(t *testing.T) {
+	resourceName := "kubernetes_node_taint.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccKubernetesNodeTaintDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesNodeTaintConfig_multipleBasic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccKubernetesNodeTaintExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.key", taintKey+"-1"),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.0.effect", taintEffect),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.key", taintKey+"-2"),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.1.effect", taintEffect),
+					resource.TestCheckResourceAttr(resourceName, "taint.2.key", taintKey+"-3"),
+					resource.TestCheckResourceAttr(resourceName, "taint.2.value", taintValue),
+					resource.TestCheckResourceAttr(resourceName, "taint.2.effect", taintEffect),
+				),
+			},
+		},
+	})
+}
+
 func testAccKubernetesCheckNodeTaint(rs *terraform.ResourceState) error {
 	nodeName, taint, err := idToNodeTaint(rs.Primary.ID)
 	if err != nil {
@@ -106,4 +135,32 @@ resource "kubernetes_node_taint" "test" {
   field_manager = "%s"
 }
 `, taintKey, taintValue, taintEffect, fieldManager)
+}
+
+func testAccKubernetesNodeTaintConfig_multipleBasic() string {
+	return fmt.Sprintf(`
+data "kubernetes_nodes" "test" {}
+
+resource "kubernetes_node_taint" "test" {
+  metadata {
+    name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
+  }
+  taint {
+    key    = "%s-1"
+    value  = "%s"
+    effect = "%s"
+  }
+  taint {
+    key    = "%s-2"
+    value  = "%s"
+    effect = "%s"
+  }
+  taint {
+    key    = "%s-3"
+    value  = "%s"
+    effect = "%s"
+  }
+  field_manager = "%s"
+}
+`, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, fieldManager)
 }

--- a/kubernetes/resource_kubernetes_node_taint_test.go
+++ b/kubernetes/resource_kubernetes_node_taint_test.go
@@ -169,11 +169,11 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%s"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q"
+    value  = "%q"
+    effect = "%q"
   }
-  field_manager = "%s"
+  field_manager = "%q"
 }
 `, taintKey, taintValue, taintEffect, fieldManager)
 }
@@ -187,21 +187,21 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%s-1"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-1"
+    value  = "%q"
+    effect = "%q"
   }
   taint {
-    key    = "%s-2"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-2"
+    value  = "%q"
+    effect = "%q"
   }
   taint {
-    key    = "%s-3"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-3"
+    value  = "%q"
+    effect = "%q"
   }
-  field_manager = "%s"
+  field_manager = "%q"
 }
 `, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, taintKey, taintValue, taintEffect, fieldManager)
 }
@@ -215,21 +215,21 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%s-1"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-1"
+    value  = "%q"
+    effect = "%q"
   }
   taint {
-    key    = "%s-2"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-2"
+    value  = "%q"
+    effect = "%q"
   }
   taint {
-    key    = "%s-3"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-3"
+    value  = "%q"
+    effect = "%q"
   }
-  field_manager = "%s"
+  field_manager = "%q"
 }
 `, taintKey, taintValue, "NoSchedule", taintKey, taintValue, "NoSchedule", taintKey, taintValue, taintEffect, fieldManager)
 }
@@ -243,16 +243,16 @@ resource "kubernetes_node_taint" "test" {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
   taint {
-    key    = "%s-1"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-1"
+    value  = "%q"
+    effect = "%q"
   }
   taint {
-    key    = "%s-2"
-    value  = "%s"
-    effect = "%s"
+    key    = "%q-2"
+    value  = "%q"
+    effect = "%q"
   }
-  field_manager = "%s"
+  field_manager = "%q"
 }
 `, taintKey, taintValue, "NoSchedule", taintKey, taintValue, "NoSchedule", fieldManager)
 }
@@ -265,7 +265,7 @@ resource "kubernetes_node_taint" "test" {
   metadata {
     name = data.kubernetes_nodes.test.nodes.0.metadata.0.name
   }
-  field_manager = "%s"
+  field_manager = "%q"
 }
 `, fieldManager)
 }

--- a/kubernetes/schema_node_spec.go
+++ b/kubernetes/schema_node_spec.go
@@ -116,7 +116,6 @@ func nodeTaintFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The taint key",
 			Required:    true,
-			ForceNew:    true,
 		},
 		"value": {
 			Type:        schema.TypeString,
@@ -127,7 +126,6 @@ func nodeTaintFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The taint effect",
 			Required:    true,
-			ForceNew:    true,
 		},
 	}
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #2035

Removes the `MaxItems` line from the "taint" attribute. Should allow the ability of multiple taint blocks if desired.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`kubernetes/resource_kubernetes_node_taint.go`: Remove MaxItems from taint attribute
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
