### PR TITLE
chore(lint): make consistent make() calls

### DIFF
--- a/kubernetes/patch_operations.go
+++ b/kubernetes/patch_operations.go
@@ -11,7 +11,7 @@ import (
 )
 
 func diffStringMap(pathPrefix string, oldV, newV map[string]interface{}) PatchOperations {
-	ops := make([]PatchOperation, 0, 0)
+	ops := make([]PatchOperation, 0)
 
 	pathPrefix = strings.TrimRight(pathPrefix, "/")
 

--- a/kubernetes/resource_kubernetes_ingress_class.go
+++ b/kubernetes/resource_kubernetes_ingress_class.go
@@ -299,7 +299,7 @@ func flattenIngressClassSpec(in networking.IngressClassSpec) []interface{} {
 }
 
 func flattenIngressClassParameters(in *networking.IngressClassParametersReference) []interface{} {
-	att := make([]interface{}, 1, 1)
+	att := make([]interface{}, 1)
 
 	m := make(map[string]interface{})
 	m["kind"] = in.Kind

--- a/kubernetes/structure_csi_driver.go
+++ b/kubernetes/structure_csi_driver.go
@@ -31,7 +31,7 @@ func expandCSIDriverSpec(l []interface{}) storage.CSIDriverSpec {
 }
 
 func expandCSIDriverVolumeLifecycleModes(l []interface{}) []storage.VolumeLifecycleMode {
-	lifecycleModes := make([]storage.VolumeLifecycleMode, 0, 0)
+	lifecycleModes := make([]storage.VolumeLifecycleMode, 0)
 	for _, lifecycleMode := range l {
 		lifecycleModes = append(lifecycleModes, storage.VolumeLifecycleMode(lifecycleMode.(string)))
 	}
@@ -55,7 +55,7 @@ func flattenCSIDriverSpec(in storage.CSIDriverSpec) ([]interface{}, error) {
 }
 
 func patchCSIDriverSpec(keyPrefix, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
-	ops := make(PatchOperations, 0, 0)
+	ops := make(PatchOperations, 0)
 	if d.HasChange(keyPrefix + "attach_required") {
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/attachRequired",

--- a/kubernetes/structure_csi_driver_v1.go
+++ b/kubernetes/structure_csi_driver_v1.go
@@ -31,7 +31,7 @@ func expandCSIDriverV1Spec(l []interface{}) storage.CSIDriverSpec {
 }
 
 func expandCSIDriverV1VolumeLifecycleModes(l []interface{}) []storage.VolumeLifecycleMode {
-	lifecycleModes := make([]storage.VolumeLifecycleMode, 0, 0)
+	lifecycleModes := make([]storage.VolumeLifecycleMode, 0)
 	for _, lifecycleMode := range l {
 		lifecycleModes = append(lifecycleModes, storage.VolumeLifecycleMode(lifecycleMode.(string)))
 	}
@@ -55,7 +55,7 @@ func flattenCSIDriverV1Spec(in storage.CSIDriverSpec) ([]interface{}, error) {
 }
 
 func patchCSIDriverV1Spec(keyPrefix, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
-	ops := make(PatchOperations, 0, 0)
+	ops := make(PatchOperations, 0)
 	if d.HasChange(keyPrefix + "attach_required") {
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/attachRequired",

--- a/kubernetes/structure_endpoints.go
+++ b/kubernetes/structure_endpoints.go
@@ -75,7 +75,7 @@ func expandEndpointsSubsets(in *schema.Set) []api.EndpointSubset {
 }
 
 func flattenEndpointsAddresses(in []api.EndpointAddress) *schema.Set {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		if n.Hostname != "" {
@@ -91,7 +91,7 @@ func flattenEndpointsAddresses(in []api.EndpointAddress) *schema.Set {
 }
 
 func flattenEndpointsPorts(in []api.EndpointPort) *schema.Set {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		if n.Name != "" {
@@ -105,7 +105,7 @@ func flattenEndpointsPorts(in []api.EndpointPort) *schema.Set {
 }
 
 func flattenEndpointsSubsets(in []api.EndpointSubset) *schema.Set {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		if len(n.Addresses) > 0 {

--- a/kubernetes/structure_endpointslice.go
+++ b/kubernetes/structure_endpointslice.go
@@ -120,7 +120,7 @@ func expandEndpointSliceCondition(in []interface{}) api.EndpointConditions {
 }
 
 func flattenEndpointSliceEndpoints(in []api.Endpoint) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, e := range in {
 		m := make(map[string]interface{})
 		if e.Hostname != nil {
@@ -165,7 +165,7 @@ func flattenEndpointSliceConditions(in api.EndpointConditions) []interface{} {
 }
 
 func flattenEndpointSlicePorts(in []api.EndpointPort) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, e := range in {
 		m := make(map[string]interface{})
 		if *e.Name != "" {

--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -12,7 +12,7 @@ import (
 // Flatteners
 
 func flattenIngressRule(in []v1beta1.IngressRule) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, r := range in {
 		m := make(map[string]interface{})
 
@@ -27,7 +27,7 @@ func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
 	if in == nil {
 		return []interface{}{}
 	}
-	pathAtts := make([]interface{}, len(in.Paths), len(in.Paths))
+	pathAtts := make([]interface{}, len(in.Paths))
 	for i, p := range in.Paths {
 		path := map[string]interface{}{
 			"path":    p.Path,
@@ -44,7 +44,7 @@ func flattenIngressRuleHttp(in *v1beta1.HTTPIngressRuleValue) []interface{} {
 }
 
 func flattenIngressBackend(in *v1beta1.IngressBackend) []interface{} {
-	att := make([]interface{}, 1, 1)
+	att := make([]interface{}, 1)
 
 	m := make(map[string]interface{})
 	m["service_name"] = in.ServiceName
@@ -78,7 +78,7 @@ func flattenIngressSpec(in v1beta1.IngressSpec) []interface{} {
 }
 
 func flattenIngressTLS(in []v1beta1.IngressTLS) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 
 	for i, v := range in {
 		m := make(map[string]interface{})
@@ -97,7 +97,7 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 	if len(l) == 0 || l[0] == nil {
 		return []v1beta1.IngressRule{}
 	}
-	obj := make([]v1beta1.IngressRule, len(l), len(l))
+	obj := make([]v1beta1.IngressRule, len(l))
 	for i, n := range l {
 		cfg := n.(map[string]interface{})
 
@@ -109,7 +109,7 @@ func expandIngressRule(l []interface{}) []v1beta1.IngressRule {
 				http := h.(map[string]interface{})
 				if v, ok := http["path"]; ok {
 					pathList := v.([]interface{})
-					paths = make([]v1beta1.HTTPIngressPath, len(pathList), len(pathList))
+					paths = make([]v1beta1.HTTPIngressPath, len(pathList))
 					for i, path := range pathList {
 						p := path.(map[string]interface{})
 						hip := v1beta1.HTTPIngressPath{
@@ -183,7 +183,7 @@ func expandIngressTLS(l []interface{}) []v1beta1.IngressTLS {
 		return nil
 	}
 
-	tlsList := make([]v1beta1.IngressTLS, len(l), len(l))
+	tlsList := make([]v1beta1.IngressTLS, len(l))
 	for i, t := range l {
 		in := t.(map[string]interface{})
 		obj := v1beta1.IngressTLS{}
@@ -204,7 +204,7 @@ func expandIngressTLS(l []interface{}) []v1beta1.IngressTLS {
 // Patch Ops
 
 func patchIngressSpec(keyPrefix, pathPrefix string, d *schema.ResourceData) PatchOperations {
-	ops := make([]PatchOperation, 0, 0)
+	ops := make([]PatchOperation, 0)
 	if d.HasChange(keyPrefix + "backend") {
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "backend",

--- a/kubernetes/structure_ingress_spec_v1.go
+++ b/kubernetes/structure_ingress_spec_v1.go
@@ -13,7 +13,7 @@ import (
 // Flatteners
 
 func flattenIngressV1Rule(in []networking.IngressRule) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, r := range in {
 		m := make(map[string]interface{})
 
@@ -28,7 +28,7 @@ func flattenIngressV1RuleHttp(in *networking.HTTPIngressRuleValue) []interface{}
 	if in == nil {
 		return []interface{}{}
 	}
-	pathAtts := make([]interface{}, len(in.Paths), len(in.Paths))
+	pathAtts := make([]interface{}, len(in.Paths))
 	for i, p := range in.Paths {
 		path := map[string]interface{}{
 			"path":    p.Path,
@@ -105,7 +105,7 @@ func flattenIngressV1Spec(in networking.IngressSpec) []interface{} {
 }
 
 func flattenIngressV1TLS(in []networking.IngressTLS) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 
 	for i, v := range in {
 		m := make(map[string]interface{})
@@ -124,7 +124,7 @@ func expandIngressV1Rule(l []interface{}) []networking.IngressRule {
 	if len(l) == 0 || l[0] == nil {
 		return []networking.IngressRule{}
 	}
-	obj := make([]networking.IngressRule, len(l), len(l))
+	obj := make([]networking.IngressRule, len(l))
 	for i, n := range l {
 		cfg := n.(map[string]interface{})
 
@@ -136,7 +136,7 @@ func expandIngressV1Rule(l []interface{}) []networking.IngressRule {
 				http := h.(map[string]interface{})
 				if v, ok := http["path"]; ok {
 					pathList := v.([]interface{})
-					paths = make([]networking.HTTPIngressPath, len(pathList), len(pathList))
+					paths = make([]networking.HTTPIngressPath, len(pathList))
 					for i, path := range pathList {
 						p := path.(map[string]interface{})
 						t := networking.PathType(p["path_type"].(string))
@@ -242,7 +242,7 @@ func expandIngressV1TLS(l []interface{}) []networking.IngressTLS {
 		return nil
 	}
 
-	tlsList := make([]networking.IngressTLS, len(l), len(l))
+	tlsList := make([]networking.IngressTLS, len(l))
 	for i, t := range l {
 		in := t.(map[string]interface{})
 		obj := networking.IngressTLS{}
@@ -263,7 +263,7 @@ func expandIngressV1TLS(l []interface{}) []networking.IngressTLS {
 // Patch Ops
 
 func patchIngressV1Spec(keyPrefix, pathPrefix string, d *schema.ResourceData) PatchOperations {
-	ops := make([]PatchOperation, 0, 0)
+	ops := make([]PatchOperation, 0)
 	if d.HasChange(keyPrefix + "backend") {
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "backend",

--- a/kubernetes/structure_label_selector.go
+++ b/kubernetes/structure_label_selector.go
@@ -22,7 +22,7 @@ func flattenLabelSelector(in *metav1.LabelSelector) []interface{} {
 }
 
 func flattenLabelSelectorRequirement(in []metav1.LabelSelectorRequirement) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["key"] = n.Key
@@ -54,7 +54,7 @@ func expandLabelSelectorRequirement(l []interface{}) []metav1.LabelSelectorRequi
 	if len(l) == 0 || l[0] == nil {
 		return []metav1.LabelSelectorRequirement{}
 	}
-	obj := make([]metav1.LabelSelectorRequirement, len(l), len(l))
+	obj := make([]metav1.LabelSelectorRequirement, len(l))
 	for i, n := range l {
 		in := n.(map[string]interface{})
 		obj[i] = metav1.LabelSelectorRequirement{

--- a/kubernetes/structure_network_policy.go
+++ b/kubernetes/structure_network_policy.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -30,7 +30,7 @@ func flattenNetworkPolicySpec(in v1.NetworkPolicySpec) []interface{} {
 }
 
 func flattenNetworkPolicyIngress(in []v1.NetworkPolicyIngressRule) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, ingress := range in {
 		m := make(map[string]interface{})
 		if ingress.Ports != nil && len(ingress.Ports) > 0 {
@@ -45,7 +45,7 @@ func flattenNetworkPolicyIngress(in []v1.NetworkPolicyIngressRule) []interface{}
 }
 
 func flattenNetworkPolicyEgress(in []v1.NetworkPolicyEgressRule) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, egress := range in {
 		m := make(map[string]interface{})
 		if egress.Ports != nil && len(egress.Ports) > 0 {
@@ -60,7 +60,7 @@ func flattenNetworkPolicyEgress(in []v1.NetworkPolicyEgressRule) []interface{} {
 }
 
 func flattenNetworkPolicyPorts(in []v1.NetworkPolicyPort) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, port := range in {
 		m := make(map[string]interface{})
 		if port.Port != nil {
@@ -75,7 +75,7 @@ func flattenNetworkPolicyPorts(in []v1.NetworkPolicyPort) []interface{} {
 }
 
 func flattenNetworkPolicyPeer(in []v1.NetworkPolicyPeer) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, peer := range in {
 		m := make(map[string]interface{})
 		if peer.IPBlock != nil {
@@ -141,7 +141,7 @@ func expandNetworkPolicySpec(in []interface{}) (*v1.NetworkPolicySpec, error) {
 }
 
 func expandNetworkPolicyIngress(l []interface{}) (*[]v1.NetworkPolicyIngressRule, error) {
-	ingresses := make([]v1.NetworkPolicyIngressRule, len(l), len(l))
+	ingresses := make([]v1.NetworkPolicyIngressRule, len(l))
 	for i, ingress := range l {
 		if ingress == nil {
 			continue
@@ -170,7 +170,7 @@ func expandNetworkPolicyIngress(l []interface{}) (*[]v1.NetworkPolicyIngressRule
 }
 
 func expandNetworkPolicyEgress(l []interface{}) (*[]v1.NetworkPolicyEgressRule, error) {
-	egresses := make([]v1.NetworkPolicyEgressRule, len(l), len(l))
+	egresses := make([]v1.NetworkPolicyEgressRule, len(l))
 	for i, egress := range l {
 		if egress == nil {
 			continue
@@ -199,7 +199,7 @@ func expandNetworkPolicyEgress(l []interface{}) (*[]v1.NetworkPolicyEgressRule, 
 }
 
 func expandNetworkPolicyPorts(l []interface{}) (*[]v1.NetworkPolicyPort, error) {
-	policyPorts := make([]v1.NetworkPolicyPort, len(l), len(l))
+	policyPorts := make([]v1.NetworkPolicyPort, len(l))
 	for i, port := range l {
 		in, ok := port.(map[string]interface{})
 		if !ok {
@@ -218,7 +218,7 @@ func expandNetworkPolicyPorts(l []interface{}) (*[]v1.NetworkPolicyPort, error) 
 }
 
 func expandNetworkPolicyPeer(l []interface{}) (*[]v1.NetworkPolicyPeer, error) {
-	policyPeers := make([]v1.NetworkPolicyPeer, len(l), len(l))
+	policyPeers := make([]v1.NetworkPolicyPeer, len(l))
 	for i, peer := range l {
 		if peer == nil {
 			continue
@@ -263,7 +263,7 @@ func expandIPBlock(l []interface{}) (*v1.IPBlock, error) {
 }
 
 func expandNetworkPolicyTypes(l []interface{}) (*[]v1.PolicyType, error) {
-	policyTypes := make([]v1.PolicyType, 0, 0)
+	policyTypes := make([]v1.PolicyType, 0)
 	for _, policyType := range l {
 		policyTypes = append(policyTypes, v1.PolicyType(policyType.(string)))
 	}
@@ -273,7 +273,7 @@ func expandNetworkPolicyTypes(l []interface{}) (*[]v1.PolicyType, error) {
 // Patchers
 
 func patchNetworkPolicySpec(keyPrefix, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
-	ops := make(PatchOperations, 0, 0)
+	ops := make(PatchOperations, 0)
 	if d.HasChange(keyPrefix + "ingress") {
 		oldV, _ := d.GetChange(keyPrefix + "ingress")
 		ingress, err := expandNetworkPolicyIngress(d.Get(keyPrefix + "ingress").([]interface{}))

--- a/kubernetes/structure_pod_security_policy_spec.go
+++ b/kubernetes/structure_pod_security_policy_spec.go
@@ -81,7 +81,7 @@ func flattenPodSecurityPolicySpec(in v1beta1.PodSecurityPolicySpec) []interface{
 }
 
 func flattenAllowedFlexVolumes(in []v1beta1.AllowedFlexVolume) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = map[string]interface{}{
@@ -93,7 +93,7 @@ func flattenAllowedFlexVolumes(in []v1beta1.AllowedFlexVolume) []interface{} {
 }
 
 func flattenAllowedHostPaths(in []v1beta1.AllowedHostPath) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = map[string]interface{}{
@@ -106,7 +106,7 @@ func flattenAllowedHostPaths(in []v1beta1.AllowedHostPath) []interface{} {
 }
 
 func flattenListOfStrings(in []string) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = v
@@ -116,7 +116,7 @@ func flattenListOfStrings(in []string) []interface{} {
 }
 
 func flattenAllowedProcMountTypes(in []v1.ProcMountType) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = fmt.Sprintf("%v", v)
@@ -135,7 +135,7 @@ func flattenFSGroup(in v1beta1.FSGroupStrategyOptions) []interface{} {
 }
 
 func flattenIDRangeSlice(in []v1beta1.IDRange) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = map[string]interface{}{
@@ -148,7 +148,7 @@ func flattenIDRangeSlice(in []v1beta1.IDRange) []interface{} {
 }
 
 func flattenHostPortRangeSlice(in []v1beta1.HostPortRange) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = map[string]interface{}{
@@ -200,7 +200,7 @@ func flattenSupplementalGroups(in v1beta1.SupplementalGroupsStrategyOptions) []i
 }
 
 func flattenFSTypes(in []v1beta1.FSType) []interface{} {
-	result := make([]interface{}, len(in), len(in))
+	result := make([]interface{}, len(in))
 
 	for k, v := range in {
 		result[k] = fmt.Sprintf("%v", v)
@@ -312,7 +312,7 @@ func expandPodSecurityPolicySpec(in []interface{}) (v1beta1.PodSecurityPolicySpe
 }
 
 func expandAllowedFlexVolumeSlice(in []interface{}) []v1beta1.AllowedFlexVolume {
-	result := make([]v1beta1.AllowedFlexVolume, len(in), len(in))
+	result := make([]v1beta1.AllowedFlexVolume, len(in))
 	for k, v := range in {
 		result[k] = v1beta1.AllowedFlexVolume{
 			Driver: v.(string),
@@ -322,7 +322,7 @@ func expandAllowedFlexVolumeSlice(in []interface{}) []v1beta1.AllowedFlexVolume 
 }
 
 func expandAllowedHostPathSlice(in []interface{}) []v1beta1.AllowedHostPath {
-	result := make([]v1beta1.AllowedHostPath, len(in), len(in))
+	result := make([]v1beta1.AllowedHostPath, len(in))
 	for k, v := range in {
 		if m, ok := v.(map[string]interface{}); ok {
 			hp := v1beta1.AllowedHostPath{
@@ -340,7 +340,7 @@ func expandAllowedHostPathSlice(in []interface{}) []v1beta1.AllowedHostPath {
 }
 
 func expandAllowedProcMountTypes(in []interface{}) []v1.ProcMountType {
-	result := make([]v1.ProcMountType, len(in), len(in))
+	result := make([]v1.ProcMountType, len(in))
 
 	for k, v := range in {
 		result[k] = v1.ProcMountType(v.(string))
@@ -366,7 +366,7 @@ func expandFSGroup(in []interface{}) v1beta1.FSGroupStrategyOptions {
 }
 
 func expandIDRangeSlice(in []interface{}) []v1beta1.IDRange {
-	result := make([]v1beta1.IDRange, len(in), len(in))
+	result := make([]v1beta1.IDRange, len(in))
 
 	for k, v := range in {
 		if m, ok := v.(map[string]interface{}); ok {
@@ -381,7 +381,7 @@ func expandIDRangeSlice(in []interface{}) []v1beta1.IDRange {
 }
 
 func expandHostPortRangeSlice(in []interface{}) []v1beta1.HostPortRange {
-	result := make([]v1beta1.HostPortRange, len(in), len(in))
+	result := make([]v1beta1.HostPortRange, len(in))
 
 	for k, v := range in {
 		if m, ok := v.(map[string]interface{}); ok {
@@ -484,7 +484,7 @@ func expandSupplementalGroup(in []interface{}) v1beta1.SupplementalGroupsStrateg
 }
 
 func expandVolumeFSTypeSlice(in []interface{}) []v1beta1.FSType {
-	result := make([]v1beta1.FSType, len(in), len(in))
+	result := make([]v1beta1.FSType, len(in))
 	for k, v := range in {
 		if s, ok := v.(string); ok {
 			result[k] = v1beta1.FSType(s)
@@ -497,7 +497,7 @@ func expandVolumeFSTypeSlice(in []interface{}) []v1beta1.FSType {
 // Patchers
 
 func patchPodSecurityPolicySpec(keyPrefix string, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
-	ops := make(PatchOperations, 0, 0)
+	ops := make(PatchOperations, 0)
 
 	if d.HasChange(keyPrefix + "allow_privilege_escalation") {
 		ops = append(ops, &ReplaceOperation{

--- a/kubernetes/structure_service_spec.go
+++ b/kubernetes/structure_service_spec.go
@@ -13,7 +13,7 @@ import (
 // Flatteners
 
 func flattenServicePort(in []v1.ServicePort) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["app_protocol"] = n.AppProtocol
@@ -29,7 +29,7 @@ func flattenServicePort(in []v1.ServicePort) []interface{} {
 }
 
 func flattenIPFamilies(in []v1.IPFamily) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		att[i] = string(n)
 	}
@@ -122,7 +122,7 @@ func flattenServiceSpec(in v1.ServiceSpec) []interface{} {
 }
 
 func flattenLoadBalancerStatus(in v1.LoadBalancerStatus) []interface{} {
-	out := make([]interface{}, len(in.Ingress), len(in.Ingress))
+	out := make([]interface{}, len(in.Ingress))
 	for i, ingress := range in.Ingress {
 		att := make(map[string]interface{})
 
@@ -145,7 +145,7 @@ func expandServicePort(l []interface{}, removeNodePort bool) []v1.ServicePort {
 	if len(l) == 0 || l[0] == nil {
 		return []v1.ServicePort{}
 	}
-	obj := make([]v1.ServicePort, len(l), len(l))
+	obj := make([]v1.ServicePort, len(l))
 	for i, n := range l {
 		cfg := n.(map[string]interface{})
 		obj[i] = v1.ServicePort{
@@ -172,7 +172,7 @@ func expandIPFamilies(l []interface{}) []v1.IPFamily {
 	if l[0] == nil {
 		return []v1.IPFamily{}
 	}
-	obj := make([]v1.IPFamily, len(l), len(l))
+	obj := make([]v1.IPFamily, len(l))
 	for i, n := range l {
 		obj[i] = v1.IPFamily(n.(string))
 	}
@@ -287,7 +287,7 @@ func expandServiceSpec(l []interface{}) v1.ServiceSpec {
 // Patch Ops
 
 func patchServiceSpec(keyPrefix, pathPrefix string, d *schema.ResourceData, kv *gversion.Version) (PatchOperations, error) {
-	ops := make([]PatchOperation, 0, 0)
+	ops := make([]PatchOperation, 0)
 
 	if d.HasChange(keyPrefix + "allocate_load_balancer_node_ports") {
 		ops = append(ops, &ReplaceOperation{

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -68,7 +68,7 @@ func expandMetadata(in []interface{}) metav1.ObjectMeta {
 }
 
 func patchMetadata(keyPrefix, pathPrefix string, d *schema.ResourceData) PatchOperations {
-	ops := make([]PatchOperation, 0, 0)
+	ops := make([]PatchOperation, 0)
 	if d.HasChange(keyPrefix + "annotations") {
 		oldV, newV := d.GetChange(keyPrefix + "annotations")
 		diffOps := diffStringMap(pathPrefix+"annotations", oldV.(map[string]interface{}), newV.(map[string]interface{}))
@@ -110,7 +110,7 @@ func expandStringMapToByteMap(m map[string]interface{}) map[string][]byte {
 }
 
 func expandStringSlice(s []interface{}) []string {
-	result := make([]string, len(s), len(s))
+	result := make([]string, len(s))
 	for k, v := range s {
 		// Handle the Terraform parser bug which turns empty strings in lists to nil.
 		if v == nil {
@@ -263,7 +263,7 @@ func ptrToInt64(i int64) *int64 {
 }
 
 func sliceOfString(slice []interface{}) []string {
-	result := make([]string, len(slice), len(slice))
+	result := make([]string, len(slice))
 	for i, s := range slice {
 		result[i] = s.(string)
 	}
@@ -332,7 +332,7 @@ func expandMapToResourceList(m map[string]interface{}) (*api.ResourceList, error
 }
 
 func flattenPersistentVolumeAccessModes(in []api.PersistentVolumeAccessMode) *schema.Set {
-	var out = make([]interface{}, len(in), len(in))
+	var out = make([]interface{}, len(in))
 	for i, v := range in {
 		out[i] = string(v)
 	}
@@ -340,7 +340,7 @@ func flattenPersistentVolumeAccessModes(in []api.PersistentVolumeAccessMode) *sc
 }
 
 func expandPersistentVolumeAccessModes(s []interface{}) []api.PersistentVolumeAccessMode {
-	out := make([]api.PersistentVolumeAccessMode, len(s), len(s))
+	out := make([]api.PersistentVolumeAccessMode, len(s))
 	for i, v := range s {
 		out[i] = api.PersistentVolumeAccessMode(v.(string))
 	}
@@ -389,7 +389,7 @@ func expandResourceQuotaSpec(s []interface{}) (*api.ResourceQuotaSpec, error) {
 }
 
 func flattenResourceQuotaScopes(in []api.ResourceQuotaScope) *schema.Set {
-	out := make([]string, len(in), len(in))
+	out := make([]string, len(in))
 	for i, scope := range in {
 		out[i] = string(scope)
 	}
@@ -397,7 +397,7 @@ func flattenResourceQuotaScopes(in []api.ResourceQuotaScope) *schema.Set {
 }
 
 func expandResourceQuotaScopes(s []interface{}) []api.ResourceQuotaScope {
-	out := make([]api.ResourceQuotaScope, len(s), len(s))
+	out := make([]api.ResourceQuotaScope, len(s))
 	for i, scope := range s {
 		out[i] = api.ResourceQuotaScope(scope.(string))
 	}
@@ -420,7 +420,7 @@ func expandResourceQuotaScopeSelector(s []interface{}) *api.ScopeSelector {
 }
 
 func expandResourceQuotaScopeSelectorMatchExpressions(s []interface{}) []api.ScopedResourceSelectorRequirement {
-	out := make([]api.ScopedResourceSelectorRequirement, len(s), len(s))
+	out := make([]api.ScopedResourceSelectorRequirement, len(s))
 
 	for i, raw := range s {
 		matchExp := raw.(map[string]interface{})
@@ -471,14 +471,14 @@ func flattenResourceQuotaScopeSelectorMatchExpressions(in []api.ScopedResourceSe
 }
 
 func newStringSet(f schema.SchemaSetFunc, in []string) *schema.Set {
-	var out = make([]interface{}, len(in), len(in))
+	var out = make([]interface{}, len(in))
 	for i, v := range in {
 		out[i] = v
 	}
 	return schema.NewSet(f, out)
 }
 func newInt64Set(f schema.SchemaSetFunc, in []int64) *schema.Set {
-	var out = make([]interface{}, len(in), len(in))
+	var out = make([]interface{}, len(in))
 	for i, v := range in {
 		out[i] = int(v)
 	}
@@ -515,7 +515,7 @@ func expandLimitRangeSpec(s []interface{}, isNew bool) (*api.LimitRangeSpec, err
 	m := s[0].(map[string]interface{})
 
 	if limits, ok := m["limit"].([]interface{}); ok {
-		newLimits := make([]api.LimitRangeItem, len(limits), len(limits))
+		newLimits := make([]api.LimitRangeItem, len(limits))
 
 		for i, l := range limits {
 			lrItem := api.LimitRangeItem{}
@@ -586,7 +586,7 @@ func flattenLimitRangeSpec(in api.LimitRangeSpec) []interface{} {
 	}
 
 	out := make([]interface{}, 1)
-	limits := make([]interface{}, len(in.Limits), len(in.Limits))
+	limits := make([]interface{}, len(in.Limits))
 
 	for i, l := range in.Limits {
 		m := make(map[string]interface{}, 0)
@@ -745,7 +745,7 @@ func expandNodeSelectorTerm(l []interface{}) *api.NodeSelectorTerm {
 }
 
 func flattenNodeSelectorTerms(in []api.NodeSelectorTerm) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		att[i] = flattenNodeSelectorTerm(n)[0]
 	}
@@ -756,7 +756,7 @@ func expandNodeSelectorTerms(l []interface{}) []api.NodeSelectorTerm {
 	if len(l) == 0 || l[0] == nil {
 		return []api.NodeSelectorTerm{}
 	}
-	obj := make([]api.NodeSelectorTerm, len(l), len(l))
+	obj := make([]api.NodeSelectorTerm, len(l))
 	for i, n := range l {
 		obj[i] = *expandNodeSelectorTerm([]interface{}{n})
 	}
@@ -764,7 +764,7 @@ func expandNodeSelectorTerms(l []interface{}) []api.NodeSelectorTerm {
 }
 
 func flattenPersistentVolumeMountOptions(in []string) *schema.Set {
-	var out = make([]interface{}, len(in), len(in))
+	var out = make([]interface{}, len(in))
 	for i, v := range in {
 		out[i] = string(v)
 	}

--- a/kubernetes/structures_affinity.go
+++ b/kubernetes/structures_affinity.go
@@ -5,7 +5,7 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // Flatteners
@@ -70,7 +70,7 @@ func flattenPodAntiAffinity(in *v1.PodAntiAffinity) []interface{} {
 }
 
 func flattenWeightedPodAffinityTerms(in []v1.WeightedPodAffinityTerm) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["weight"] = int(n.Weight)
@@ -81,7 +81,7 @@ func flattenWeightedPodAffinityTerms(in []v1.WeightedPodAffinityTerm) []interfac
 }
 
 func flattenPodAffinityTerms(in []v1.PodAffinityTerm) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["namespaces"] = newStringSet(schema.HashString, n.Namespaces)
@@ -106,7 +106,7 @@ func flattenNodeSelector(in *v1.NodeSelector) []interface{} {
 }
 
 func flattenPreferredSchedulingTerm(in []v1.PreferredSchedulingTerm) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["weight"] = int(n.Weight)
@@ -185,7 +185,7 @@ func expandPreferredSchedulingTerms(t []interface{}) []v1.PreferredSchedulingTer
 	if len(t) == 0 || t[0] == nil {
 		return []v1.PreferredSchedulingTerm{}
 	}
-	obj := make([]v1.PreferredSchedulingTerm, len(t), len(t))
+	obj := make([]v1.PreferredSchedulingTerm, len(t))
 	for i, n := range t {
 		in := n.(map[string]interface{})
 		if v, ok := in["weight"].(int); ok {
@@ -214,7 +214,7 @@ func expandPodAffinityTerms(t []interface{}) []v1.PodAffinityTerm {
 	if len(t) == 0 || t[0] == nil {
 		return []v1.PodAffinityTerm{}
 	}
-	obj := make([]v1.PodAffinityTerm, len(t), len(t))
+	obj := make([]v1.PodAffinityTerm, len(t))
 	for i, n := range t {
 		in := n.(map[string]interface{})
 		if v, ok := in["label_selector"].([]interface{}); ok && len(v) > 0 {
@@ -234,7 +234,7 @@ func expandWeightedPodAffinityTerms(t []interface{}) []v1.WeightedPodAffinityTer
 	if len(t) == 0 || t[0] == nil {
 		return []v1.WeightedPodAffinityTerm{}
 	}
-	obj := make([]v1.WeightedPodAffinityTerm, len(t), len(t))
+	obj := make([]v1.WeightedPodAffinityTerm, len(t))
 	for i, n := range t {
 		in := n.(map[string]interface{})
 		if v, ok := in["weight"].(int); ok {

--- a/kubernetes/structures_certificate_signing_request.go
+++ b/kubernetes/structures_certificate_signing_request.go
@@ -22,7 +22,7 @@ func expandCertificateSigningRequestSpec(csr []interface{}) (*v1beta1.Certificat
 }
 
 func expandCertificateSigningRequestUsages(s []interface{}) []v1beta1.KeyUsage {
-	out := make([]v1beta1.KeyUsage, len(s), len(s))
+	out := make([]v1beta1.KeyUsage, len(s))
 	for i, v := range s {
 		out[i] = v1beta1.KeyUsage(v.(string))
 	}

--- a/kubernetes/structures_certificate_signing_request_v1.go
+++ b/kubernetes/structures_certificate_signing_request_v1.go
@@ -26,7 +26,7 @@ func expandCertificateSigningRequestV1Spec(csr []interface{}) (*certificates.Cer
 }
 
 func expandCertificateSigningRequestV1Usages(s []interface{}) []certificates.KeyUsage {
-	out := make([]certificates.KeyUsage, len(s), len(s))
+	out := make([]certificates.KeyUsage, len(s))
 	for i, v := range s {
 		out[i] = certificates.KeyUsage(v.(string))
 	}

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -14,7 +14,7 @@ import (
 )
 
 func flattenCapability(in []v1.Capability) []string {
-	att := make([]string, len(in), len(in))
+	att := make([]string, len(in))
 	for i, v := range in {
 		att[i] = string(v)
 	}
@@ -639,7 +639,7 @@ func expandContainerSecurityContext(l []interface{}) (*v1.SecurityContext, error
 }
 
 func expandCapabilitySlice(s []interface{}) []v1.Capability {
-	result := make([]v1.Capability, len(s), len(s))
+	result := make([]v1.Capability, len(s))
 	for k, v := range s {
 		result[k] = v1.Capability(v.(string))
 	}

--- a/kubernetes/structures_node.go
+++ b/kubernetes/structures_node.go
@@ -69,7 +69,7 @@ func flattenNodeStatus(in v1.NodeStatus) []interface{} {
 }
 
 func flattenNodeTaints(in ...v1.Taint) []interface{} {
-	out := make([]interface{}, len(in), len(in))
+	out := make([]interface{}, len(in))
 	for i, taint := range in {
 		m := make(map[string]interface{})
 		m["key"] = taint.Key

--- a/kubernetes/structures_rbac.go
+++ b/kubernetes/structures_rbac.go
@@ -130,7 +130,7 @@ func flattenRBACSubjects(in []api.Subject) []interface{} {
 }
 
 func flattenClusterRoleRules(in []api.PolicyRule) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["api_groups"] = n.APIGroups

--- a/kubernetes/structures_storage_class.go
+++ b/kubernetes/structures_storage_class.go
@@ -49,7 +49,7 @@ func expandStorageClassMatchLabelExpressions(l []interface{}) []v1.TopologySelec
 	if len(l) == 0 || l[0] == nil {
 		return []v1.TopologySelectorLabelRequirement{}
 	}
-	obj := make([]v1.TopologySelectorLabelRequirement, len(l), len(l))
+	obj := make([]v1.TopologySelectorLabelRequirement, len(l))
 	for i, n := range l {
 		in := n.(map[string]interface{})
 		obj[i] = v1.TopologySelectorLabelRequirement{
@@ -71,7 +71,7 @@ func flattenStorageClassAllowedTopologies(in []v1.TopologySelectorTerm) []interf
 }
 
 func flattenStorageClassMatchLabelExpressions(in []v1.TopologySelectorLabelRequirement) []interface{} {
-	att := make([]interface{}, len(in), len(in))
+	att := make([]interface{}, len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
 		m["key"] = n.Key

--- a/manifest/payload/to_value.go
+++ b/manifest/payload/to_value.go
@@ -138,8 +138,8 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 }
 
 func sliceToTFDynamicValue(in []interface{}, st tftypes.Type, th map[string]string, at *tftypes.AttributePath) (tftypes.Value, error) {
-	il := make([]tftypes.Value, len(in), len(in))
-	oTypes := make([]tftypes.Type, len(in), len(in))
+	il := make([]tftypes.Value, len(in))
+	oTypes := make([]tftypes.Type, len(in))
 	for k, v := range in {
 		eap := at.WithElementKeyInt(k)
 		var iv tftypes.Value
@@ -178,11 +178,11 @@ func sliceToTFListValue(in []interface{}, st tftypes.Type, th map[string]string,
 }
 
 func sliceToTFTupleValue(in []interface{}, st tftypes.Type, th map[string]string, at *tftypes.AttributePath) (tftypes.Value, error) {
-	il := make([]tftypes.Value, len(in), len(in))
-	oTypes := make([]tftypes.Type, len(in), len(in))
+	il := make([]tftypes.Value, len(in))
+	oTypes := make([]tftypes.Type, len(in))
 	ttypes := st.(tftypes.Tuple).ElementTypes
 	if len(ttypes) == 1 && len(il) > 1 {
-		ttypes = make([]tftypes.Type, len(in), len(in))
+		ttypes = make([]tftypes.Type, len(in))
 		for i := range il {
 			ttypes[i] = st.(tftypes.Tuple).ElementTypes[0]
 		}
@@ -201,7 +201,7 @@ func sliceToTFTupleValue(in []interface{}, st tftypes.Type, th map[string]string
 }
 
 func sliceToTFSetValue(in []interface{}, st tftypes.Type, th map[string]string, at *tftypes.AttributePath) (tftypes.Value, error) {
-	il := make([]tftypes.Value, len(in), len(in))
+	il := make([]tftypes.Value, len(in))
 	var oType tftypes.Type = tftypes.Type(nil)
 	for k, v := range in {
 		eap := at.WithElementKeyInt(k)


### PR DESCRIPTION
### Description

Currently the project does not use `make()` consistently. Some calls have both `length` and `capacity` equally defined, some just `length`. By default `capacity` equals to `length` ([see godoc here](https://pkg.go.dev/builtin#make)) which makes this more of a code quality improvement than a fix.

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

No new tests added. Acceptance tests do not succeed on `main` as seen on [this previous run](https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5335040748) but they fail exactly the same on this branch :)

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

None

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
