### PR TITLE
Adds support for waiting for default service account in ns resource

### DIFF
--- a/.changelog/2119.txt
+++ b/.changelog/2119.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+`kubernetes/resource_kubernetes_namespace.go`: Add attribute `wait_for_default_service_account` to namespaces which will force Terraform to wait until the default service account has been created by Kubernetes on namespace creation.
+```

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -64,12 +64,7 @@ func resourceKubernetesNamespaceCreate(ctx context.Context, d *schema.ResourceDa
 
 	if d.Get("wait_for_default_service_account").(bool) {
 		log.Printf("[DEBUG] Waiting for default service account to be created")
-		// FIXME: Since the creation of the Default ServiceAccount is asynchronous to the Namespace
-		// We need to wait some period of time, using something like d.Timeout(schema.TimeoutCreate)
-		// is not long enough for a Kind cluster to pass without timing out (about 10 seconds).
-		// Using an undefined word here forces the timeout to use the defaultTimeout of 20mins.
-		// I do not consider this production ready.
-		err = resource.RetryContext(ctx, d.Timeout("FIXME"), func() *resource.RetryError {
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			_, err := conn.CoreV1().ServiceAccounts(out.Name).Get(ctx, "default", metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -64,7 +64,12 @@ func resourceKubernetesNamespaceCreate(ctx context.Context, d *schema.ResourceDa
 
 	if d.Get("wait_for_default_service_account").(bool) {
 		log.Printf("[DEBUG] Waiting for default service account to be created")
-		err = resource.RetryContext(ctx, d.Timeout("foo"), func() *resource.RetryError {
+		// FIXME: Since the creation of the Default ServiceAccount is asynchronous to the Namespace
+		// We need to wait some period of time, using something like d.Timeout(schema.TimeoutCreate)
+		// is not long enough for a Kind cluster to pass without timing out (about 10 seconds).
+		// Using an undefined word here forces the timeout to use the defaultTimeout of 20mins.
+		// I do not consider this production ready.
+		err = resource.RetryContext(ctx, d.Timeout("FIXME"), func() *resource.RetryError {
 			_, err := conn.CoreV1().ServiceAccounts(out.Name).Get(ctx, "default", metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -122,7 +122,7 @@ func TestAccKubernetesNamespace_default_service_account(t *testing.T) {
 		CheckDestroy:      testAccCheckKubernetesSecretDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesNamespaceConfig_basic(nsName),
+				Config: testAccKubernetesNamespaceConfig_wait_for_default_service_acccount(nsName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesNamespaceExists("kubernetes_namespace.test", &nsConf),
 					testAccCheckKubernetesDefaultServiceAccountExists(resourceName, &saConf),
@@ -383,6 +383,16 @@ func testAccKubernetesNamespaceConfig_deleteTimeout(nsName string) string {
   timeouts {
     delete = "30m"
   }
+}
+`, nsName)
+}
+
+func testAccKubernetesNamespaceConfig_wait_for_default_service_acccount(nsName string) string {
+	return fmt.Sprintf(`resource "kubernetes_namespace" "test" {
+  metadata {
+    name = "%s"
+  }
+  wait_for_default_service_account = true
 }
 `, nsName)
 }

--- a/website/docs/d/namespace.html.markdown
+++ b/website/docs/d/namespace.html.markdown
@@ -54,3 +54,11 @@ The following arguments are supported:
 #### Attributes
 
 * `finalizers` - An opaque list of values that must be empty to permanently remove object from storage. For more info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+
+## Attribute Reference
+
+* `wait_for_default_service_account` - (Optional) When set to `true` Terraform will wait until the
+default service account has been asynchronously created by Kubernetes when creating the namespace resource.
+This has the equivalent effect of creating a `resource_kubernetes_default_service_account` resource for dependent resources
+but allows a user to consume the "default" service account directly.
+The default behaviour (`false`) does not wait for the default service account to exist.


### PR DESCRIPTION
We are experiencing some flaky tests over in `hashicorp/vault-secrets-operator` in our project when running on low resource CI systems where we experience a race between the creation of a namespace resource and the ability to reference the `default` serviceaccount that Kubernetes creates for every namespace. The result is that the namespace is created by tf and dependent resources on the namespace (which also depend on the default serviceaccount) will fail to be created.

