### PR TITLE
chore(ci): fix acceptance tests

### DIFF
--- a/.github/config/acceptance_tests_kind_config.yaml
+++ b/.github/config/acceptance_tests_kind_config.yaml
@@ -1,0 +1,7 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: "./.github/config/seccomp-profiles"
+    containerPath: "/var/lib/kubelet/seccomp/profiles"

--- a/.github/config/seccomp-profiles/audit.json
+++ b/.github/config/seccomp-profiles/audit.json
@@ -1,0 +1,3 @@
+{
+    "defaultAction": "SCMP_ACT_LOG"
+}

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           wait: 2m
           version: v${{ github.event.inputs.kindVersion }}
+          config: .github/config/acceptance_tests_kind_config.yaml
       - name: Run Acceptance Test Suite
         env:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -359,9 +360,11 @@ func isRunningInKind() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	labels := node.GetLabels()
-	if v, ok := labels["kubernetes.io/hostname"]; ok && v == "kind-control-plane" {
+	u, err := url.Parse(node.Spec.ProviderID)
+	if err != nil {
+		return false, err
+	}
+	if u.Scheme == "kind" {
 		return true, nil
 	}
 	return false, nil

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -317,6 +317,16 @@ func skipIfNotRunningInMinikube(t *testing.T) {
 	}
 }
 
+func skipIfNotRunningInKind(t *testing.T) {
+	isRunningInKind, err := isRunningInKind()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isRunningInKind {
+		t.Skip("The Kubernetes endpoint must come from Kind for this test to run - skipping")
+	}
+}
+
 func skipIfRunningInMinikube(t *testing.T) {
 	isInMinikube, err := isRunningInMinikube()
 	if err != nil {
@@ -339,6 +349,19 @@ func isRunningInMinikube() (bool, error) {
 
 	labels := node.GetLabels()
 	if v, ok := labels["kubernetes.io/hostname"]; ok && v == "minikube" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func isRunningInKind() (bool, error) {
+	node, err := getFirstNode()
+	if err != nil {
+		return false, err
+	}
+
+	labels := node.GetLabels()
+	if v, ok := labels["kubernetes.io/hostname"]; ok && v == "kind-control-plane" {
 		return true, nil
 	}
 	return false, nil

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -75,7 +75,7 @@ func TestAccKubernetesCronJobV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.successful_jobs_history_limit", "3"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.suspend", "false"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.job_template.0.spec.0.parallelism", "2"),
-					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.job_template.0.spec.0.backoff_limit", "0"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.job_template.0.spec.0.backoff_limit", "6"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.job_template.0.spec.0.template.0.metadata.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job_v1.test", "spec.0.job_template.0.spec.0.template.0.metadata.0.labels.%", "1"),

--- a/kubernetes/resource_kubernetes_daemonset_test.go
+++ b/kubernetes/resource_kubernetes_daemonset_test.go
@@ -293,14 +293,31 @@ func TestAccKubernetesDaemonSet_with_container_security_context_seccomp_profile(
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.type", "RuntimeDefault"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccKubernetesDaemonSet_with_container_security_context_seccomp_localhost_profile(t *testing.T) {
+	var conf appsv1.DaemonSet
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := nginxImageVersion
+	resourceName := "kubernetes_daemonset.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); skipIfNotRunningInKind(t); skipIfClusterVersionLessThan(t, "1.19.0") },
+		IDRefreshName:     "kubernetes_daemonset.test",
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesDaemonSetDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesDaemonSetConfigWithContainerSecurityContextSeccompProfileLocalhost(name, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDaemonSetExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.localhost_profile", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.localhost_profile", "profiles/audit.json"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", "profiles/audit.json"),
 				),
 			},
 		},
@@ -870,7 +887,7 @@ func testAccKubernetesDaemonSetConfigWithContainerSecurityContextSeccompProfileL
         security_context {
           seccomp_profile {
             type              = "Localhost"
-            localhost_profile = ""
+            localhost_profile = "profiles/audit.json"
           }
         }
         container {
@@ -880,7 +897,7 @@ func testAccKubernetesDaemonSetConfigWithContainerSecurityContextSeccompProfileL
           security_context {
             seccomp_profile {
               type              = "Localhost"
-              localhost_profile = ""
+              localhost_profile = "profiles/audit.json"
             }
           }
         }

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -579,9 +579,9 @@ func TestAccKubernetesDeployment_with_container_security_context_seccomp_profile
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.localhost_profile", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.localhost_profile", "profiles/audit.json"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", "profiles/audit.json"),
 				),
 			},
 		},
@@ -2149,7 +2149,7 @@ func testAccKubernetesDeploymentConfigWithContainerSecurityContextSeccompProfile
         security_context {
           seccomp_profile {
             type              = "Localhost"
-            localhost_profile = "bar"
+            localhost_profile = "profiles/audit.json"
           }
         }
         container {
@@ -2159,7 +2159,7 @@ func testAccKubernetesDeploymentConfigWithContainerSecurityContextSeccompProfile
           security_context {
             seccomp_profile {
               type              = "Localhost"
-              localhost_profile = "foo"
+              localhost_profile = "profiles/audit.json"
             }
           }
         }

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -554,7 +554,7 @@ func TestAccKubernetesDeployment_with_container_security_context_seccomp_profile
 	resourceName := "kubernetes_deployment.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t); skipIfClusterVersionLessThan(t, "1.19.0") },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
