### PR TITLE
Fix tests for HPAv2Beta2 since it is unavailable in 1.26

### DIFF
--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2beta2_test.go
@@ -23,6 +23,7 @@ func TestAccKubernetesHorizontalPodAutoscalerV2Beta2_minimal(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			skipIfClusterVersionLessThan(t, "1.23.0")
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.26.0")
 		},
 		IDRefreshName:     resourceName,
 		ProviderFactories: testAccProviderFactories,
@@ -59,7 +60,11 @@ func TestAccKubernetesHorizontalPodAutoscalerV2Beta2_basic(t *testing.T) {
 	resourceName := "kubernetes_horizontal_pod_autoscaler_v2beta2.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.23.0")
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.26.0")
+		},
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,
@@ -177,7 +182,11 @@ func TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource(t *testin
 	resourceName := "kubernetes_horizontal_pod_autoscaler_v2beta2.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.23.0")
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.26.0")
+		},
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,


### PR DESCRIPTION
### Description

Fix HPAv2Beta2 tests since it is unavailable in 1.26.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS="-count 1 -run ^TestAccKubernetesHorizontalPodAutoscalerV2Beta2"

=== RUN   TestAccKubernetesHorizontalPodAutoscalerV2Beta2_minimal
    provider_test.go:236: This test does not run on cluster versions 1.26.0 and above
--- SKIP: TestAccKubernetesHorizontalPodAutoscalerV2Beta2_minimal (0.02s)
=== RUN   TestAccKubernetesHorizontalPodAutoscalerV2Beta2_basic
    provider_test.go:236: This test does not run on cluster versions 1.26.0 and above
--- SKIP: TestAccKubernetesHorizontalPodAutoscalerV2Beta2_basic (0.00s)
=== RUN   TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource
    provider_test.go:236: This test does not run on cluster versions 1.26.0 and above
--- SKIP: TestAccKubernetesHorizontalPodAutoscalerV2Beta2_containerResource (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	1.298s
...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
