### PR TITLE
remove defaultSecret warning message

### DIFF
--- a/.changelog/2085.txt
+++ b/.changelog/2085.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`kubernetes/resource_kubernetes_service_account.go`: Remove `default_secret_name` warning
+```

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -180,20 +180,6 @@ func findDefaultServiceAccount(ctx context.Context, sa *api.ServiceAccount, conn
 	*/
 	ds := make([]string, 0)
 
-	sv, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
-	if err != nil {
-		return "", diag.FromErr(err)
-	}
-	if sv {
-		return "", diag.Diagnostics{
-			diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  `"default_secret_name" is no longer applicable for Kubernetes v1.24.0 and above`,
-				Detail:   `Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, "default_secret_name" will be empty`,
-			},
-		}
-	}
-
 	for _, saSecret := range sa.Secrets {
 		if !strings.HasPrefix(saSecret.Name, fmt.Sprintf("%s-token-", sa.Name)) {
 			log.Printf("[DEBUG] Skipping %s as it doesn't have the right name", saSecret.Name)
@@ -317,20 +303,6 @@ func resourceKubernetesServiceAccountRead(ctx context.Context, d *schema.Resourc
 	err = d.Set("secret", secrets)
 	if err != nil {
 		return diag.FromErr(err)
-	}
-
-	sv, err := serverVersionGreaterThanOrEqual(conn, "1.24.0")
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if sv {
-		return diag.Diagnostics{
-			diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  `"default_secret_name" is no longer applicable for Kubernetes v1.24.0 and above`,
-				Detail:   `Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, "default_secret_name" will be empty`,
-			},
-		}
 	}
 
 	return nil


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #1990

Removes the unnecessary message when wanting to use `default_secret_name`

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`kubernetes/resource_kubernetes_service_account.go`: Remove `default_secret_name` warning
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