@@ -574,6 +574,22 @@ func TestAccKubernetesDeployment_with_container_security_context_seccomp_profile
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.type", "RuntimeDefault"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccKubernetesDeployment_with_container_security_context_seccomp_localhost_profile(t *testing.T) {
+	var conf appsv1.Deployment
+
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := nginxImageVersion
+	resourceName := "kubernetes_deployment.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); skipIfNotRunningInKind(t); skipIfClusterVersionLessThan(t, "1.19.0") },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesDeploymentDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContextSeccompProfileLocalhost(deploymentName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -579,9 +579,9 @@ func TestAccKubernetesDeployment_with_container_security_context_seccomp_profile
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.localhost_profile", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.security_context.0.seccomp_profile.0.localhost_profile", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", "foo"),
 				),
 			},
 		},
@@ -2149,7 +2149,7 @@ func testAccKubernetesDeploymentConfigWithContainerSecurityContextSeccompProfile
         security_context {
           seccomp_profile {
             type              = "Localhost"
-            localhost_profile = ""
+            localhost_profile = "bar"
           }
         }
         container {
@@ -2159,7 +2159,7 @@ func testAccKubernetesDeploymentConfigWithContainerSecurityContextSeccompProfile
           security_context {
             seccomp_profile {
               type              = "Localhost"
-              localhost_profile = ""
+              localhost_profile = "foo"
             }
           }
         }

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -102,7 +102,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.labels.foo", "bar"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.active_deadline_seconds", "0"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.backoff_limit", "0"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.backoff_limit", "6"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.completions", "1"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "1"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.manual_selector", "true"),

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -455,13 +455,35 @@ func TestAccKubernetesPod_with_pod_security_context_seccomp_profile(t *testing.T
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_with_pod_security_context_seccomp_localhost_profile(t *testing.T) {
+	var conf api.Pod
+
+	podName := acctest.RandomWithPrefix("tf-acc-test")
+	imageName := nginxImageVersion
+	resourceName := "kubernetes_pod.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); skipIfNotRunningInKind(t); skipIfClusterVersionLessThan(t, "1.19.0") },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
 				Config: testAccKubernetesPodConfigWithSecurityContextSeccompProfileLocalhost(podName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.security_context.0.seccomp_profile.0.localhost_profile", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.security_context.0.seccomp_profile.0.localhost_profile", "profiles/audit.json"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.security_context.0.seccomp_profile.0.type", "Localhost"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.security_context.0.seccomp_profile.0.localhost_profile", "profiles/audit.json"),
 				),
 			},
 			{
@@ -1875,7 +1897,7 @@ resource "kubernetes_pod" "test" {
     security_context {
       seccomp_profile {
         type              = "Localhost"
-        localhost_profile = ""
+        localhost_profile = "profiles/audit.json"
       }
     }
 
@@ -1885,7 +1907,7 @@ resource "kubernetes_pod" "test" {
       security_context {
         seccomp_profile {
           type              = "Localhost"
-          localhost_profile = ""
+          localhost_profile = "profiles/audit.json"
         }
       }
     }


### PR DESCRIPTION
### Description

Currently acceptance tests run against Kind are failing as seen on the previous run [here](https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5335040748/jobs/9667697623). I ran them on my fork as well with the following setups and both failed:

- [Failed run: Kind 0.17 + Terraform 1.4.0](https://github.com/thevilledev/terraform-provider-kubernetes/actions/runs/5352235064/jobs/9706944052)
- [Failed run: Kind 0.20 + Terraform 1.5.1](https://github.com/thevilledev/terraform-provider-kubernetes/actions/runs/5352236224/jobs/9706946534)

Two issues here:

- On k8s 1.25 an empty localhost seccomp profile is a no-op but errors on k8s 1.27 with `Error: localhostProfile must be set if seccompProfile type is Localhost`. Fixing it for 1.27 only makes it better for 1.25.
- Pod backoff limit is 6 by default ([see docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy)) not 0, which is why tests fail on both 1.25 and 1.27. This is one of the reasons why AKS acceptance tests ([see example run](https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5351488705/jobs/9705357914)) are failing as well.

This PR addresses the issues as follows:

- Add a sample `audit` seccomp profile to `.github/config/seccomp-profiles` as documented on [k8s docs](https://kubernetes.io/docs/tutorials/security/seccomp/#download-profiles). Happy to hear input if this is the right place to store these.
- Add a custom deployment configuration in `.github/config` for Kind, in which the seccomp profiles directory is mounted upon cluster creation.
- Use custom config in Kind GHA.
- Add methods for identifying whether a test is run against a Kind cluster. Similar methods exist for GKE, AKS, Minikube and the like already.
- Spin-off separate test for seccomp tests which require node-local seccomp policies. Run it only on Kind. Maybe this can be extended to cover other clusters as well, but I don't have any test clusters on those platforms.
- Change pod backoff limit default expectations to match documentation.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

- [Successful run: Kind 0.17 (k8s 1.25) and Terraform 1.4.0](https://github.com/thevilledev/terraform-provider-kubernetes/actions/runs/5349610352)
- [Successful run: Kind 0.20 (k8s 1.27) and Terraform 1.5.1](https://github.com/thevilledev/terraform-provider-kubernetes/actions/runs/5349692040)

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

None

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
