### PR TITLE
Replace images in acceptance tests

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -392,7 +392,7 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get(t 
 	var conf appsv1.Deployment
 
 	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -422,7 +422,7 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp(t *test
 	var conf appsv1.Deployment
 
 	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -1845,7 +1845,7 @@ func testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(deploymentNa
         container {
           image = "%s"
           name  = "containername"
-          args  = ["/server"]
+          args  = ["liveness"]
 
           liveness_probe {
             http_get {
@@ -1897,7 +1897,7 @@ func testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(deploymentName, 
         container {
           image = "%s"
           name  = "containername"
-          args  = ["/server"]
+          args  = ["liveness"]
 
           liveness_probe {
             tcp_socket {
@@ -2006,9 +2006,9 @@ func testAccKubernetesDeploymentConfigWithContainerSecurityContext(deploymentNam
         }
 
         container {
-          image = "gcr.io/google_containers/liveness"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
           name  = "containername2"
-          args  = ["/server"]
+          args  = ["liveness"]
 
           security_context {
             allow_privilege_escalation = true

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -536,7 +536,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_http_get(t *testin
 	var conf api.Pod
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 	resourceName := "kubernetes_pod.test"
 
 	resource.Test(t, resource.TestCase{
@@ -573,7 +573,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_tcp(t *testing.T) 
 	var conf api.Pod
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 	resourceName := "kubernetes_pod.test"
 
 	resource.Test(t, resource.TestCase{
@@ -605,7 +605,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_grpc(t *testing.T)
 	var conf api.Pod
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 	resourceName := "kubernetes_pod.test"
 
 	resource.Test(t, resource.TestCase{
@@ -641,7 +641,7 @@ func TestAccKubernetesPod_with_container_lifecycle(t *testing.T) {
 	var conf api.Pod
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 	resourceName := "kubernetes_pod.test"
 
 	resource.Test(t, resource.TestCase{
@@ -1960,7 +1960,7 @@ func testAccKubernetesPodConfigWithLivenessProbeUsingHTTPGet(podName, imageName 
     container {
       image = "%s"
       name  = "containername"
-      args  = ["/server"]
+      args  = ["liveness"]
 
       liveness_probe {
         http_get {
@@ -1996,7 +1996,7 @@ func testAccKubernetesPodConfigWithLivenessProbeUsingTCP(podName, imageName stri
     container {
       image = "%s"
       name  = "containername"
-      args  = ["/server"]
+      args  = ["liveness"]
 
       liveness_probe {
         tcp_socket {
@@ -2026,7 +2026,7 @@ func testAccKubernetesPodConfigWithLivenessProbeUsingGRPC(podName, imageName str
     container {
       image = "%s"
       name  = "containername"
-      args  = ["/server"]
+      args  = ["liveness"]
 
       liveness_probe {
         grpc {
@@ -2057,7 +2057,7 @@ func testAccKubernetesPodConfigWithLifeCycle(podName, imageName string) string {
     container {
       image = "%s"
       name  = "containername"
-      args  = ["/server"]
+      args  = ["liveness"]
 
       lifecycle {
         post_start {

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -280,7 +280,7 @@ func TestAccKubernetesReplicationController_with_container_liveness_probe_using_
 	var conf api.ReplicationController
 
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -310,7 +310,7 @@ func TestAccKubernetesReplicationController_with_container_liveness_probe_using_
 	var conf api.ReplicationController
 
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -335,7 +335,7 @@ func TestAccKubernetesReplicationController_with_container_lifecycle(t *testing.
 	var conf api.ReplicationController
 
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "registry.k8s.io/e2e-test-images/agnhost:2.40"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -917,7 +917,7 @@ func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingHTTPGet(r
         container {
           image = "%s"
           name  = "containername"
-          args  = ["/server"]
+          args  = ["liveness"]
 
           liveness_probe {
             http_get {
@@ -967,7 +967,7 @@ func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingTCP(rcNam
         container {
           image = "%s"
           name  = "containername"
-          args  = ["/server"]
+          args  = ["liveness"]
 
           liveness_probe {
             tcp_socket {
@@ -1011,7 +1011,7 @@ func testAccKubernetesReplicationControllerConfigWithLifeCycle(rcName, imageName
         container {
           image = "%s"
           name  = "containername"
-          args  = ["/server"]
+          args  = ["liveness"]
 
           lifecycle {
             post_start {

--- a/kubernetes/resource_kubernetes_stateful_set_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_test.go
@@ -168,7 +168,7 @@ func TestAccKubernetesStatefulSet_Update(t *testing.T) {
 				Config: testAccKubernetesStatefulSetConfigUpdateImage(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetExists("kubernetes_stateful_set.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.template.0.spec.0.container.0.image", "k8s.gcr.io/liveness:latest"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.template.0.spec.0.container.0.image", "registry.k8s.io/e2e-test-images/agnhost:2.40"),
 				),
 			},
 			{
@@ -542,7 +542,8 @@ func testAccKubernetesStatefulSetConfigUpdateImage(name string) string {
       spec {
         container {
           name  = "ss-test"
-          image = "k8s.gcr.io/liveness:latest"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
+          args  = ["pause"]
 
           port {
             container_port = "80"
@@ -627,7 +628,8 @@ func testAccKubernetesStatefulSetConfigUpdatedSelectorLabels(name string) string
       spec {
         container {
           name  = "ss-test"
-          image = "k8s.gcr.io/pause:latest"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
+          args  = ["pause"]
 
           port {
             container_port = "80"
@@ -710,7 +712,8 @@ func testAccKubernetesStatefulSetConfigUpdateReplicas(name string, replicas stri
       spec {
         container {
           name  = "ss-test"
-          image = "k8s.gcr.io/pause:latest"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
+          args  = ["pause"]
 
           port {
             container_port = "80"
@@ -793,7 +796,8 @@ func testAccKubernetesStatefulSetConfigUpdateTemplate(name string) string {
       spec {
         container {
           name  = "ss-test"
-          image = "k8s.gcr.io/pause:latest"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
+          args  = ["pause"]
 
           port {
             container_port = "80"
@@ -897,7 +901,8 @@ func testAccKubernetesStatefulSetConfigRollingUpdatePartition(name string) strin
       spec {
         container {
           name  = "ss-test"
-          image = "k8s.gcr.io/pause:latest"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
+          args  = ["pause"]
 
           port {
             container_port = "80"
@@ -980,7 +985,8 @@ func testAccKubernetesStatefulSetConfigUpdateStrategyOnDelete(name string) strin
       spec {
         container {
           name  = "ss-test"
-          image = "k8s.gcr.io/pause:latest"
+          image = "registry.k8s.io/e2e-test-images/agnhost:2.40"
+          args  = ["pause"]
 
           port {
             container_port = "80"


### PR DESCRIPTION
### Description

Replace `liveness` and `pause` images with `agnhost`(this is an image that the Kubernetes team uses for E2E tests) in acceptance tests to make them work on the `arm64` platform.

@sheneska  _I did a bulk replacement, we should make this image a variable in our further PRs._

Links:

- https://pkg.go.dev/k8s.io/kubernetes/test/images/agnhost

### Acceptance tests
- [ ] ~Have you added an acceptance test for the functionality being added?~
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing: https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5552361649

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):


```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
