### PR TITLE
Update flaky Pod test

### DIFF
--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   acceptance_tests:
-    runs-on: [custom, linux, small]
+    runs-on: [custom, linux, medium]
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   acceptance_tests:
-    runs-on: ubuntu-latest
+    runs-on: [custom, linux, small]
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/kubernetes/resource_kubernetes_pod_v1_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_test.go
@@ -1561,10 +1561,14 @@ func TestAccKubernetesPodV1_phase(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "target_state"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"metadata.0.resource_version",
+					"spec.0.node_name",
+					"target_state",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
### Description

Update the flaky Pod test `TestAccKubernetesPodV1_phase` and change "runs-on" in the kind acceptance test workflow.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

- https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/6022134125/job/16336270819

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):


```release-note
NONE
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
