### PR TITLE
Updated references to rbac documentation page

### DIFF
--- a/website/docs/r/cluster_role_binding.html.markdown
+++ b/website/docs/r/cluster_role_binding.html.markdown
@@ -46,8 +46,8 @@ resource "kubernetes_cluster_role_binding" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard kubernetes metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
-* `role_ref` - (Required) The ClusterRole to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding)
-* `subject` - (Required) The Users, Groups, or ServiceAccounts to grant permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#referring-to-subjects)
+* `role_ref` - (Required) The ClusterRole to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
+* `subject` - (Required) The Users, Groups, or ServiceAccounts to grant permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects)
 
 
 ## Nested Blocks
@@ -56,12 +56,12 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata. 
+* `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata.
 
 ~> By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding. 
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding.
 
 ~> By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 

--- a/website/docs/r/cluster_role_binding_v1.html.markdown
+++ b/website/docs/r/cluster_role_binding_v1.html.markdown
@@ -46,8 +46,8 @@ resource "kubernetes_cluster_role_binding_v1" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard kubernetes metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
-* `role_ref` - (Required) The ClusterRole to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding)
-* `subject` - (Required) The Users, Groups, or ServiceAccounts to grant permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#referring-to-subjects)
+* `role_ref` - (Required) The ClusterRole to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
+* `subject` - (Required) The Users, Groups, or ServiceAccounts to grant permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects)
 
 
 ## Nested Blocks
@@ -56,12 +56,12 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata. 
+* `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata.
 
 ~> By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding. 
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding.
 
 ~> By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 

--- a/website/docs/r/role_binding.html.markdown
+++ b/website/docs/r/role_binding.html.markdown
@@ -46,8 +46,8 @@ resource "kubernetes_role_binding" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard kubernetes metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
-* `role_ref` - (Required) The Role to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding)
-* `subject` - (Required) The Users, Groups, or ServiceAccounts to grand permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#referring-to-subjects)
+* `role_ref` - (Required) The Role to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
+* `subject` - (Required) The Users, Groups, or ServiceAccounts to grand permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects)
 
 
 ## Nested Blocks

--- a/website/docs/r/role_binding_v1.html.markdown
+++ b/website/docs/r/role_binding_v1.html.markdown
@@ -46,8 +46,8 @@ resource "kubernetes_role_binding_v1" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard kubernetes metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
-* `role_ref` - (Required) The Role to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding)
-* `subject` - (Required) The Users, Groups, or ServiceAccounts to grand permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/admin/authorization/rbac/#referring-to-subjects)
+* `role_ref` - (Required) The Role to bind Subjects to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
+* `subject` - (Required) The Users, Groups, or ServiceAccounts to grand permissions to. For more info see [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects)
 
 
 ## Nested Blocks


### PR DESCRIPTION
### Description

This PR fixes a broken link in the documentation for the [kubernetes_cluster_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding), [kubernetes_cluster_role_binding_v1](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1), [kubernetes_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding), and [kubernetes_role_binding_v1](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1) resources.

### Acceptance tests
n/a

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Correct broken link in docs for kubernetes_cluster_role_binding, kubernetes_cluster_role_binding_v1, kubernetes_role_binding, and kubernetes_role_binding_v1
```

### References
n/a

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
