### PR TITLE
kubernetes_node_taint: don't fail if node is missing

### DIFF
--- a/.changelog/2099.txt
+++ b/.changelog/2099.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+`resource/kubernetes_node_taint`: Don't fail when there is a taint in the state file for a node that no longer exists.
+
+```

--- a/kubernetes/resource_kubernetes_node_taint.go
+++ b/kubernetes/resource_kubernetes_node_taint.go
@@ -100,6 +100,14 @@ func resourceKubernetesNodeTaintRead(ctx context.Context, d *schema.ResourceData
 
 	conn, err := m.(KubeClientsets).MainClientset()
 	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			// The node is gone so the resource should be deleted.
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "Node has been deleted",
+				Detail:   fmt.Sprintf("The underlying node %q has been deleted. You should remove it from your configuration.", nodeName),
+			}}
+		}
 		return diag.FromErr(err)
 	}
 	nodeApi := conn.CoreV1().Nodes()


### PR DESCRIPTION
### Description

Show a warning instead of an error if a tainted node is missing. Otherwise taints for deleted nodes can only be removed via `terraform state rm`.

Closes #2100 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestTestAccKubernetesResourceNodeTaint'
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/home/mwilder/src/go/src/github.com/partcyborg/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesResourceNodeTaint -timeout 3h
=== RUN   TestAccKubernetesResourceNodeTaint_basic
--- PASS: TestAccKubernetesResourceNodeTaint_basic (15.58s)
=== RUN   TestAccKubernetesResourceNodeTaint_MultipleBasic
--- PASS: TestAccKubernetesResourceNodeTaint_MultipleBasic (37.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	52.599s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
`resource/kubernetes_node_taint`: Don't fail when there is a taint in the state file for a node that no longer exists.
```

### References


### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
