### PR TITLE
Update Pod affinity tests

### DIFF
--- a/kubernetes/resource_kubernetes_pod_v1_affinity_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_affinity_test.go
@@ -282,10 +282,10 @@ resource "kubernetes_pod_v1" "test" {
 
 func testAccKubernetesPodV1ConfigWithNodeAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
-    metadata {
-      name = %[1]q
-    }
+  metadata {
+    name = %[1]q
   }
+}
 
 resource "kubernetes_pod_v1" "test" {
   metadata {
@@ -334,10 +334,10 @@ resource "kubernetes_pod_v1" "test" {
 
 func testAccKubernetesPodV1ConfigWithPodAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
-    metadata {
-      name = %[1]q
-    }
+  metadata {
+    name = %[1]q
   }
+}
 
 resource "kubernetes_pod_v1" "test" {
   metadata {
@@ -381,10 +381,10 @@ resource "kubernetes_pod_v1" "test" {
 
 func testAccKubernetesPodV1ConfigWithPodAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
-    metadata {
-      name = %[1]q
-    }
+  metadata {
+    name = %[1]q
   }
+}
 
 resource "kubernetes_pod_v1" "test" {
   metadata {
@@ -432,10 +432,10 @@ resource "kubernetes_pod_v1" "test" {
 
 func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
-    metadata {
-      name = %[1]q
-    }
+  metadata {
+    name = %[1]q
   }
+}
 
 resource "kubernetes_pod_v1" "test" {
   metadata {
@@ -479,10 +479,10 @@ resource "kubernetes_pod_v1" "test" {
 
 func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
 	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
-    metadata {
-      name = %[1]q
-    }
+  metadata {
+    name = %[1]q
   }
+}
 
 resource "kubernetes_pod_v1" "test" {
   metadata {

--- a/kubernetes/resource_kubernetes_pod_v1_affinity_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_affinity_test.go
@@ -230,12 +230,19 @@ func TestAccKubernetesPodV1_with_pod_anti_affinity_with_preferred_during_schedul
 }
 
 func testAccKubernetesPodV1ConfigWithNodeAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
+  metadata {
+    name = %[1]q
+  }
+}
+
+resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
     }
-    name = "%s"
+    namespace = kubernetes_namespace_v1.test.metadata.0.name
+    name      = %[1]q
   }
   spec {
     affinity {
@@ -257,7 +264,7 @@ func testAccKubernetesPodV1ConfigWithNodeAffinityWithRequiredDuringSchedulingIgn
       }
     }
     container {
-      image = "%s"
+      image = %[2]q
       name  = "containername"
       args  = ["sleep", "300"]
       resources {
@@ -274,12 +281,19 @@ func testAccKubernetesPodV1ConfigWithNodeAffinityWithRequiredDuringSchedulingIgn
 }
 
 func testAccKubernetesPodV1ConfigWithNodeAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
+    metadata {
+      name = %[1]q
+    }
+  }
+
+resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
     }
-    name = "%s"
+    namespace = kubernetes_namespace_v1.test.metadata.0.name
+    name      = %[1]q
   }
   spec {
     affinity {
@@ -302,7 +316,7 @@ func testAccKubernetesPodV1ConfigWithNodeAffinityWithPreferredDuringSchedulingIg
       }
     }
     container {
-      image = "%s"
+      image = %[2]q
       name  = "containername"
       args  = ["sleep", "300"]
       resources {
@@ -319,12 +333,19 @@ func testAccKubernetesPodV1ConfigWithNodeAffinityWithPreferredDuringSchedulingIg
 }
 
 func testAccKubernetesPodV1ConfigWithPodAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
+    metadata {
+      name = %[1]q
+    }
+  }
+
+resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
     }
-    name = "%s"
+    namespace = kubernetes_namespace_v1.test.metadata.0.name
+    name      = %[1]q
   }
   spec {
     affinity {
@@ -342,7 +363,7 @@ func testAccKubernetesPodV1ConfigWithPodAffinityWithRequiredDuringSchedulingIgno
       }
     }
     container {
-      image = "%s"
+      image = %[2]q
       name  = "containername"
       args  = ["sleep", "300"]
       resources {
@@ -359,12 +380,19 @@ func testAccKubernetesPodV1ConfigWithPodAffinityWithRequiredDuringSchedulingIgno
 }
 
 func testAccKubernetesPodV1ConfigWithPodAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
+    metadata {
+      name = %[1]q
+    }
+  }
+
+resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
     }
-    name = "%s"
+    namespace = kubernetes_namespace_v1.test.metadata.0.name
+    name      = %[1]q
   }
   spec {
     affinity {
@@ -386,7 +414,7 @@ func testAccKubernetesPodV1ConfigWithPodAffinityWithPreferredDuringSchedulingIgn
       }
     }
     container {
-      image = "%s"
+      image = %[2]q
       name  = "containername"
       args  = ["sleep", "300"]
       resources {
@@ -403,12 +431,19 @@ func testAccKubernetesPodV1ConfigWithPodAffinityWithPreferredDuringSchedulingIgn
 }
 
 func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
+    metadata {
+      name = %[1]q
+    }
+  }
+
+resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
     }
-    name = "%s"
+    namespace = kubernetes_namespace_v1.test.metadata.0.name
+    name      = %[1]q
   }
   spec {
     affinity {
@@ -426,7 +461,7 @@ func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithRequiredDuringScheduling
       }
     }
     container {
-      image = "%s"
+      image = %[2]q
       name  = "containername"
       args  = ["sleep", "300"]
       resources {
@@ -443,12 +478,19 @@ func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithRequiredDuringScheduling
 }
 
 func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_namespace_v1" "test" {
+    metadata {
+      name = %[1]q
+    }
+  }
+
+resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
     }
-    name = "%s"
+    namespace = kubernetes_namespace_v1.test.metadata.0.name
+    name      = %[1]q
   }
   spec {
     affinity {
@@ -469,7 +511,7 @@ func testAccKubernetesPodV1ConfigWithPodAntiAffinityWithPreferredDuringSchedulin
       }
     }
     container {
-      image = "%s"
+      image = %[2]q
       name  = "containername"
       args  = ["sleep", "300"]
       resources {

--- a/kubernetes/resource_kubernetes_pod_v1_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_test.go
@@ -1339,7 +1339,7 @@ func TestAccKubernetesPodV1_bug1085(t *testing.T) {
 	var conf api.Pod
 	resourceName := "kubernetes_pod_v1.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); skipIfNotRunningInMinikube(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckKubernetesPodV1Destroy,
@@ -1514,7 +1514,7 @@ func TestAccKubernetesPodV1_with_ephemeral_storage(t *testing.T) {
 	resourceName := "kubernetes_pod_v1.test"
 	volumeName := "ephemeral"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			skipIfNotRunningInKind(t)


### PR DESCRIPTION
### Description

Make Pod affinity tests run in separate namespaces.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

- https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/6052470499/job/16425993197

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
