### PR TITLE
Adding a Runtime class resource

### DIFF
--- a/.changelog/2080.txt
+++ b/.changelog/2080.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+`resource/kubernetes_runtime_class_v1`: Add a new resource `kubernetes_runtime_class_v1`.
+```

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -345,6 +345,9 @@ func Provider() *schema.Provider {
 
 			// authentication
 			"kubernetes_token_request_v1": resourceKubernetesTokenRequestV1(),
+
+			//node
+			"kubernetes_runtime_class_v1": resourceKubernetesRuntimeClassV1(),
 		},
 	}
 

--- a/kubernetes/resource_kubernetes_runtime_class_v1.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1.go
@@ -1,0 +1,110 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package kubernetes
+
+import (
+	"context"
+	// "fmt"
+	"log"
+	"regexp"
+	// "time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	//"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	nodev1 "k8s.io/api/node/v1"
+	// api "k8s.io/api/core/v1"
+	// "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// pkgApi "k8s.io/apimachinery/pkg/types"
+)
+
+func resourceKubernetesRuntimeClassV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKubernetesRuntimeClassV1Create,
+		ReadContext:   resourceKubernetesRuntimeClassV1Read,
+		UpdateContext: resourceKubernetesRuntimeClassV1Update,
+		DeleteContext: resourceKubernetesRuntimeClassV1Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"metadata": metadataSchema("runtimeclass", true),
+			// "overhead": {
+			// 	Type:        schema.TypeMap,
+			// 	Description: "Represents the esource overhead associated with running a pod for a given RuntimeClass",
+			// },
+			// "scheduling": {
+			// 	Type:        schema.TypeMap,
+			// 	Description: "Holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it",
+			// },
+			"handler": {
+				Type:         schema.TypeString,
+				Description:  "Specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class",
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?`), ""),
+			},
+		},
+	}
+}
+
+func resourceKubernetesRuntimeClassV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	//converting metadata for resource -> HCL for TF
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+
+	runtimeClass := nodev1.RuntimeClass{
+		ObjectMeta: metadata,
+		Handler:    d.Get("handler").(string), //returns the string from handler
+	}
+
+	out, err := conn.NodeV1().RuntimeClasses().Create(ctx, &runtimeClass, metav1.CreateOptions{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] New runtime class created: %#v", out)
+	//d.SetID(out.Name)
+
+	return nil
+}
+
+func resourceKubernetesRuntimeClassV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// if err != nil {
+	// 	return diag.FromErr(err)
+	// }
+	// if !exists {
+	// 	d.SetId("")
+	// 	return diags
+	// }
+	// conn, err := meta.(KubeClientsets).MainClientset()
+	// if err != nil {
+	// 	return diag.FromErr(err)
+	// }
+	return nil
+}
+
+func resourceKubernetesRuntimeClassV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// conn, err := meta.(KubeClientsets).MainClientset()
+	// if err != nil {
+	// 	return diag.FromErr(err)
+	// }
+	// diags := diag.Diagnostics{}
+
+	// exists, err := resourceKubernetesStorageClassExists(ctx, d, meta)
+
+	return nil
+}
+
+func resourceKubernetesRuntimeClassV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}