Some example code which we've seen hit this issue:
```
resource "kubernetes_namespace" "tenant-1" {
  metadata {
    name = var.k8s_test_namespace
  }
}

resource "kubernetes_secret" "default-sa-secret" {
  metadata {
    namespace = kubernetes_namespace.tenant-1.metadata[0].name
    name      = "default-sa-secret"
    annotations = {
      "kubernetes.io/service-account.name" = "default"
    }
  }
  type                           = "kubernetes.io/service-account-token"
  wait_for_service_account_token = true
}
```
This results in tests that fail like:
```
estVaultAuthMethods 2023-05-17T14:25:47Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1; ╷
│ Error: secrets "default-sa-secret" not found
│ 
│   with kubernetes_secret.default-sa,
│   on main.tf line 39, in resource "kubernetes_secret" "default-sa":
│   39: resource "kubernetes_secret" "default-sa" {
│ 
╵}
    apply.go:15: 
        	Error Trace:	/home/runner/go/pkg/mod/github.com/gruntwork-io/terratest@v0.41.19/modules/terraform/apply.go:15
        	            				/home/runner/work/vault-secrets-operator/vault-secrets-operator/test/integration/vaultauthmethods_integration_test.go:91
        	Error:      	Received unexpected error:
        	            	FatalError{Underlying: error while running command: exit status 1; ╷
        	            	│ Error: secrets "default-sa-secret" not found
        	            	│ 
        	            	│   with kubernetes_secret.default-sa,
        	            	│   on main.tf line 39, in resource "kubernetes_secret" "default-sa":
        	            	│   39: resource "kubernetes_secret" "default-sa" {
        	            	│ 
        	            	╵}
        	Test:       	TestVaultAuthMethods
```

The reason that it fails is that kubernetes will refuse to create a Secret which references a serviceaccount via annotation when the serviceaccount does not exist.

This is similar to https://github.com/hashicorp/terraform-provider-kubernetes/issues/1943

Some workarounds which do work
* Deploy your own namespace+serviceaccount+secret and not use the `default` serviceaccount.
* Successfully used the `kubernetes_default_service_account` resource to provide the expected behaviour.

We've also attempted to use `data` [to reference the default service account](https://github.com/hashicorp/vault-secrets-operator/pull/208/commits/f80a1edae9c54b04db1c7410fed2ed98347a9a51) but it also hits the same issue:
```
https://github.com/hashicorp/vault-secrets-operator/actions/runs/5082362220/jobs/9132077465
│ Error: Unable to fetch service account from Kubernetes: serviceaccounts "default" not found
│ 
│   with data.kubernetes_service_account.default,
│   on variables.tf line 4, in data "kubernetes_service_account" "default":
│    4: data "kubernetes_service_account" "default" {
│ 
╵}
    apply.go:15: 
        	Error Trace:	/home/runner/go/pkg/mod/github.com/gruntwork-io/terratest@v0.41.25/modules/terraform/apply.go:15
        	            				/home/runner/work/vault-secrets-operator/vault-secrets-operator/test/integration/vaultauthmethods_integration_test.go:93
        	Error:      	Received unexpected error:
        	            	FatalError{Underlying: error while running command: exit status 1; ╷
        	            	│ Error: Unable to fetch service account from Kubernetes: serviceaccounts "default" not found
        	            	│ 
        	            	│   with data.kubernetes_service_account.default,
        	            	│   on variables.tf line 4, in data "kubernetes_service_account" "default":
        	            	│    4: data "kubernetes_service_account" "default" {
        	            	│ 
        	            	╵}
```

This PR adds the optional ability to wait for the default service account to be created by Kubernetes when creating a namespace resource:

```
resource "kubernetes_namespace" "test" {
  metadata {
    name = "%s"
  }
  wait_for_default_service_account = true
}
```

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
demo $ KUBE_CONFIG_PATH=~/.kube/config make testacc TESTARGS='-run=TestAccKubernetesNamespace'
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/kyle/go/src/github.com/kschoche/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesNamespace -timeout 3h
=== RUN   TestAccKubernetesNamespace_basic
--- PASS: TestAccKubernetesNamespace_basic (13.60s)
=== RUN   TestAccKubernetesNamespace_default_service_account
--- PASS: TestAccKubernetesNamespace_default_service_account (8.78s)
=== RUN   TestAccKubernetesNamespace_generatedName
--- PASS: TestAccKubernetesNamespace_generatedName (8.18s)
=== RUN   TestAccKubernetesNamespace_withSpecialCharacters
--- PASS: TestAccKubernetesNamespace_withSpecialCharacters (7.91s)
=== RUN   TestAccKubernetesNamespace_deleteTimeout
--- PASS: TestAccKubernetesNamespace_deleteTimeout (7.91s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   47.057s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds `wait_for_default_service_account` to namespace resource which will wait for the `default` kubernetes serviceaccount to be created by Kubernetes.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
