### PR TITLE
Update EKS acceptance tests to use doormat action

### DIFF
--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -42,14 +42,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        uses: hashicorp/doormat-action@566eb1d2575eea7bc17f80710ce8077124aa1ec0 # v1
         with:
-          aws-region: ${{ github.event.inputs.region }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          role-session-name: github-actions-tests-${{ github.run_number }}
-          role-duration-seconds: 14400
+          aws-role-arn: ${{ secrets.DOORMAT_AWS_ROLE_ARN }}
       - name: Install Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:

--- a/kubernetes/test-infra/doormat/aws/iam.tf
+++ b/kubernetes/test-infra/doormat/aws/iam.tf
@@ -1,0 +1,36 @@
+provider aws {}
+
+resource "aws_iam_role" "tfprov_kubernetes_gha" {
+  name = "tfprov-kubernetes-gha"
+  tags = {
+    hc-service-uri = "github.com/hashicorp/terraform-provider-kubernetes@event_name=workflow_displatch"
+  }
+  max_session_duration = 43200 
+  assume_role_policy   = data.aws_iam_policy_document.tfprov_kubernetes_gha_assume.json
+  inline_policy {
+    name   = "AdminAccess"
+    policy = data.aws_iam_policy_document.tfprov_kubernetes_gha.json
+  }
+}
+
+data "aws_iam_policy_document" "tfprov_kubernetes_gha_assume" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:SetSourceIdentity",
+      "sts:TagSession"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::397512762488:user/doormatServiceUser"] # infrasec_prod
+    }
+  }
+}
+
+data "aws_iam_policy_document" "tfprov_kubernetes_gha" {
+  statement {
+    actions   = ["*"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
