### PR TITLE
Update `kubernetes_config_map_v1_data` resource error handling

### DIFF
--- a/.changelog/2230.txt
+++ b/.changelog/2230.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/kubernetes_config_map_v1_data`: improve error handling while validating the existence of the target ConfigMap.
+```

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -158,7 +158,11 @@ func resourceKubernetesConfigMapV1DataUpdate(ctx context.Context, d *schema.Reso
 			// if the resource is gone
 			return nil
 		}
-		return diag.Errorf("The configmap %q does not exist", name)
+		if statusErr, ok := err.(*errors.StatusError); ok && errors.IsNotFound(statusErr) {
+			return diag.Errorf("The ConfigMap %q does not exist", name)
+		}
+
+		return diag.Errorf("Have got the following error while validating the existence of the ConfigMap %q: %v", name, err)
 	}
 
 	// craft the patch to update the data

--- a/kubernetes/resource_kubernetes_config_map_v1_data_test.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data_test.go
@@ -5,6 +5,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -17,7 +18,7 @@ func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
 	namespace := "default"
 	resourceName := "kubernetes_config_map_v1_data.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			createConfigMap(name, namespace)
@@ -64,6 +65,24 @@ func TestAccKubernetesConfigMapV1Data_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "field_manager", "tftest"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesConfigMapV1Data_validation(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_config_map_v1_data.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccKubernetesConfigMapV1Data_empty(name),
+				ExpectError: regexp.MustCompile("The ConfigMap .* does not exist"),
 			},
 		},
 	})


### PR DESCRIPTION
### Description

Improve error handling while validating the existence of the target ConfigMap.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$  make testacc TESTARGS="-count 1 -run 'TestAccKubernetesConfigMapV1Data_*'"

==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test ".../terraform-provider-kubernetes/kubernetes" -v -vet=off -count 1 -run 'TestAccKubernetesConfigMapV1Data_*' -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesConfigMapV1Data_basic
=== PAUSE TestAccKubernetesConfigMapV1Data_basic
=== RUN   TestAccKubernetesConfigMapV1Data_validation
=== PAUSE TestAccKubernetesConfigMapV1Data_validation
=== CONT  TestAccKubernetesConfigMapV1Data_basic
=== CONT  TestAccKubernetesConfigMapV1Data_validation
--- PASS: TestAccKubernetesConfigMapV1Data_validation (0.72s)
--- PASS: TestAccKubernetesConfigMapV1Data_basic (6.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	6.944s
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note:enhancement
`resource/kubernetes_config_map_v1_data`: improve error handling while validating the existence of the target ConfigMap.
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/2224

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
