### PR TITLE
🐛 Fix an issue in `kubernetes_manifest` resource

### DIFF
--- a/.changelog/2164.txt
+++ b/.changelog/2164.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_manifest`: fix an issue in the `kubernetes_manifest` resource when it panics if tuple attributes within an object have a different number of elements. This leads to the situation when all types of end tuples are getting the same type.
+```

--- a/manifest/morph/scaffold.go
+++ b/manifest/morph/scaffold.go
@@ -68,7 +68,7 @@ func DeepUnknown(t tftypes.Type, v tftypes.Value, p *tftypes.AttributePath) (tft
 			}
 			atts = make([]tftypes.Type, len(v.Type().(tftypes.Tuple).ElementTypes))
 			for i := range v.Type().(tftypes.Tuple).ElementTypes {
-				atts[i] = t.(tftypes.Tuple).ElementTypes[0]
+				atts[i] = v.Type().(tftypes.Tuple).ElementTypes[i]
 			}
 		}
 		var vals []tftypes.Value

--- a/manifest/morph/scaffold_test.go
+++ b/manifest/morph/scaffold_test.go
@@ -100,6 +100,205 @@ func TestDeepUnknown(t *testing.T) {
 				}),
 			}),
 		},
+		"unequal-tuples": {
+			In: deepUnknownTestSampleInput{
+				T: tftypes.Tuple{ElementTypes: []tftypes.Type{
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"second": tftypes.Number,
+							}},
+						}},
+					}},
+				}},
+				V: tftypes.NewValue(
+					tftypes.Tuple{ElementTypes: []tftypes.Type{
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+							"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+								tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+									"second": tftypes.Number,
+								}},
+							}},
+						}},
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+							"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+								tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+									"second": tftypes.Number,
+								}},
+								tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+									"second": tftypes.Number,
+								}},
+							}},
+						}},
+					}},
+					[]tftypes.Value{
+						tftypes.NewValue(
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+										"second": tftypes.Number,
+									}},
+								}},
+							}},
+							map[string]tftypes.Value{
+								"first": tftypes.NewValue(
+									tftypes.Tuple{ElementTypes: []tftypes.Type{
+										tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+											"second": tftypes.Number,
+										}},
+									}},
+									[]tftypes.Value{
+										tftypes.NewValue(
+											tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+												"second": tftypes.Number,
+											}},
+											map[string]tftypes.Value{
+												"second": tftypes.NewValue(tftypes.Number, 10),
+											},
+										),
+									},
+								),
+							},
+						),
+						tftypes.NewValue(
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+										"second": tftypes.Number,
+									}},
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+										"second": tftypes.Number,
+									}},
+								}},
+							}},
+							map[string]tftypes.Value{
+								"first": tftypes.NewValue(
+									tftypes.Tuple{ElementTypes: []tftypes.Type{
+										tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+											"second": tftypes.Number,
+										}},
+										tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+											"second": tftypes.Number,
+										}},
+									}},
+									[]tftypes.Value{
+										tftypes.NewValue(
+											tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+												"second": tftypes.Number,
+											}},
+											map[string]tftypes.Value{
+												"second": tftypes.NewValue(tftypes.Number, 10),
+											},
+										),
+										tftypes.NewValue(
+											tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+												"second": tftypes.Number,
+											}},
+											map[string]tftypes.Value{
+												"second": tftypes.NewValue(tftypes.Number, 10),
+											},
+										),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			Out: tftypes.NewValue(
+				tftypes.Tuple{ElementTypes: []tftypes.Type{
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"second": tftypes.Number,
+							}},
+						}},
+					}},
+					tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"second": tftypes.Number,
+							}},
+							tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+								"second": tftypes.Number,
+							}},
+						}},
+					}},
+				}},
+				[]tftypes.Value{
+					tftypes.NewValue(
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+							"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+								tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+									"second": tftypes.Number,
+								}},
+							}},
+						}},
+						map[string]tftypes.Value{
+							"first": tftypes.NewValue(
+								tftypes.Tuple{ElementTypes: []tftypes.Type{
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+										"second": tftypes.Number,
+									}},
+								}},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+											"second": tftypes.Number,
+										}},
+										map[string]tftypes.Value{
+											"second": tftypes.NewValue(tftypes.Number, 10),
+										},
+									),
+								},
+							),
+						},
+					),
+					tftypes.NewValue(
+						tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+							"first": tftypes.Tuple{ElementTypes: []tftypes.Type{
+								tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+									"second": tftypes.Number,
+								}},
+								tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+									"second": tftypes.Number,
+								}},
+							}},
+						}},
+						map[string]tftypes.Value{
+							"first": tftypes.NewValue(
+								tftypes.Tuple{ElementTypes: []tftypes.Type{
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+										"second": tftypes.Number,
+									}},
+									tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+										"second": tftypes.Number,
+									}},
+								}},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+											"second": tftypes.Number,
+										}},
+										map[string]tftypes.Value{
+											"second": tftypes.NewValue(tftypes.Number, 10),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+											"second": tftypes.Number,
+										}},
+										map[string]tftypes.Value{
+											"second": tftypes.NewValue(tftypes.Number, 10),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			),
+		},
 	}
 	for n, s := range samples {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
### Description

This PR fixes an issue in the `kubernetes_manifest` resource when it panics if tuple attributes within an object have a different number of elements. This leads to the situation when all types of end tuples are getting the same type.

Example.

```hcl
resource "kubernetes_manifest" "this" {
  manifest = {
    "apiVersion" = "..."
    "kind"       = "..."
    "metadata" = {...}
    "spec" = {
      "tuple" = [
        {
          "name" = "een"
        },
        {
          "name" = "twee"
          "object" = {
            "things" = [
              {
                "thing" = 10
              },
              {
                "thing" = 20
              },
            ]
          }
        },
      ]
    }
  }
}
```

`spec.tuple` consists of objects of the same type, however, `spec.tuple[X].object` is an optional attribute and thus not presented in `spec.tuple[0]`. This leads to the situation when `kubernetes_manifest` expects `spec.tuple[0]` to have attribute `configuration` with two elements, however, it has only one with `UnknownValue`, since it is not configured. The panic happens due to validation, an item has 1 attribute, but the resource expects 2.

### Tests

I have updated the `TestDeepUnknown` unit test.

```console
$ go test -v -count 1 -timeout=30s -run TestDeepUnknown

=== RUN   TestDeepUnknown
=== RUN   TestDeepUnknown/string-nil
=== RUN   TestDeepUnknown/object
=== RUN   TestDeepUnknown/unequal-tuples
--- PASS: TestDeepUnknown (0.00s)
    --- PASS: TestDeepUnknown/string-nil (0.00s)
    --- PASS: TestDeepUnknown/object (0.00s)
    --- PASS: TestDeepUnknown/unequal-tuples (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/manifest/morph	0.705s
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
...
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1649

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
