### PR TITLE
Add ability to execute tests in parallel

### DIFF
--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -12,6 +12,9 @@ on:
       terraformVersion:
         description: Terraform version
         default: 1.5.3
+      parallelRuns:
+        description: The maximum number of tests to run simultaneously
+        default: 8
   schedule:
     - cron: '0 21 * * *'
 
@@ -19,6 +22,7 @@ env:
   KUBECONFIG: ${{ github.workspace }}/.kube/config
   KIND_VERSION: ${{ github.event.inputs.kind_version || vars.KIND_VERSION }}
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
 
 jobs:
   acceptance_tests:
@@ -47,6 +51,3 @@ jobs:
           TESTARGS: -run '${{ github.event.inputs.runTests }}'
         run: |
           make testacc
-
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ website/vendor
 
 # output binary
 terraform-provider-kubernetes
+__debug_bin

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,6 +17,9 @@ endif
 LAST_RELEASE?=$$(git describe --tags $$(git rev-list --tags --max-count=1))
 THIS_RELEASE?=$$(git rev-parse --abbrev-ref HEAD)
 
+# The maximum number of tests to run simultaneously.
+PARALLEL_RUNS?=8
+
 default: build
 
 all: build depscheck fmtcheck test testacc test-compile tests-lint tests-lint-fix tools vet website-lint website-lint-fix
@@ -78,7 +81,7 @@ test: fmtcheck
 	go test ./tools
 
 testacc: fmtcheck vet
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 3h
+	TF_ACC=1 go test $(TEST) -v -vet=off $(TESTARGS) -parallel $(PARALLEL_RUNS) -timeout 3h
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \


### PR DESCRIPTION
### Description

This PR adds `-parallel` option to run acceptance tests. It is recommended(see `go help testflag`) to set the value equal to `GOMAXPROCS`, however, the selected default value is **_8_**. This number demonstrates the most optimal performance time-wise. This statement was validated on a default GH action runner where `GOMAXPROCS` is equal to 2 and on the dev laptops, where `GOMAXPROCS` is equal to 10.

The number can be changed by setting up the environment variable `PARALLEL_RUNS` to the desired number. In the case of GH actions, the number can be set via inputs when tests run manually, or picked up from the GH variable `PARALLEL_RUNS` when tests run on schedule.

#### Usage example

_default_
```console
$ make testacc TESTARGS="-count 1 -run 'TestAccKubernetesPod_'"

==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test ".../terraform-provider-kubernetes/kubernetes" -v -vet=off -count 1 -run 'TestAccKubernetesPod_' -parallel 8 -timeout 3h
```

_change the number of parallel runs_
```console
$ PARALLEL_RUNS=16 make testacc TESTARGS="-count 1 -run 'TestAccKubernetesPod_'"

==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test ".../terraform-provider-kubernetes/kubernetes" -v -vet=off -count 1 -run 'TestAccKubernetesPod_' -parallel 16 -timeout 3h
```

In addition to that, I have added `-vet=off` to the `testacc` target, since it runs `go vet` before execute tests.

### Acceptance tests

This change doesn't affect current acceptance tests since they are not written to be run in parallel. In other words, the option `-parallel` is ignored.

Example:

- https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/5714107313/job/15480770684

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
