### PR TITLE
Add support for Generic Ephemeral Volumes

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -1037,7 +1037,43 @@ func volumeSchema(isUpdatable bool) *schema.Resource {
 			},
 		},
 	}
+
+	v["ephemeral"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "Represents a generic ephemeral Volume. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes",
+		Optional:    true,
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"volume_claim_template": {
+					Type:        schema.TypeList,
+					Description: "A template for the ephemeral Volume",
+					Optional:    true,
+					MaxItems:    1,
+					Elem: &schema.Resource{
+						Schema: volumeClaimTemplateFields(),
+					},
+				},
+			},
+		},
+	}
+
 	return &schema.Resource{
 		Schema: v,
+	}
+}
+
+func volumeClaimTemplateFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": namespacedMetadataSchemaIsTemplate("persistent volume claim", false, true),
+		"spec": {
+			Type:        schema.TypeList,
+			Description: "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims",
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: persistentVolumeClaimSpecFields(),
+			},
+		},
 	}
 }


### PR DESCRIPTION
### Description

Adds support for [Generic Ephemeral Volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) to Pod (and therefore to Deployment, StatefulSet, DaemonSet, Job, CronJob, etc).

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
```release-note
Add generic ephemeral volume support to `pod.spec.volume`. That affects all resources and data sources that use `pod.spec.volume` directly or as a template.
```

### References

Closes #2032 

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
