### PR TITLE
Fix an issue with `kubernetes_node_taint`

### DIFF
--- a/.changelog/2077.txt
+++ b/.changelog/2077.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+`resource/kubernetes_node_taint`: Fix an issue when updating taint does not update the ID in the state file.
+
+```

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -181,7 +181,7 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 		return nil
 	}
 
-	d.SetId(nodeTaintToId(node.ObjectMeta.Name, d.Get("taint").([]interface{})))
+	d.SetId(nodeTaintToId(node.Name, d.Get("taint").([]interface{})))
 	return resourceKubernetesNodeTaintRead(ctx, d, m)
 }
 

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -10,18 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
-
-var taintMap = map[string]v1.TaintEffect{
-	"NoExecute":        v1.TaintEffectNoExecute,
-	"NoSchedule":       v1.TaintEffectNoSchedule,
-	"PreferNoSchedule": v1.TaintEffectPreferNoSchedule,
-}
 
 func resourceKubernetesNodeTaint() *schema.Resource {
 	return &schema.Resource{
@@ -172,7 +165,8 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 		FieldManager: d.Get("field_manager").(string),
 		Force:        ptrToBool(d.Get("force").(bool)),
 	}
-	if _, err := nodeApi.Patch(ctx, nodeName, types.ApplyPatchType, patchBytes, patchOpts); err != nil {
+	node, err := nodeApi.Patch(ctx, nodeName, types.ApplyPatchType, patchBytes, patchOpts)
+	if err != nil {
 		if errors.IsConflict(err) {
 			return diag.Diagnostics{{
 				Severity: diag.Error,
@@ -186,11 +180,12 @@ func resourceKubernetesNodeTaintUpdate(ctx context.Context, d *schema.ResourceDa
 	if d.Id() == "" {
 		return nil
 	}
+
+	d.SetId(nodeTaintToId(node.ObjectMeta.Name, d.Get("taint").([]interface{})))
 	return resourceKubernetesNodeTaintRead(ctx, d, m)
 }
 
-func nodeTaintToId(nodeName string, taints []interface{}) string {
-	var id string = fmt.Sprintf("%s", nodeName)
+func nodeTaintToId(id string, taints []interface{}) string {
 	for _, t := range taints {
 		taint := t.(map[string]interface{})
 		id += fmt.Sprintf(",%s=%s:%s", taint["key"], taint["value"], taint["effect"])


### PR DESCRIPTION
### Description

Fix an issue when updating taint in the `kubernetes_node_taint` resource does not update the ID in the state file.

### Acceptance tests

- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS="-count 1 -run ^TestAccKubernetesResourceNodeTaint"

=== RUN   TestAccKubernetesResourceNodeTaint_basic
--- PASS: TestAccKubernetesResourceNodeTaint_basic (2.17s)
=== RUN   TestAccKubernetesResourceNodeTaint_MultipleBasic
--- PASS: TestAccKubernetesResourceNodeTaint_MultipleBasic (4.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	7.864s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:bug
`resource/kubernetes_node_taint`: Fix an issue when updating taint does not update the ID in the state file.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
