### PR TITLE
Make target pod state / phase configurable

### DIFF
--- a/.changelog/2200.txt
+++ b/.changelog/2200.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/kubernetes_pod`: add a new attribute `target_state` to specify the Pod phase(s) that indicate whether it was successfully created.
+```
+
+```release-note:enhancement
+`resource/kubernetes_pod_v1`: add a new attribute `target_state` to specify the Pod phase(s) that indicate whether it was successfully created.
+```

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	api "k8s.io/api/core/v1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgApi "k8s.io/apimachinery/pkg/types"
@@ -56,11 +57,19 @@ func resourceKubernetesPodSchemaV1() map[string]*schema.Schema {
 				Schema: podSpecFields(false, false),
 			},
 		},
-		"legacy_lifecycle_states": {
-			Type:        schema.TypeBool,
-			Description: "Setting this attribute to `false` would set the target pod lifecycle state as [\"Running\", \"Succeeded\", \"Failed\"]. The default value of `true` would leave the target pod lifecycle state as [\"Running\"]`.",
+		"target_state": {
+			Type:        schema.TypeList,
+			Description: fmt.Sprintf("A list of the target statuses of the pod that indicate whether it was successfully created. Options: %q, %q, %q. Default: %q. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase", corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed, corev1.PodRunning),
 			Optional:    true,
-			Default:     true,
+			MinItems:    1,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(corev1.PodRunning),
+					string(corev1.PodSucceeded),
+					string(corev1.PodFailed),
+				}, false),
+			},
 		},
 	}
 }
@@ -77,7 +86,7 @@ func resourceKubernetesPodCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	pod := api.Pod{
+	pod := corev1.Pod{
 		ObjectMeta: metadata,
 		Spec:       *spec,
 	}
@@ -92,15 +101,9 @@ func resourceKubernetesPodCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(buildId(out.ObjectMeta))
 
-	target := []string{"Running"}
-
-	if d.Get("legacy_lifecycle_states").(bool) != true {
-		target = []string{"Running", "Succeeded", "Failed"}
-	}
-
 	stateConf := &resource.StateChangeConf{
-		Target:  target,
-		Pending: []string{"Pending"},
+		Target:  expandPodTargetState(d.Get("target_state").([]interface{})),
+		Pending: []string{string(corev1.PodPending)},
 		Timeout: d.Timeout(schema.TimeoutCreate),
 		Refresh: func() (interface{}, string, error) {
 			out, err := conn.CoreV1().Pods(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -59,15 +59,17 @@ func resourceKubernetesPodSchemaV1() map[string]*schema.Schema {
 		},
 		"target_state": {
 			Type:        schema.TypeList,
-			Description: fmt.Sprintf("A list of the pod phases that indicate whether it was successfully created. Options: %q, %q, %q. Default: %q. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase", corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed, corev1.PodRunning),
+			Description: fmt.Sprintf("A list of the pod phases that indicate whether it was successfully created. Options: %q, %q, %q, %q, %q. Default: %q. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase", corev1.PodPending, corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed, corev1.PodUnknown, corev1.PodRunning),
 			Optional:    true,
 			MinItems:    1,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{
+					string(corev1.PodPending),
 					string(corev1.PodRunning),
 					string(corev1.PodSucceeded),
 					string(corev1.PodFailed),
+					string(corev1.PodUnknown),
 				}, false),
 			},
 		},

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -59,7 +59,7 @@ func resourceKubernetesPodSchemaV1() map[string]*schema.Schema {
 		},
 		"target_state": {
 			Type:        schema.TypeList,
-			Description: fmt.Sprintf("A list of the target statuses of the pod that indicate whether it was successfully created. Options: %q, %q, %q. Default: %q. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase", corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed, corev1.PodRunning),
+			Description: fmt.Sprintf("A list of the pod phases that indicate whether it was successfully created. Options: %q, %q, %q. Default: %q. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase", corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed, corev1.PodRunning),
 			Optional:    true,
 			MinItems:    1,
 			Elem: &schema.Schema{

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -661,6 +661,18 @@ func flattenReadinessGates(in []v1.PodReadinessGate) ([]interface{}, error) {
 
 // Expanders
 
+func expandPodTargetState(p []interface{}) []string {
+	if len(p) > 0 {
+		t := make([]string, len(p))
+		for i, v := range p {
+			t[i] = v.(string)
+		}
+		return t
+	}
+
+	return []string{string(v1.PodRunning)}
+}
+
 func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 	obj := &v1.PodSpec{}
 	if len(p) == 0 || p[0] == nil {

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
-* `target_state` - (Optional) A list of the target statuses of the pod that indicate whether it was successfully created. Options: "Running", "Succeeded", "Failed". Default: "Running". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
+* `target_state` - (Optional) A list of the pod phases that indicate whether it was successfully created. Options: "Running", "Succeeded", "Failed". Default: "Running". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
 
 ## Nested Blocks
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
-* `legacy_lifecycle_states` - (Optional) Setting this attribute to `false` would set the target pod lifecycle state as `["Running", "Succeeded", "Failed"]`. The default value of `true` would leave the target pod lifecycle state as `["Running"]`.
+* `target_state` - (Optional) A list of the target statuses of the pod that indicate whether it was successfully created. Options: "Running", "Succeeded", "Failed". Default: "Running". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
 
 ## Nested Blocks
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
-* `target_state` - (Optional) A list of the pod phases that indicate whether it was successfully created. Options: "Running", "Succeeded", "Failed". Default: "Running". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
+* `target_state` - (Optional) A list of the pod phases that indicate whether it was successfully created. Options: "Pending", "Running", "Succeeded", "Failed", "Unknown". Default: "Running". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
 
 ## Nested Blocks
 

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
-* `target_state` - (Optional) A list of the pod phases that indicate whether it was successfully created. Options: `Running`, `Succeeded`, `Failed`. Default: `Running`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
+* `target_state` - (Optional) A list of the pod phases that indicate whether it was successfully created. Options: "Pending", "Running", "Succeeded", "Failed", "Unknown". Default: "Running". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
 
 ## Nested Blocks
 

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
-* `target_state` - (Optional) A list of the target statuses of the pod that indicate whether it was successfully created. Options: `Running`, `Succeeded`, `Failed`. Default: `Running`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
+* `target_state` - (Optional) A list of the pod phases that indicate whether it was successfully created. Options: `Running`, `Succeeded`, `Failed`. Default: `Running`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
 
 ## Nested Blocks
 

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -169,6 +169,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard pod's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 * `spec` - (Required) Spec of the pod owned by the cluster
+* `target_state` - (Optional) A list of the target statuses of the pod that indicate whether it was successfully created. Options: `Running`, `Succeeded`, `Failed`. Default: `Running`. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase")
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

Replace Pod resource option `legacy_lifecycle_states` to `target_state`. It allows to specify the Pod phase(s) that indicate whether it was successfully created. Default to `Running`. It allows all 5 currently available phases even though some of them may not be an indication of a successfully created pod.

**Links:**

- https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?
    - All tests: hhttps://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5691661382/job/15427262240
    - Pod tests: https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5691660004/job/15427258099

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note:enhancement
`resource/kubernetes_pod`: add a new attribute `target_state` to specify the Pod phase(s) that indicate whether it was successfully created.

`resource/kubernetes_pod_v1`: add a new attribute `target_state` to specify the Pod phase(s) that indicate whether it was successfully created.
```

### References

Enhance: https://github.com/hashicorp/terraform-provider-kubernetes/pull/2141

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
