### PR TITLE
chore(test): enable test for TTLAfterFinished feature gate

### DIFF
--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -195,30 +195,29 @@ func TestAccKubernetesJob_update(t *testing.T) {
 	})
 }
 
-// FIXME uncomment this check when the TTLSecondsAfterFinished feature gate defaults to true
-//func TestAccKubernetesJob_ttl_seconds_after_finished(t *testing.T) {
-//	var conf api.Job
-//	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-//
-//	resource.Test(t, resource.TestCase{
-//		PreCheck:      func() { testAccPreCheck(t) },
-//		IDRefreshName: "kubernetes_job.test",
-//		IDRefreshIgnore: []string{
-//			"spec.0.selector.0.match_expressions.#",
-//		},
-//		ProviderFactories: testAccProviderFactories,
-//		CheckDestroy:      testAccCheckKubernetesJobDestroy,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccKubernetesJobConfig_ttl_seconds_after_finished(name, busyboxImageVersion),
-//				Check: resource.ComposeAggregateTestCheckFunc(
-//					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
-//					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.ttl_seconds_after_finished", "60"),
-//				),
-//			},
-//		},
-//	})
-//}
+func TestAccKubernetesJob_ttl_seconds_after_finished(t *testing.T) {
+	var conf api.Job
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_job.test",
+		IDRefreshIgnore: []string{
+			"spec.0.selector.0.match_expressions.#",
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesJobConfig_ttl_seconds_after_finished(name, busyboxImageVersion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.ttl_seconds_after_finished", "60"),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckKubernetesJobForceNew(old, new *api.Job, wantNew bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -200,7 +200,7 @@ func TestAccKubernetesJob_ttl_seconds_after_finished(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfClusterVersionLessThan(t, "1.21.0") },
 		IDRefreshName: "kubernetes_job.test",
 		IDRefreshIgnore: []string{
 			"spec.0.selector.0.match_expressions.#",


### PR DESCRIPTION
### Description

Test for feature gate `TTLAfterFinished` has been commented out since #1194.

This feature gate has been enabled by default in k8s 1.21 (in "beta" stage) and GA since k8s 1.23. See [k8s feature gates docs](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/) for reference.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccKubernetesJob_ttl_seconds_after_finished"
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/root/terraform-provider-kubernetes/kubernetes" -v -run=TestAccKubernetesJob_ttl_seconds_after_finished -timeout 3h
=== RUN   TestAccKubernetesJob_ttl_seconds_after_finished
--- PASS: TestAccKubernetesJob_ttl_seconds_after_finished (19.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	19.959s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

None

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
