### PR TITLE
add legacy_lifecyclestates to ImportStateVerifyIgnore

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -1505,7 +1505,11 @@ func TestAccKubernetesPod_with_ephemeral_storage(t *testing.T) {
 	volumeName := "ephemeral"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfNotRunningInKind(t)
+			skipIfClusterVersionLessThan(t, "1.23.0")
+		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesPodDestroy,
 		Steps: []resource.TestStep{

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -1499,8 +1499,10 @@ func TestAccKubernetesPod_with_ephemeral_storage(t *testing.T) {
 	var pod api.Pod
 	var pvc api.PersistentVolumeClaim
 
-	testName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := nginxImageVersion
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := busyboxImageVersion
+	resourceName := "kubernetes_pod_v1.test"
+	volumeName := "ephemeral"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -1508,17 +1510,18 @@ func TestAccKubernetesPod_with_ephemeral_storage(t *testing.T) {
 		CheckDestroy:      testAccCheckKubernetesPodDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesPodEphemeralStorage(testName, imageName),
+				Config: testAccKubernetesPodEphemeralStorageClass(podName) +
+					testAccKubernetesPodEphemeralStorage(podName, imageName, volumeName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod_v1.test", &pod),
-					testAccCheckKubernetesPersistentVolumeClaimCreated("default", testName+"-ephemeral", &pvc),
-					resource.TestCheckResourceAttr("kubernetes_pod_v1.test", "spec.0.volume.0.name", "ephemeral"),
-					resource.TestCheckResourceAttr("kubernetes_pod_v1.test", "spec.0.volume.0.ephemeral.0.spec.0.storage_class_name", testName),
+					testAccCheckKubernetesPodExists(resourceName, &pod),
+					testAccCheckKubernetesPersistentVolumeClaimCreated("default", fmt.Sprintf("%s-%s", podName, volumeName), &pvc),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.volume.0.name", volumeName),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.volume.0.ephemeral.0.spec.0.storage_class_name", podName),
 				),
 			},
 			// Do a second test with only the storage class and check that the PVC has been deleted by the ephemeral volume
 			{
-				Config: testAccKubernetesPodEphemeralStorageWithoutPod(testName),
+				Config: testAccKubernetesPodEphemeralStorageClass(podName),
 				Check:  testAccCheckKubernetesPersistentVolumeClaimIsDestroyed(&pvc),
 			},
 		},
@@ -3323,21 +3326,8 @@ resource "kubernetes_pod_v1" "scheduler" {
 `, name)
 }
 
-func testAccKubernetesPodEphemeralStorage(name, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_storage_class" "test" {
-  metadata {
-    name = %[1]q
-  }
-  storage_provisioner = "pd.csi.storage.gke.io"
-  reclaim_policy      = "Delete"
-  volume_binding_mode = "WaitForFirstConsumer"
-
-  parameters = {
-    type = "pd-standard"
-  }
-}
-
-resource "kubernetes_pod_v1" "test" {
+func testAccKubernetesPodEphemeralStorage(podName, imageName, volumeName string) string {
+	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
   metadata {
     name = %[1]q
     labels = {
@@ -3351,12 +3341,12 @@ resource "kubernetes_pod_v1" "test" {
 
       volume_mount {
         mount_path = "/ephemeral"
-        name       = "ephemeral"
+        name       = %[3]q
       }
     }
 
     volume {
-      name = "ephemeral"
+      name = %[3]q
 
       ephemeral {
         metadata {
@@ -3370,7 +3360,7 @@ resource "kubernetes_pod_v1" "test" {
 
           resources {
             requests = {
-              storage = "5Gi"
+              storage = "1Gi"
             }
           }
         }
@@ -3378,21 +3368,17 @@ resource "kubernetes_pod_v1" "test" {
     }
   }
 }
-`, name, imageName)
+`, podName, imageName, volumeName)
 }
 
-func testAccKubernetesPodEphemeralStorageWithoutPod(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_storage_class" "test" {
+func testAccKubernetesPodEphemeralStorageClass(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_storage_class_v1" "test" {
   metadata {
     name = %[1]q
   }
-  storage_provisioner = "pd.csi.storage.gke.io"
+  storage_provisioner = "rancher.io/local-path"
   reclaim_policy      = "Delete"
   volume_binding_mode = "WaitForFirstConsumer"
-
-  parameters = {
-    type = "pd-standard"
-  }
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -3345,7 +3345,6 @@ resource "kubernetes_pod_v1" "test" {
     }
   }
   spec {
-    priority_class_name = "default"
     container {
       name  = "containername"
       image = %[2]q

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -458,7 +458,7 @@ func TestAccKubernetesPod_with_pod_security_context_seccomp_profile(t *testing.T
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -40,7 +40,7 @@ func TestAccKubernetesPod_minimal(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config:   testAccKubernetesPodConfigMinimal(name, busyboxImageVersion),
@@ -99,7 +99,7 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -166,7 +166,7 @@ func TestAccKubernetesPod_initContainer_updateForcesNew(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config: testAccKubernetesPodConfigWithInitContainer(podName, image1),
@@ -219,7 +219,7 @@ func TestAccKubernetesPod_updateArgsForceNew(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config: testAccKubernetesPodConfigArgsUpdate(podName, imageName, argsAfter),
@@ -278,7 +278,7 @@ func TestAccKubernetesPod_updateEnvForceNew(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config: testAccKubernetesPodConfigEnvUpdate(podName, imageName, envAfter),
@@ -328,7 +328,7 @@ func TestAccKubernetesPod_with_pod_security_context(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -361,7 +361,7 @@ func TestAccKubernetesPod_with_pod_security_context_fs_group_change_policy(t *te
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -420,7 +420,7 @@ func TestAccKubernetesPod_with_pod_security_context_run_as_group(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -490,7 +490,7 @@ func TestAccKubernetesPod_with_pod_security_context_seccomp_localhost_profile(t 
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -526,7 +526,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_exec(t *testing.T)
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -563,7 +563,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_http_get(t *testin
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -595,7 +595,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_tcp(t *testing.T) 
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -631,7 +631,7 @@ func TestAccKubernetesPod_with_container_liveness_probe_using_grpc(t *testing.T)
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -669,7 +669,7 @@ func TestAccKubernetesPod_with_container_lifecycle(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -706,7 +706,7 @@ func TestAccKubernetesPod_with_container_security_context(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -743,7 +743,7 @@ func TestAccKubernetesPod_with_volume_mount(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -785,7 +785,7 @@ func TestAccKubernetesPod_with_cfg_map_volume_mount(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -877,7 +877,7 @@ func TestAccKubernetesPod_with_projected_volume(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -912,7 +912,7 @@ func TestAccKubernetesPod_with_resource_requirements(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config: testAccKubernetesPodConfigWithEmptyResourceRequirements(podName, imageName),
@@ -974,7 +974,7 @@ func TestAccKubernetesPod_with_empty_dir_volume(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1008,7 +1008,7 @@ func TestAccKubernetesPod_with_empty_dir_volume_with_sizeLimit(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1041,7 +1041,7 @@ func TestAccKubernetesPod_with_secret_vol_items(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1073,7 +1073,7 @@ func TestAccKubernetesPod_gke_with_nodeSelector(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1105,7 +1105,7 @@ func TestAccKubernetesPod_config_with_automount_service_account_token(t *testing
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1135,7 +1135,7 @@ func TestAccKubernetesPod_config_container_working_dir(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config: testAccKubernetesPodConfigWorkingDir(podName, imageName, "/srv"),
@@ -1179,7 +1179,7 @@ func TestAccKubernetesPod_config_container_startup_probe(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1210,7 +1210,7 @@ func TestAccKubernetesPod_termination_message_policy_default(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1241,7 +1241,7 @@ func TestAccKubernetesPod_termination_message_policy_override_as_file(t *testing
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1272,7 +1272,7 @@ func TestAccKubernetesPod_termination_message_policy_override_as_fallback_to_log
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1308,7 +1308,7 @@ func TestAccKubernetesPod_enableServiceLinks(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1352,7 +1352,7 @@ func TestAccKubernetesPod_bug1085(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 			{
 				Config: testAccKubernetesPodConfigWithVolume(name, imageName, `service_account_name="test"`),
@@ -1415,7 +1415,7 @@ func TestAccKubernetesPod_readinessGate(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1450,7 +1450,7 @@ func TestAccKubernetesPod_topologySpreadConstraint(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})
@@ -1489,7 +1489,7 @@ func TestAccKubernetesPod_runtimeClassName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "legacy_lifecycle_states"},
 			},
 		},
 	})


### PR DESCRIPTION
### Description

This should fix the latest failed tests that occured in the [acceptance test (kind)](https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5580602359/jobs/10197734754)

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing: https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5614140992

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
