### PR TITLE
🐛 Fix the wait conditions issue in the kubernetes_manifest resource

### DIFF
--- a/.changelog/2173.txt
+++ b/.changelog/2173.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_manifest`: fix an issue with the `kubernetes_manifest` resource, where an object fails to update correctly when employing wait conditions and thus some attributes are not available for the reference after creation.
+```

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -17,6 +17,10 @@ variable "enable_alpha" {
   default = false
 }
 
+variable "cluster_name" {
+  default = ""
+}
+
 data "google_compute_zones" "available" {
 }
 
@@ -36,7 +40,7 @@ resource "google_service_account" "default" {
 
 resource "google_container_cluster" "primary" {
   provider           = google-beta
-  name               = "tf-acc-test-${random_id.cluster_name.hex}"
+  name               = var.cluster_name != "" ? var.cluster_name : "tf-acc-test-${random_id.cluster_name.hex}"
   location           = data.google_compute_zones.available.names[0]
   node_version       = data.google_container_engine_versions.supported.latest_node_version
   min_master_version = data.google_container_engine_versions.supported.latest_master_version

--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -404,18 +404,6 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			return resp, nil
 		}
 
-		newResObject, err := payload.ToTFValue(RemoveServerSideFields(result.Object), tsch, th, tftypes.NewAttributePath())
-		if err != nil {
-			resp.Diagnostics = append(resp.Diagnostics,
-				&tfprotov5.Diagnostic{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "Conversion from Unstructured to tftypes.Value failed",
-					Detail:   err.Error(),
-				})
-			return resp, nil
-		}
-		s.logger.Trace("[ApplyResourceChange][Apply]", "[payload.ToTFValue]", dump(newResObject))
-
 		wt, _, err := s.TFTypeFromOpenAPI(ctx, gvk, true)
 		if err != nil {
 			return resp, fmt.Errorf("failed to determine resource type ID: %s", err)
@@ -454,7 +442,33 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 				}
 				return resp, nil
 			}
+
+			r, err := rs.Get(ctxDeadline, rname, metav1.GetOptions{})
+			if err != nil {
+				s.logger.Error("[ApplyResourceChange][ReadAfterWait]", "API error", dump(err), "API response", dump(result))
+				resp.Diagnostics = append(resp.Diagnostics,
+					&tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  fmt.Sprintf(`Failed to read resource "%s" after wait conditions`, rname),
+						Detail:   err.Error(),
+					})
+
+				return resp, nil
+			}
+			result = r
 		}
+
+		newResObject, err := payload.ToTFValue(RemoveServerSideFields(result.Object), tsch, th, tftypes.NewAttributePath())
+		if err != nil {
+			resp.Diagnostics = append(resp.Diagnostics,
+				&tfprotov5.Diagnostic{
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Conversion from Unstructured to tftypes.Value failed",
+					Detail:   err.Error(),
+				})
+			return resp, nil
+		}
+		s.logger.Trace("[ApplyResourceChange][Apply]", "[payload.ToTFValue]", dump(newResObject))
 
 		compObj, err := morph.DeepUnknown(tsch, newResObject, tftypes.NewAttributePath())
 		if err != nil {

--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -449,7 +449,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 				resp.Diagnostics = append(resp.Diagnostics,
 					&tfprotov5.Diagnostic{
 						Severity: tfprotov5.DiagnosticSeverityError,
-						Summary:  fmt.Sprintf(`Failed to read resource "%s" after wait conditions`, rname),
+						Summary:  fmt.Sprintf(`Failed to read resource %q after wait conditions`, rname),
 						Detail:   err.Error(),
 					})
 

--- a/manifest/test/acceptance/testdata/Wait/wait_for_fields_annotations.tf
+++ b/manifest/test/acceptance/testdata/Wait/wait_for_fields_annotations.tf
@@ -1,0 +1,31 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Secret"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+
+      annotations = {
+        "kubernetes.io/service-account.name" = "default"
+      }
+    }
+    type = "kubernetes.io/service-account-token"
+  }
+  wait {
+    fields = {
+      "metadata.annotations[\"kubernetes.io/service-account.uid\"]" = "^.*$",
+    }
+  }
+
+  timeouts {
+    create = "10s"
+  }
+}
+
+output "test" {
+  value = kubernetes_manifest.test.object.metadata.annotations["kubernetes.io/service-account.uid"]
+}

--- a/manifest/test/acceptance/wait_test.go
+++ b/manifest/test/acceptance/wait_test.go
@@ -8,7 +8,6 @@ package acceptance
 
 import (
 	"context"
-	// "fmt"
 	"strings"
 	"testing"
 	"time"

--- a/manifest/test/helper/state/state_helper.go
+++ b/manifest/test/helper/state/state_helper.go
@@ -207,3 +207,33 @@ func (s *Helper) AssertAttributeFalse(t *testing.T, address string) {
 		assert.False(t, v, fmt.Sprintf("Address: %q", address))
 	}
 }
