### PR TITLE
Fix crash in manifest when configuration contains DynamicPseudotyped unknown values.

### DIFF
--- a/.changelog/2055.txt
+++ b/.changelog/2055.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_manifest`: Fix crash when manifest config contains unknown values of unknown type (DynamicPseudoType)
+```

--- a/manifest/morph/scaffold.go
+++ b/manifest/morph/scaffold.go
@@ -16,7 +16,7 @@ func DeepUnknown(t tftypes.Type, v tftypes.Value, p *tftypes.AttributePath) (tft
 		return tftypes.Value{}, fmt.Errorf("type cannot be nil")
 	}
 	if !v.IsKnown() {
-		return v, nil
+		return tftypes.NewValue(t, tftypes.UnknownValue), nil
 	}
 	switch {
 	case t.Is(tftypes.Object{}):


### PR DESCRIPTION
### Description

Fixes a crash in `kubernetes_manifest` when user configuration contains unknown values which also have unknown types, like the ones sometimes generated by the `try(...)` function.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:bug
`resource/kubernetes_manifest: Fix crash when configuration contains unknown values of unknown type (DynamicPseudoType)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
