### PR TITLE
Supported `Succeeded` and `Failed` states in Target Pods

### DIFF
--- a/.changelog/2141.txt
+++ b/.changelog/2141.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`kubernetes/resource_kubernetes_pod.go`: Add `legacy_lifecycle_states` attribute
+```

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -56,10 +56,10 @@ func resourceKubernetesPodSchemaV1() map[string]*schema.Schema {
 				Schema: podSpecFields(false, false),
 			},
 		},
-		"updated_target": {
+		"legacy_lifecycle_states": {
 			Type:     schema.TypeBool,
 			Optional: true,
-			Default:  false,
+			Default:  true,
 		},
 	}
 }
@@ -93,7 +93,7 @@ func resourceKubernetesPodCreate(ctx context.Context, d *schema.ResourceData, me
 
 	target := []string{"Running"}
 
-	if d.Get("updated_target").(bool) == true {
+	if d.Get("legacy_lifecycle_states").(bool) != true {
 		target = []string{"Running", "Succeeded", "Failed"}
 	}
 

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -56,6 +56,11 @@ func resourceKubernetesPodSchemaV1() map[string]*schema.Schema {
 				Schema: podSpecFields(false, false),
 			},
 		},
+		"updated_target": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 	}
 }
 
@@ -86,8 +91,14 @@ func resourceKubernetesPodCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(buildId(out.ObjectMeta))
 
+	target := []string{"Running"}
+
+	if d.Get("updated_target").(bool) == true {
+		target = []string{"Running", "Succeeded", "Failed"}
+	}
+
 	stateConf := &resource.StateChangeConf{
-		Target:  []string{"Running"},
+		Target:  target,
 		Pending: []string{"Pending"},
 		Timeout: d.Timeout(schema.TimeoutCreate),
 		Refresh: func() (interface{}, string, error) {

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -57,9 +57,10 @@ func resourceKubernetesPodSchemaV1() map[string]*schema.Schema {
 			},
 		},
 		"legacy_lifecycle_states": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
+			Type:        schema.TypeBool,
+			Description: "Setting this attribute to `false` would set the target pod lifecycle state as [\"Running\", \"Succeeded\", \"Failed\"]. The default value of `true` would leave the target pod lifecycle state as [\"Running\"]`.",
+			Optional:    true,
+			Default:     true,
 		},
 	}
 }

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -169,6 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
+* `legacy_lifecycle_states` - (Optional) Default is `true`, sets the states that are used in a pod lifecycle.
 
 ## Nested Blocks
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
-* `legacy_lifecycle_states` - (Optional) Default is `true`, sets the states that are used in a pod lifecycle.
+* `legacy_lifecycle_states` - (Optional) Setting this attribute to `false` would set the target pod lifecycle state as `["Running", "Succeeded", "Failed"]`. The default value of `true` would leave the target pod lifecycle state as `["Running"]`.
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Adds `updated_target` attribute flag to allow users the option to use the new target fields or not. This is more to prevent any sudden breaks from this change to users.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
kubernetes/resource_kubernetes_pod.go`: Add `legacy_lifecycle_states` attribute
```

### References

Fix: #599

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
