### PR TITLE
Fix diff when importing podspec resources containing volume_mount

### DIFF
--- a/.changelog/2061.txt
+++ b/.changelog/2061.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix diff after import when importing resources containing volume_mount
+```

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -297,6 +297,8 @@ func flattenContainerVolumeMounts(in []v1.VolumeMount) ([]interface{}, error) {
 		if v.SubPath != "" {
 			m["sub_path"] = v.SubPath
 		}
+
+		m["mount_propagation"] = string(v1.MountPropagationNone)
 		if v.MountPropagation != nil {
 			m["mount_propagation"] = string(*v.MountPropagation)
 		}

--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -260,3 +260,63 @@ func TestExpandContainerEnv(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenContainerVolumeMounts_mountPropogation(t *testing.T) {
+	bidimode := v1.MountPropagationBidirectional
+
+	cases := []struct {
+		Input    []v1.VolumeMount
+		Expected []interface{}
+	}{
+		{
+			[]v1.VolumeMount{
+				{
+					Name:      "cache",
+					MountPath: "/cache",
+					ReadOnly:  false,
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"mount_path":        "/cache",
+					"mount_propagation": "None",
+					"name":              "cache",
+					"read_only":         false,
+				},
+			},
+		},
+		{
+			[]v1.VolumeMount{
+				{
+					Name:             "cache",
+					MountPath:        "/cache",
+					MountPropagation: &bidimode,
+					ReadOnly:         true,
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"mount_path":        "/cache",
+					"mount_propagation": "Bidirectional",
+					"name":              "cache",
+					"read_only":         true,
+				},
+			},
+		},
+		{
+			[]v1.VolumeMount{},
+			[]interface{}{},
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := flattenContainerVolumeMounts(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected failure in flattener.\nInput: %#v, error: %#v", tc.Input, err)
+		}
+		if !reflect.DeepEqual(output, tc.Expected) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.Expected, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
