### PR TITLE
Add a new GH action to validate Web links in the doc files

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,30 @@
+name: Check Markdown links
+
+on:
+  schedule:
+    # Run once a week, every Sunday
+    - cron: '30 4 * * 0'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'website/docs/**'
+  workflow_dispatch:
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Run Markdown links checker
+        uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # 1.0.15
+        with:
+          base-branch: main
+          config-file: '.github/workflows/markdown.links.config.json'
+          file-extension: '.markdown'
+          folder-path: 'website/docs'
+          use-verbose-mode: yes
+          use-quiet-mode: yes
+          max-depth: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,8 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - name: Run markdown link checker
-      uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # 1.0.15
-      with:
-        config-file: '.github/workflows/markdown.links.config.json'
-        folder-path: 'website/'
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

Add a new GH action to run on schedule and validate broken web-links:

- GH Action: https://github.com/gaurav-nelson/github-action-markdown-link-check
- Underhood tool: https://github.com/tcort/markdown-link-check

### Acceptance tests

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