--- a/kubernetes/resource_kubernetes_runtime_class_v1.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1.go
@@ -5,9 +5,10 @@ package kubernetes
 
 import (
 	"context"
-	// "fmt"
+	//"fmt"
 	"log"
 	"regexp"
+
 	// "time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -16,10 +17,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	nodev1 "k8s.io/api/node/v1"
+
 	// api "k8s.io/api/core/v1"
 	// "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	// pkgApi "k8s.io/apimachinery/pkg/types"
+	pkgApi "k8s.io/apimachinery/pkg/types"
 )
 
 func resourceKubernetesRuntimeClassV1() *schema.Resource {
@@ -48,9 +51,11 @@ func resourceKubernetesRuntimeClassV1() *schema.Resource {
 				Description:  "Specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class",
 				Required:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?`), ""),
+				ForceNew:     true,
 			},
 		},
 	}
+
 }
 
 func resourceKubernetesRuntimeClassV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -73,38 +78,115 @@ func resourceKubernetesRuntimeClassV1Create(ctx context.Context, d *schema.Resou
 	}
 
 	log.Printf("[INFO] New runtime class created: %#v", out)
-	//d.SetID(out.Name)
+	d.SetId(out.Name) //id of resource used in the state file, not a namespace refers to its name of the resource
 
-	return nil
+	return resourceKubernetesRuntimeClassV1Read(ctx, d, meta) //create & read goes hand in hand basically
 }
 
 func resourceKubernetesRuntimeClassV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// if err != nil {
-	// 	return diag.FromErr(err)
-	// }
-	// if !exists {
-	// 	d.SetId("")
-	// 	return diags
-	// }
-	// conn, err := meta.(KubeClientsets).MainClientset()
-	// if err != nil {
-	// 	return diag.FromErr(err)
-	// }
+	exists, err := resourceKubernetesRuntimeClassV1Exists(ctx, d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if !exists {
+		d.SetId("")
+		return diag.Diagnostics{}
+	}
+
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Id()
+
+	log.Printf("[INFO] Reading Run Time Class %s", name)
+	rc, err := conn.NodeV1().RuntimeClasses().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Received Run Time Class: %#v", rc)
+	err = d.Set("metadata", flattenMetadata(rc.ObjectMeta, d, meta))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("handler", rc.Handler)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
 func resourceKubernetesRuntimeClassV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// conn, err := meta.(KubeClientsets).MainClientset()
-	// if err != nil {
-	// 	return diag.FromErr(err)
-	// }
-	// diags := diag.Diagnostics{}
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	// exists, err := resourceKubernetesStorageClassExists(ctx, d, meta)
+	name := d.Id()
+
+	patch := patchMetadata("metadata.0.", "/metadata/", d)
+
+	data, err := patch.MarshalJSON()
+	if err != nil {
+		return diag.Errorf("Failed to marshal update operations: %s", err)
+	}
+
+	log.Printf("[INFO] Updating run time class %s: %#v", d.Id(), patch)
+
+	out, err := conn.NodeV1().RuntimeClasses().Patch(ctx, name, pkgApi.JSONPatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return diag.Errorf("Failed to update run time class! API error: %s", err)
+	}
+
+	log.Printf("[INFO] Submitted updated run time class: %#v", out)
+	d.SetId(out.Name)
+
+	return resourceKubernetesRuntimeClassV1Read(ctx, d, meta)
+}
+
+func resourceKubernetesRuntimeClassV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Id()
+
+	log.Printf("[INFO] RunTimeClass: %#v", name)
+	err = conn.NodeV1().RuntimeClasses().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+	log.Printf("[INFO] RunTimeClass %s deleted", name)
 
 	return nil
 }
 
-func resourceKubernetesRuntimeClassV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil
+// trying to get resource, if we get an error then we know it doesnt exists
+func resourceKubernetesRuntimeClassV1Exists(ctx context.Context, d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
+
+	name := d.Id()
+
+	log.Printf("[INFO] Checking Run Time Class %s", name)
+	_, err = conn.NodeV1().RuntimeClasses().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return false, nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+	}
+
+	return true, err
 }

--- a/kubernetes/resource_kubernetes_runtime_class_v1_test.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAccKubernetesruntime_class_basic(t *testing.T) {
+	var conf nodev1.RuntimeClass
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_runtime_class.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		//CheckDestroy:      testAccCheckKubernetesRuntimeClassDestroy,
+		Steps: []resource.TestStep{
+			//creating a run time class
+			{
+				Config: testAccKubernetesSecretConfig_immutable(rcName, true, "password"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesruntime_classExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rcName),
+					resource.TestCheckResourceAttr(resourceName, "immutable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesruntime_classExists(n string, obj *nodev1.RuntimeClass) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+		ctx := context.TODO()
+
+		out, err := conn.NodeV1().RuntimeClasses().Get(ctx, rs.Primary.ID, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		*obj = *out
+		return nil
+	}
+}

--- a/kubernetes/resource_kubernetes_runtime_class_v1_test.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1_test.go
@@ -41,11 +41,11 @@ func TestAccKubernetesruntime_class_v1_basic(t *testing.T) {
 
 func testAccKubernetesruntime_class_v1(name string) string {
 	return fmt.Sprintf(`resource "kubernetes_runtime_class_v1" "test" {
-		metadata {
-		  name = %q
-		}
-		handler = "myclass" 
-	}
+  metadata {
+    name = %q
+  }
+  handler = "myclass"
+}
 	`, name)
 }
 

--- a/kubernetes/resource_kubernetes_runtime_class_v1_test.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1_test.go
@@ -15,10 +15,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAccKubernetesruntime_class_basic(t *testing.T) {
+func TestAccKubernetesruntime_class_v1_basic(t *testing.T) {
 	var conf nodev1.RuntimeClass
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	resourceName := "kubernetes_runtime_class.test"
+	resourceName := "kubernetes_runtime_class_v1.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -29,15 +29,24 @@ func TestAccKubernetesruntime_class_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			//creating a run time class
 			{
-				Config: testAccKubernetesSecretConfig_immutable(rcName, true, "password"),
+				Config: testAccKubernetesruntime_class_v1(rcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesruntime_classExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rcName),
-					resource.TestCheckResourceAttr(resourceName, "immutable", "true"),
 				),
 			},
 		},
 	})
+}
+
+func testAccKubernetesruntime_class_v1(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_runtime_class_v1" "test" {
+		metadata {
+		  name = %q
+		}
+		handler = "runc" 
+	}
+	`, name)
 }
 
 func testAccCheckKubernetesruntime_classExists(n string, obj *nodev1.RuntimeClass) resource.TestCheckFunc {

--- a/kubernetes/resource_kubernetes_runtime_class_v1_test.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1_test.go
@@ -32,6 +32,7 @@ func TestAccKubernetesruntime_class_v1_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesruntime_class_v1Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rcName),
+					resource.TestCheckResourceAttr(resourceName, "handler", "myclass"),
 				),
 			},
 			{
@@ -49,6 +50,7 @@ func TestAccKubernetesruntime_class_v1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.annotations.TestAnnotationTwo", "two"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rcName),
+					resource.TestCheckResourceAttr(resourceName, "handler", "newclass"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
@@ -65,6 +67,7 @@ func TestAccKubernetesruntime_class_v1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelOne", "one"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.labels.TestLabelTwo", "two"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", rcName),
+					resource.TestCheckResourceAttr(resourceName, "handler", "my-class"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
@@ -107,8 +110,8 @@ func testAccKubernetesruntime_class_v1_addLabels(name string) string {
     }
 
     labels = {
-      TestLabelOne   = "one"
-      TestLabelTwo   = "two"
+      TestLabelOne = "one"
+      TestLabelTwo = "two"
     }
     name = %q
   }

--- a/kubernetes/resource_kubernetes_runtime_class_v1_test.go
+++ b/kubernetes/resource_kubernetes_runtime_class_v1_test.go
@@ -44,7 +44,7 @@ func testAccKubernetesruntime_class_v1(name string) string {
 		metadata {
 		  name = %q
 		}
-		handler = "runc" 
+		handler = "myclass" 
 	}
 	`, name)
 }

--- a/website/docs/r/runtime_class_v1.html.markdown
+++ b/website/docs/r/runtime_class_v1.html.markdown
@@ -19,7 +19,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard role's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `handler` - (Required) Specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class
-[Kubernetes reference] (https://kubernetes.io/docs/concepts/containers/runtime-class/)
+[Kubernetes reference](https://kubernetes.io/docs/concepts/containers/runtime-class/)
 
 ## Nested Blocks
 

--- a/website/docs/r/runtime_class_v1.html.markdown
+++ b/website/docs/r/runtime_class_v1.html.markdown
@@ -1,18 +1,55 @@
 ---
 layout: "kubernetes"
-subcategory: "rbac/v1"
+subcategory: "node/v1"
 page_title: "Kubernetes: kubernetes_runtime_class_v1"
 description: |-
-  A is used to determine which container runtime is used to run all containers in a pod. 
+  A runtime class is used to determine which container runtime is used to run all containers in a pod. 
 ---
 
 # kubernetes_runtime_class_v1
 
-A is used to determine which container runtime is used to run all containers in a pod.
+A runtime class is used to determine which container runtime is used to run all containers in a pod.
 
 
 ## Example usage
 
 ## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard role's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+* `handler` - (Required) Specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class
+[Kubernetes reference] (https://kubernetes.io/docs/concepts/containers/runtime-class/)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the role that may be used to store arbitrary metadata.
+
+~> By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](hhttps://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the role. **Must match `selector`**.
+
+~> By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+
+* `name` - (Optional) Name of the role, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this role that can be used by clients to determine when role has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
+* `uid` - The unique in time and space value for this role. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+## Import
+
+Runtime class can be imported using the name only, e.g.
+
+```
+$ terraform import kubernetes_runtime_class_v1.example myclass
+```
 
 

--- a/website/docs/r/runtime_class_v1.html.markdown
+++ b/website/docs/r/runtime_class_v1.html.markdown
@@ -13,6 +13,15 @@ A runtime class is used to determine which container runtime is used to run all 
 
 ## Example usage
 
+```hcl
+resource "kubernetes_runtime_class_v1" "example" {
+  metadata {
+    name = "myclass"
+  }
+  handler = "abcdeagh"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/runtime_class_v1.html.markdown
+++ b/website/docs/r/runtime_class_v1.html.markdown
@@ -1,0 +1,18 @@
+---
+layout: "kubernetes"
+subcategory: "rbac/v1"
+page_title: "Kubernetes: kubernetes_runtime_class_v1"
+description: |-
+  A is used to determine which container runtime is used to run all containers in a pod. 
+---
+
+# kubernetes_runtime_class_v1
+
+A is used to determine which container runtime is used to run all containers in a pod.
+
+
+## Example usage
+
+## Argument Reference
+
+


### PR DESCRIPTION
### Description

Added a runtime class resource (with handler attribute only for now) & wrote test file that asserts for only the `creating a runtime class` step

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-count 1 -run ^TestAccKubernetesruntime_class_v1_basic"

TF_ACC=1 go test "/Users/sacha/Documents/code/hashicorp/terraform-provider-kubernetes/kubernetes" -v -count 1 -run ^TestAccKubernetesruntime_class_v1_basic -timeout 3h
=== RUN   TestAccKubernetesruntime_class_v1_basic
--- PASS: TestAccKubernetesruntime_class_v1_basic (5.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	6.160s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:new-resource
`resource/kubernetes_runtime_class_v1`: Add a new resource `kubernetes_runtime_class_v1`.
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1114

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
