### PR TITLE
Fix formatting for Markdown links

### DIFF
--- a/website/docs/d/pod.html.markdown
+++ b/website/docs/d/pod.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 A pod is a group of one or more containers, the shared storage for those containers, and options about how to run the containers. Pods are always co-located and co-scheduled, and run in a shared context.
 
-Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod)/
+Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod/)
 
 ## Example Usage
 
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `active_deadline_seconds` - Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `automount_service_account_token` - Indicates whether a service account token should be automatically mounted. Defaults to true for Pods.
 * `container` - List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `host_alias` - List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty. See `host_alias` block definition below.
@@ -310,7 +310,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/d/pod_v1.html.markdown
+++ b/website/docs/d/pod_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 A pod is a group of one or more containers, the shared storage for those containers, and options about how to run the containers. Pods are always co-located and co-scheduled, and run in a shared context.
 
-Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod)/
+Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod/)
 
 ## Example Usage
 
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `active_deadline_seconds` - Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `automount_service_account_token` - Indicates whether a service account token should be automatically mounted. Defaults to true for Pods.
 * `container` - List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `host_alias` - List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty. See `host_alias` block definition below.
@@ -310,7 +310,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to `true`.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - (Optional) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `enable_service_links` - (Optional) Enables generating environment variables for service discovery. Optional: Defaults to true. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service).
@@ -647,7 +647,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to `true`.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - (Optional) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `enable_service_links` - (Optional) Enables generating environment variables for service discovery. Optional: Defaults to true. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service).
@@ -657,7 +657,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 * `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to `true`.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
 * `readiness_gate` - (Optional) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True". [More info](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - (Optional) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `enable_service_links` - (Optional) Enables generating environment variables for service discovery. Optional: Defaults to true. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service).
@@ -669,7 +669,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/r/deployment_v1.html.markdown
+++ b/website/docs/r/deployment_v1.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 * `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to `true`.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
 * `readiness_gate` - (Optional) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True". [More info](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - (Optional) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `enable_service_links` - (Optional) Enables generating environment variables for service discovery. Optional: Defaults to true. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service).
@@ -659,7 +659,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # kubernetes_namespace
 
 Kubernetes supports multiple virtual clusters backed by the same physical cluster. These virtual clusters are called namespaces.
-Read more about namespaces at [Kubernetes reference](https://kubernetes.io/docs/user-guide/namespaces)/
+Read more about namespaces at [Kubernetes reference](https://kubernetes.io/docs/user-guide/namespaces/)
 
 ## Example Usage
 

--- a/website/docs/r/namespace_v1.html.markdown
+++ b/website/docs/r/namespace_v1.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # kubernetes_namespace_v1
 
 Kubernetes supports multiple virtual clusters backed by the same physical cluster. These virtual clusters are called namespaces.
-Read more about namespaces at [Kubernetes reference](https://kubernetes.io/docs/user-guide/namespaces)/
+Read more about namespaces at [Kubernetes reference](https://kubernetes.io/docs/user-guide/namespaces/)
 
 ## Example Usage
 

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # kubernetes_persistent_volume
 
 The resource provides a piece of networked storage in the cluster provisioned by an administrator. It is a resource in the cluster just like a node is a cluster resource. Persistent Volumes have a lifecycle independent of any individual pod that uses the PV.
-For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes)/
+For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 
 ## Example Usage
 

--- a/website/docs/r/persistent_volume_claim.html.markdown
+++ b/website/docs/r/persistent_volume_claim.html.markdown
@@ -101,8 +101,8 @@ The following arguments are supported:
 
 #### Arguments
 
-* `limits` - (Optional) Map describing the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
-* `requests` - (Optional) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Map describing the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
+* `requests` - (Optional) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 
 ### `selector`
 

--- a/website/docs/r/persistent_volume_claim_v1.html.markdown
+++ b/website/docs/r/persistent_volume_claim_v1.html.markdown
@@ -101,8 +101,8 @@ The following arguments are supported:
 
 #### Arguments
 
-* `limits` - (Optional) Map describing the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
-* `requests` - (Optional) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Map describing the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
+* `requests` - (Optional) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 
 ### `selector`
 

--- a/website/docs/r/persistent_volume_v1.html.markdown
+++ b/website/docs/r/persistent_volume_v1.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # kubernetes_persistent_volume_v1
 
 The resource provides a piece of networked storage in the cluster provisioned by an administrator. It is a resource in the cluster just like a node is a cluster resource. Persistent Volumes have a lifecycle independent of any individual pod that uses the PV.
-For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes)/
+For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 
 ## Example Usage
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 A pod is a group of one or more containers, the shared storage for those containers, and options about how to run the containers. Pods are always co-located and co-scheduled, and run in a shared context.
 
-Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod)/
+Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod/)
 
 ## Example Usage
 
@@ -203,7 +203,7 @@ The following arguments are supported:
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to `true` for Pods.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - (Optional) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `enable_service_links` - (Optional) Enables generating environment variables for service discovery. Optional: Defaults to true. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service).
@@ -719,7 +719,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 A pod is a group of one or more containers, the shared storage for those containers, and options about how to run the containers. Pods are always co-located and co-scheduled, and run in a shared context.
 
-Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod)/
+Read more at [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod/)
 
 ## Example Usage
 
@@ -202,7 +202,7 @@ The following arguments are supported:
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to `true` for Pods.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `dns_config` - (Optional) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Defaults to empty. See `dns_config` block definition below.
 * `enable_service_links` - (Optional) Enables generating environment variables for service discovery. Optional: Defaults to true. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service).
@@ -708,7 +708,7 @@ The `option` block supports the following:
 
 #### Arguments
 
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
+* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources/)
 * `requests` - (Optional) Describes the minimum amount of compute resources required.
 
 `resources` is a computed attribute and thus if it is not configured in terraform code, the value will be computed from the returned Kubernetes object. That causes a situation when removing `resources` from terraform code does not update the Kubernetes object. In order to delete `resources` from the Kubernetes object, configure an empty attribute in your code.


### PR DESCRIPTION
P.S. Many links like `docs/user-guide` are stale and will be replaced in folowing PRs.