+
+// getOutputValues gets the given output name value from the state
+func getOutputValues(state *Helper, name string) (interface{}, error) {
+	for n, v := range state.Values.Outputs {
+		if n == name {
+			return v.Value, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Could not find output %q in state", name)
+}
+
+// GetOutputValue gets the given output name value from the state
+func (s *Helper) GetOutputValue(t *testing.T, name string) interface{} {
+	t.Helper()
+
+	value, err := getOutputValues(s, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return value
+}
+
+// AssertOutputExists will fail the test if the output does not exist
+func (s *Helper) AssertOutputExists(t *testing.T, name string) {
+	t.Helper()
+
+	s.GetOutputValue(t, name)
+}

--- a/manifest/test/helper/state/state_helper.go
+++ b/manifest/test/helper/state/state_helper.go
@@ -37,6 +37,17 @@ func getAttributesValuesFromResource(state *Helper, address string) (interface{}
 	return nil, fmt.Errorf("Could not find resource %q in state", address)
 }
 
+// getOutputValues gets the given output name value from the state
+func getOutputValues(state *Helper, name string) (interface{}, error) {
+	for n, v := range state.Values.Outputs {
+		if n == name {
+			return v.Value, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Could not find output %q in state", name)
+}
+
 var errFieldNotFound = fmt.Errorf("Field not found")
 
 // findAttributeValue will return the value of the attribute at the given address in a tree of arrays and maps
@@ -102,6 +113,18 @@ func (s *Helper) GetAttributeValue(t *testing.T, address string) interface{} {
 	value, err := findAttributeValue(attrs, attributeAddress)
 	if err != nil {
 		t.Fatalf("%q does not exist", address)
+	}
+
+	return value
+}
+
+// GetOutputValue gets the given output name value from the state
+func (s *Helper) GetOutputValue(t *testing.T, name string) interface{} {
+	t.Helper()
+
+	value, err := getOutputValues(s, name)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	return value
@@ -206,29 +229,6 @@ func (s *Helper) AssertAttributeFalse(t *testing.T, address string) {
 	} else {
 		assert.False(t, v, fmt.Sprintf("Address: %q", address))
 	}
-}
-
-// getOutputValues gets the given output name value from the state
-func getOutputValues(state *Helper, name string) (interface{}, error) {
-	for n, v := range state.Values.Outputs {
-		if n == name {
-			return v.Value, nil
-		}
-	}
-
-	return nil, fmt.Errorf("Could not find output %q in state", name)
-}
-
-// GetOutputValue gets the given output name value from the state
-func (s *Helper) GetOutputValue(t *testing.T, name string) interface{} {
-	t.Helper()
-
-	value, err := getOutputValues(s, name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return value
 }
 
 // AssertOutputExists will fail the test if the output does not exist


### PR DESCRIPTION
### Description

This PR fixes an issue in the `kubernetes_manifest` manifest when it is used with the `wait` conditions. This happens because the provider works with the object that the Kubernetes cluster returns after creation and doesn't update the object(request a newer version) once the conditions are met. Because of that the initial object(the one that the provider receives right after the create call) ends up in the TF state and some attributes are not available for the reference. A good example here can be `metadata.labels` and `metadata.annotations` that controllers assign to the Kubernetes objects after their creation. `metadata.labels` and `metadata.annotations` are often used in the `wait` conditions and as an input for other resources to be created or outputs for further usage.

Changes:

- Move the `wait` condition code right after the resource creation to fail earlier in the case of any issue that occurs during the waiting time.
- Add read operation when the `wait` conditions are met successfully.

For example, the following code will be executed with the "Invalid index" error message:

```hcl
resource "kubernetes_manifest" "this" {
  manifest = {
    apiVersion = "v1"
    kind       = "Secret"
    metadata = {
      name      = "this"
      namespace = "default"

      annotations = {
        "kubernetes.io/service-account.name" = "default"
      }
    }
    type = "kubernetes.io/service-account-token"
  }
  wait {
    fields = {
      "metadata.annotations[\"kubernetes.io/service-account.uid\"]" = "^.*$",
    }
  }

  timeouts {
    create = "10s"
  }
}

output "this" {
  value = kubernetes_manifest.this.object.metadata.annotations["kubernetes.io/service-account.uid"]
}
```

That happens because the annotation `kubernetes.io/service-account.uid` is not available right after the resource creation and added by a controller for some time(that is why the condition is used here). The second apply will be successful.

### Acceptance tests

- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```console
$ go test -count=1 -tags acceptance -v ./manifest/test/acceptance/... -timeout 120m -run TestKubernetesManifest_WaitFields_Annotations

2023/07/03 17:23:03 Testing against Kubernetes API version: v1.26.6
=== RUN   TestKubernetesManifest_WaitFields_Annotations
2023-07-03T17:23:04.036+0200 [INFO]  [ApplyResourceChange][Wait] Waiting until ready...

2023-07-03T17:23:04.038+0200 [INFO]  [ApplyResourceChange][Wait] Done waiting.

--- PASS: TestKubernetesManifest_WaitFields_Annotations (1.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance	1.867s
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):


```release-note:bug
`resource/kubernetes_manifest`: fix an issue with the `kubernetes_manifest` resource, where an object fails to update correctly when employing wait conditions and thus some attributes are not available for the reference after creation.
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1957

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
