### PR TITLE
Add support for `initContainers` in `kubernetes_env` resource

### DIFF
--- a/.changelog/2067.txt
+++ b/.changelog/2067.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`kubernetes/resource_kubernetes_env.go`: add support for initContainers
+```

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	k8s.io/component-base v0.25.5 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -59,12 +59,14 @@ func resourceKubernetesEnv() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "Name of the container for which we are updating the environment variables.",
 				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 				ExactlyOneOf: []string{"container", "init_container"},
 			},
 			"init_container": {
 				Type:         schema.TypeString,
 				Description:  "Name of the initContainer for which we are updating the environment variables.",
 				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 				ExactlyOneOf: []string{"container", "init_container"},
 			},
 			"api_version": {

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -60,9 +60,9 @@ func resourceKubernetesEnv() *schema.Resource {
 				Description: "Name of the container for which we are updating the environment variables.",
 				Required:    true,
 			},
-			"initContainer": {
+			"init_container": {
 				Type:        schema.TypeBool,
-				Description: "Specifies that the environment variables will be set for an initContainer",
+				Description: "Specifies that the environment variables will be set for an initcontainer",
 				Optional:    true,
 				Default:     false,
 			},
@@ -372,7 +372,7 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 	apiVersion := d.Get("api_version").(string)
 	kind := d.Get("kind").(string)
-	initContainer := d.Get("initContainer").(bool)
+	init_container := d.Get("init_container").(bool)
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	name := metadata.GetName()
 	namespace := metadata.GetNamespace()
@@ -433,7 +433,7 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	var spec map[string]interface{}
-	if !initContainer {
+	if !init_container {
 		spec = map[string]interface{}{
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -457,14 +457,16 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 		env = []map[string]interface{}{}
 	}
 
-	containerSpec := map[string]interface{}{
-		"name": d.Get("container"),
-		"env":  env,
-	}
 	containersField := "containers"
+	containerName := d.Get("container")
 	if v := d.Get("init_container").(string); v != "" {
-		containerSpec["name"] = v
 		containersField = "initContainers"
+		containerName = v
+	}
+
+	containerSpec := map[string]interface{}{
+		"name": containerName,
+		"env":  env,
 	}
 
 	spec := map[string]interface{}{

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -60,6 +60,11 @@ func resourceKubernetesEnv() *schema.Resource {
 				Description: "Name of the container for which we are updating the environment variables.",
 				Required:    true,
 			},
+			"initContainer": {
+				Type:        schema.TypeString,
+				Description: "Name of the container for which we are updating the environment variables.",
+				Optional:    true,
+			},
 			"api_version": {
 				Type:        schema.TypeString,
 				Description: "Resource API version",
@@ -434,6 +439,12 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 						"env":  env,
 					},
 				},
+				"initContainers": []interface{}{
+					map[string]interface{}{
+						"name": d.Get("container").(string),
+						"env":  env,
+					},
+				},
 			},
 		},
 	}
@@ -447,6 +458,12 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 							"containers": []interface{}{
 								map[string]interface{}{
 									"name": d.Get("container").(string),
+									"env":  env,
+								},
+							},
+							"initContainers": []interface{}{
+								map[string]interface{}{
+									"name": d.Get("initContainers").(string),
 									"env":  env,
 								},
 							},

--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -458,15 +458,14 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	var spec map[string]interface{}
+	var containerSpec = map[string]interface{}{"env": env}
 	if container := d.Get("container").(string); container != "" {
+		containerSpec["name"] = container
 		spec = map[string]interface{}{
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{
 					"containers": []interface{}{
-						map[string]interface{}{
-							"name": container,
-							"env":  env,
-						},
+						containerSpec,
 					},
 				},
 			},
@@ -480,10 +479,7 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 						"template": map[string]interface{}{
 							"spec": map[string]interface{}{
 								"containers": []interface{}{
-									map[string]interface{}{
-										"name": container,
-										"env":  env,
-									},
+									containerSpec,
 								},
 							},
 						},
@@ -492,14 +488,12 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 			}
 		}
 	} else {
+		containerSpec["name"] = d.Get("init_container").(string)
 		spec = map[string]interface{}{
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{
 					"initContainers": []interface{}{
-						map[string]interface{}{
-							"name": d.Get("init_container").(string),
-							"env":  env,
-						},
+						containerSpec,
 					},
 				},
 			},
@@ -513,10 +507,7 @@ func resourceKubernetesEnvUpdate(ctx context.Context, d *schema.ResourceData, m 
 						"template": map[string]interface{}{
 							"spec": map[string]interface{}{
 								"initContainers": []interface{}{
-									map[string]interface{}{
-										"name": d.Get("init_container").(string),
-										"env":  env,
-									},
+									containerSpec,
 								},
 							},
 						},

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -15,6 +15,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utils "k8s.io/utils/pointer"
 )
 
 func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
@@ -427,26 +428,26 @@ func createCronJobInitContainerEnv(t *testing.T, name, namespace string) error {
 	}
 	ctx := context.Background()
 
-	var failJobLimit int32 = 5
-	var startingDeadlineSeconds int64 = 2
-	var successfulJobsLimit int32 = 2
-	var boLimit int32 = 2
-	var ttl int32 = 2
+	var failJobLimit *int32 = utils.Int32(2)
+	var startingDeadlineSeconds *int64 = utils.Int64(2)
+	var successfulJobsLimit *int32 = utils.Int32(2)
+	var boLimit *int32 = utils.Int32(2)
+	var ttl *int32 = utils.Int32(2)
 	var cronjob batchv1.CronJob = batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 		Spec: batchv1.CronJobSpec{
-			StartingDeadlineSeconds:    &startingDeadlineSeconds,
-			FailedJobsHistoryLimit:     &failJobLimit,
-			SuccessfulJobsHistoryLimit: &successfulJobsLimit,
+			StartingDeadlineSeconds:    startingDeadlineSeconds,
+			FailedJobsHistoryLimit:     failJobLimit,
+			SuccessfulJobsHistoryLimit: successfulJobsLimit,
 			ConcurrencyPolicy:          "Replace",
 			Schedule:                   "1 0 * * *",
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					BackoffLimit:            &boLimit,
-					TTLSecondsAfterFinished: &ttl,
+					BackoffLimit:            boLimit,
+					TTLSecondsAfterFinished: ttl,
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							RestartPolicy: "Never",
@@ -694,9 +695,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  init_container = "hello"
-  api_version    = "apps/v1"
-  kind           = "Deployment"
+  init_container   = "hello"
+  api_version = "apps/v1"
+  kind        = "Deployment"
   metadata {
     name      = %q
     namespace = %q
@@ -882,9 +883,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "demo" {
-  init_container = "nginx"
-  api_version    = "batch/v1"
-  kind           = "CronJob"
+  init_container   = "nginx"
+  api_version = "batch/v1"
+  kind        = "CronJob"
   metadata {
     name      = "%s"
     namespace = "%s"
@@ -948,9 +949,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  init_container = "hello"
-  api_version    = "apps/v1"
-  kind           = "Deployment"
+  init_container   = "hello"
+  api_version = "apps/v1"
+  kind        = "Deployment"
   metadata {
     name      = %q
     namespace = %q
@@ -1013,9 +1014,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "demo" {
-  init_container = "nginx"
-  api_version    = "batch/v1"
-  kind           = "CronJob"
+  init_container   = "nginx"
+  api_version = "batch/v1"
+  kind        = "CronJob"
   metadata {
     name      = "%s"
     namespace = "%s"

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -695,9 +695,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  init_container   = "hello"
-  api_version = "apps/v1"
-  kind        = "Deployment"
+  init_container = "hello"
+  api_version    = "apps/v1"
+  kind           = "Deployment"
   metadata {
     name      = %q
     namespace = %q
@@ -883,9 +883,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "demo" {
-  init_container   = "nginx"
-  api_version = "batch/v1"
-  kind        = "CronJob"
+  init_container = "nginx"
+  api_version    = "batch/v1"
+  kind           = "CronJob"
   metadata {
     name      = "%s"
     namespace = "%s"
@@ -949,9 +949,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  init_container   = "hello"
-  api_version = "apps/v1"
-  kind        = "Deployment"
+  init_container = "hello"
+  api_version    = "apps/v1"
+  kind           = "Deployment"
   metadata {
     name      = %q
     namespace = %q
@@ -1014,9 +1014,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "demo" {
-  init_container   = "nginx"
-  api_version = "batch/v1"
-  kind        = "CronJob"
+  init_container = "nginx"
+  api_version    = "batch/v1"
+  kind           = "CronJob"
   metadata {
     name      = "%s"
     namespace = "%s"

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -28,7 +28,9 @@ func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createEnv(t, name, namespace)
+			if err := createEnv(t, name, namespace); err != nil {
+				t.Fatal(err)
+			}
 		},
 		IDRefreshName:     resourceName,
 		ProviderFactories: testAccProviderFactories,
@@ -41,7 +43,7 @@ func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesEnv_Deployment_initContainer(secretName, configMapName, name, namespace),
+				Config: testAccKubernetesEnv_DeploymentBasic(secretName, configMapName, name, namespace),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
 					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
@@ -58,7 +60,7 @@ func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesEnv_modified_initContainer(secretName, configMapName, name, namespace),
+				Config: testAccKubernetesEnv_DeploymentBasic_modified(secretName, configMapName, name, namespace),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
 					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
@@ -547,7 +549,7 @@ func confirmExistingCronJobEnvs(name, namespace string) error {
 	return err
 }
 
-func testAccKubernetesEnv_Deploymentbasic(secretName, configMapName, name, namespace string) string {
+func testAccKubernetesEnv_DeploymentBasic(secretName, configMapName, name, namespace string) string {
 	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
   metadata {
     name = "%s"
@@ -612,7 +614,7 @@ resource "kubernetes_env" "test" {
 	`, secretName, configMapName, name, namespace)
 }
 
