### PR TITLE
Use actual type of input value in morpher diagnostic.

### DIFF
--- a/.changelog/2054.txt
+++ b/.changelog/2054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_manifest`: Fix a panic when constructing the diagnostic message about incompatible attribute types
+```

--- a/manifest/morph/morph.go
+++ b/manifest/morph/morph.go
@@ -278,7 +278,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 		Attribute: p,
 		Severity:  tfprotov5.DiagnosticSeverityError,
 		Summary:   "Cannot transform List value into unsupported type",
-		Detail:    fmt.Sprintf("Required type %s, but got %s\n ...at attribute\n%s", typeNameNoPrefix(t), typeNameNoPrefix(tftypes.List{}), attributePathSummary(p)),
+		Detail:    fmt.Sprintf("Required type %s, but got %s\n ...at attribute\n%s", typeNameNoPrefix(t), typeNameNoPrefix(v.Type()), attributePathSummary(p)),
 	})
 	return tftypes.Value{}, diags
 }
@@ -391,7 +391,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 		Attribute: p,
 		Severity:  tfprotov5.DiagnosticSeverityError,
 		Summary:   "Cannot transform Tuple value into unsupported type",
-		Detail:    fmt.Sprintf("Required type %s, but got %s\n ...at attribute\n%s", typeNameNoPrefix(t), typeNameNoPrefix(tftypes.Tuple{}), attributePathSummary(p)),
+		Detail:    fmt.Sprintf("Required type %s, but got %s\n ...at attribute\n%s", typeNameNoPrefix(t), typeNameNoPrefix(v.Type()), attributePathSummary(p)),
 	})
 	return tftypes.Value{}, diags
 }
@@ -492,7 +492,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 		Attribute: p,
 		Severity:  tfprotov5.DiagnosticSeverityError,
 		Summary:   "Cannot transform Set value into unsupported type",
-		Detail:    fmt.Sprintf("Required type %s, but got %s\n...at attribute:\n%s", typeNameNoPrefix(t), typeNameNoPrefix(tftypes.Set{}), attributePathSummary(p)),
+		Detail:    fmt.Sprintf("Required type %s, but got %s\n...at attribute:\n%s", typeNameNoPrefix(t), typeNameNoPrefix(v.Type()), attributePathSummary(p)),
 	})
 	return tftypes.Value{}, diags
 }
@@ -572,7 +572,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 		Attribute: p,
 		Severity:  tfprotov5.DiagnosticSeverityError,
 		Summary:   "Cannot transform Map value into unsupported type",
-		Detail:    fmt.Sprintf("Required type %s, but got %s\n...at attribute:\n%s", typeNameNoPrefix(t), typeNameNoPrefix(tftypes.Map{}), attributePathSummary(p)),
+		Detail:    fmt.Sprintf("Required type %s, but got %s\n...at attribute:\n%s", typeNameNoPrefix(t), typeNameNoPrefix(v.Type()), attributePathSummary(p)),
 	})
 	return tftypes.Value{}, diags
 }
@@ -668,7 +668,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 		Attribute: p,
 		Severity:  tfprotov5.DiagnosticSeverityError,
 		Summary:   "Failed to transform Object into unsupported type",
-		Detail:    fmt.Sprintf("Required type %s, but got %s\n...at attribute:\n%s", typeNameNoPrefix(t), typeNameNoPrefix(tftypes.Object{}), attributePathSummary(p)),
+		Detail:    fmt.Sprintf("Required type %s, but got %s\n...at attribute:\n%s", typeNameNoPrefix(t), typeNameNoPrefix(v.Type()), attributePathSummary(p)),
 	})
 	return tftypes.Value{}, diags
 }


### PR DESCRIPTION
### Description

Fixes a panic when constructing the diagnostic message if the moprher fails to find a valid converstion strategy between attribute type supplied by user config and the type dictated by the schema. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:bug
`resource/kubernetes_manifest`: Fix a panic when constructing the diagnostic message about incompatible attribute types
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