-func testAccKubernetesEnv_modified(secretName, configMapName, name, namespace string) string {
+func testAccKubernetesEnv_DeploymentBasic_modified(secretName, configMapName, name, namespace string) string {
 	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
   metadata {
     name = "%s"

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -694,9 +694,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  init_container   = "hello"
-  api_version = "apps/v1"
-  kind        = "Deployment"
+  init_container = "hello"
+  api_version    = "apps/v1"
+  kind           = "Deployment"
   metadata {
     name      = %q
     namespace = %q
@@ -882,9 +882,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "demo" {
-  init_container   = "nginx"
-  api_version = "batch/v1"
-  kind        = "CronJob"
+  init_container = "nginx"
+  api_version    = "batch/v1"
+  kind           = "CronJob"
   metadata {
     name      = "%s"
     namespace = "%s"
@@ -948,9 +948,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  init_container   = "hello"
-  api_version = "apps/v1"
-  kind        = "Deployment"
+  init_container = "hello"
+  api_version    = "apps/v1"
+  kind           = "Deployment"
   metadata {
     name      = %q
     namespace = %q
@@ -1013,9 +1013,9 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "demo" {
-  init_container   = "nginx"
-  api_version = "batch/v1"
-  kind        = "CronJob"
+  init_container = "nginx"
+  api_version    = "batch/v1"
+  kind           = "CronJob"
   metadata {
     name      = "%s"
     namespace = "%s"

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -40,7 +40,7 @@ func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesEnv_Deploymentbasic(secretName, configMapName, name, namespace),
+				Config: testAccKubernetesEnv_Deployment_initContainer(secretName, configMapName, name, namespace),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
 					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
@@ -57,7 +57,7 @@ func TestAccKubernetesEnv_DeploymentBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesEnv_modified(secretName, configMapName, name, namespace),
+				Config: testAccKubernetesEnv_modified_initContainer(secretName, configMapName, name, namespace),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
 					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
@@ -131,6 +131,126 @@ func TestAccKubernetesEnv_CronJobBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccKubernetesEnv_Deployment_initContainer(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	namespace := "default"
+	secretName := acctest.RandomWithPrefix("tf-acc-test")
+	configMapName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kubernetes_env.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createInitContainerEnv(t, name, namespace)
+		},
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			err := confirmExistingEnvs(name, namespace)
+			if err != nil {
+				return err
+			}
+			return destroyEnv(name, namespace)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesEnv_Deployment_initContainer(secretName, configMapName, name, namespace),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "env.0.name", "NGINX_HOST"),
+					resource.TestCheckResourceAttr(resourceName, "env.0.value", "foobar.com"),
+					resource.TestCheckResourceAttr(resourceName, "env.1.name", "NGINX_PORT"),
+					resource.TestCheckResourceAttr(resourceName, "env.1.value", "90"),
+					resource.TestCheckResourceAttr(resourceName, "env.2.value_from.0.secret_key_ref.0.name", secretName),
+					resource.TestCheckResourceAttr(resourceName, "env.2.value_from.0.secret_key_ref.0.key", "one"),
+					resource.TestCheckResourceAttr(resourceName, "env.3.value_from.0.config_map_key_ref.0.name", configMapName),
+					resource.TestCheckResourceAttr(resourceName, "env.3.value_from.0.config_map_key_ref.0.key", "one"),
+					resource.TestCheckResourceAttr(resourceName, "env.#", "4"),
+				),
+			},
+			{
+				Config: testAccKubernetesEnv_modified_initContainer(secretName, configMapName, name, namespace),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "api_version", "apps/v1"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "env.0.name", "NGINX_HOST"),
+					resource.TestCheckResourceAttr(resourceName, "env.0.value", "hashicorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "env.1.value_from.0.secret_key_ref.0.name", secretName),
+					resource.TestCheckResourceAttr(resourceName, "env.1.value_from.0.secret_key_ref.0.key", "two"),
+					resource.TestCheckResourceAttr(resourceName, "env.2.value_from.0.config_map_key_ref.0.name", configMapName),
+					resource.TestCheckResourceAttr(resourceName, "env.2.value_from.0.config_map_key_ref.0.key", "three"),
+					resource.TestCheckResourceAttr(resourceName, "env.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func createInitContainerEnv(t *testing.T, name, namespace string) error {
+	conn, err := testAccProvider.Meta().(kubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	var deploy appsv1.Deployment = appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "terraform",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "terraform",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+							Env: []v1.EnvVar{
+								{
+									Name:  "TEST",
+									Value: "123",
+								},
+							},
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Name:  "hello",
+							Image: "busybox",
+							Env: []v1.EnvVar{
+								{
+									Name:  "one",
+									Value: "123",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err = conn.AppsV1().Deployments(namespace).Create(ctx, &deploy, metav1.CreateOptions{})
+	if err != nil {
+		t.Error("could not create test deployment")
+		t.Fatal(err)
+	}
+
+	return err
 }
 
 func createEnv(t *testing.T, name, namespace string) error {
@@ -423,6 +543,68 @@ resource "kubernetes_env" "test" {
 	`, secretName, configMapName, name, namespace)
 }
 
+func testAccKubernetesEnv_modified_initContainer(secretName, configMapName, name, namespace string) string {
+	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data = {
+    one = "first"
+  }
+}
+
+resource "kubernetes_config_map" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data = {
+    one = "ONE"
+  }
+}
+
+resource "kubernetes_env" "test" {
+  container   = "hello"
+  api_version = "apps/v1"
+  init_container = true
+  kind        = "Deployment"
+  metadata {
+    name      = %q
+    namespace = %q
+  }
+  env {
+    name  = "NGINX_HOST"
+    value = "hashicorp.com"
+  }
+
+  env {
+    name = "EXPORTED_VARIABLE_FROM_SECRET"
+
+    value_from {
+      secret_key_ref {
+        name     = "${kubernetes_secret.test.metadata.0.name}"
+        key      = "two"
+        optional = true
+      }
+    }
+  }
+
+
+  env {
+    name = "EXPORTED_VARIABLE_FROM_CONFIG_MAP"
+    value_from {
+      config_map_key_ref {
+        name     = "${kubernetes_config_map.test.metadata.0.name}"
+        key      = "three"
+        optional = true
+      }
+    }
+  }
+}
+	`, secretName, configMapName, name, namespace)
+}
+
 func testAccKubernetesEnv_CronJobBasic(secretName, configMapName, name, namespace string) string {
 	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
   metadata {
@@ -546,6 +728,72 @@ resource "kubernetes_env" "demo" {
       }
     }
   }
+}
+	`, secretName, configMapName, name, namespace)
+}
+
+func testAccKubernetesEnv_Deployment_initContainer(secretName, configMapName, name, namespace string) string {
+	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data = {
+    one = "first"
+  }
+}
+
+resource "kubernetes_config_map" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data = {
+    one = "ONE"
+  }
+}
+
+resource "kubernetes_env" "test" {
+  container   = "initcontainer"
+  init_container = true
+  api_version = "apps/v1"
+  kind        = "Deployment"
+  metadata {
+    name      = %q
+    namespace = %q
+  }
+  env {
+    name  = "NGINX_HOST"
+    value = "foobar.com"
+  }
+
+  env {
+    name  = "NGINX_PORT"
+    value = "90"
+  }
+
+  env {
+    name = "EXPORTED_VARIABLE_FROM_SECRET"
+    value_from {
+      secret_key_ref {
+        name     = "${kubernetes_secret.test.metadata.0.name}"
+        key      = "one"
+        optional = true
+      }
+    }
+  }
+
+  env {
+    name = "EXPORTED_VARIABLE_FROM_CONFIG_MAP"
+    value_from {
+      config_map_key_ref {
+        name     = "${kubernetes_config_map.test.metadata.0.name}"
+        key      = "one"
+        optional = true
+      }
+    }
+  }
+
 }
 	`, secretName, configMapName, name, namespace)
 }

--- a/kubernetes/resource_kubernetes_env_test.go
+++ b/kubernetes/resource_kubernetes_env_test.go
@@ -565,9 +565,8 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  container   = "hello"
+  init_container   = "hello"
   api_version = "apps/v1"
-  init_container = true
   kind        = "Deployment"
   metadata {
     name      = %q
@@ -754,8 +753,7 @@ resource "kubernetes_config_map" "test" {
 }
 
 resource "kubernetes_env" "test" {
-  container   = "initcontainer"
-  init_container = true
+  init_container   = "hello"
   api_version = "apps/v1"
   kind        = "Deployment"
   metadata {

--- a/website/docs/r/env.html.markdown
+++ b/website/docs/r/env.html.markdown
@@ -41,7 +41,8 @@ The following arguments are supported:
 * `api_version` - (Required) The apiVersion of the resource to add environment variables to.
 * `kind` - (Required) The kind of the resource to add environment variables to.
 * `metadata` - (Required) Standard metadata of the resource to add environment variables to. 
-* `container` - (Required) Name of the container for which we are updating the environment variables.
+* `container` - (Optional) Name of the container for which we are updating the environment variables.
+* `init_container` - (Optional) Name of the initContainer for which we are updating the environment variables.
 * `env` - (Required) Value block with custom values used to represent environment variables
 * `force` - (Optional) Force management of environment variables if there is a conflict.
 * `field_manager` - (Optional) The name of the [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management). Defaults to `Terraform`.


### PR DESCRIPTION
### Description

Adds support of initContainers to `kubernetes_env`.

This feature request issue was mentioned here #723

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-kubernetes git:(add-initContainer-env) ✗ make testacc TESTARGS="-run TestAccKubernetesEnv_CronJob_initContainer"
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/mau/Dev/terraform-provider-kubernetes/kubernetes" -v -run TestAccKubernetesEnv_CronJob_initContainer -timeout 3h
=== RUN   TestAccKubernetesEnv_CronJob_initContainer
--- PASS: TestAccKubernetesEnv_CronJob_initContainer (9.37s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   9.992s
```
```
➜  terraform-provider-kubernetes git:(add-initContainer-env) make testacc TESTARGS="-run TestAccKubernetesEnv_Deployment_initContainer"
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/mau/Dev/terraform-provider-kubernetes/kubernetes" -v -run TestAccKubernetesEnv_Deployment_initContainer -timeout 3h
=== RUN   TestAccKubernetesEnv_Deployment_initContainer
--- PASS: TestAccKubernetesEnv_Deployment_initContainer (9.50s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   10.265s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`kubernetes/resource_kubernetes_env.go`: add support for initContainers
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
