### PR TITLE
Add termination_grace_period_seconds to pod tests

### DIFF
--- a/kubernetes/resource_kubernetes_daemon_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1_test.go
@@ -475,6 +475,7 @@ func testAccKubernetesDaemonSetV1Config_minimal(name, imageName string) string {
           name    = "tf-acc-test"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -523,6 +524,7 @@ func testAccKubernetesDaemonSetV1Config_basic(name, imageName string) string {
           name    = "tf-acc-test"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -584,8 +586,8 @@ func testAccKubernetesDaemonSetV1Config_modified(name, imageName string) string 
             name = "use-vc"
           }
         }
-
-        dns_policy = "Default"
+        dns_policy                       = "Default"
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -629,6 +631,7 @@ func testAccKubernetesDaemonSetV1ConfigWithTemplateMetadata(depName, imageName s
           image = "%s"
           name  = "containername"
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -672,6 +675,7 @@ func testAccKubernetesDaemonSetV1ConfigWithTemplateMetadataModified(depName, ima
           image = "%s"
           name  = "containername"
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -714,6 +718,7 @@ func testAccKubernetesDaemonSetV1WithInitContainer(depName, imageName string) st
           image = "%s"
           name  = "containername"
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -746,6 +751,7 @@ func testAccKubernetesDaemonSetV1WithNoTopLevelLabels(depName, imageName string)
           image = "%s"
           name  = "containername"
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -799,6 +805,7 @@ func testAccKubernetesDaemonSetV1ConfigWithTolerations(rcName, imageName string,
           image = "%s"
           name  = "containername"
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -846,6 +853,7 @@ func testAccKubernetesDaemonSetV1ConfigWithContainerSecurityContextSeccompProfil
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -895,6 +903,7 @@ func testAccKubernetesDaemonSetV1ConfigWithContainerSecurityContextSeccompProfil
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -945,6 +954,7 @@ func testAccKubernetesDaemonSetV1ConfigWithResourceRequirements(deploymentName, 
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -986,6 +996,7 @@ func testAccKubernetesDaemonSetV1ConfigWithEmptyResourceRequirements(deploymentN
             requests = {}
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1029,6 +1040,7 @@ func testAccKubernetesDaemonSetV1ConfigWithResourceRequirementsLimitsOnly(deploy
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1072,6 +1084,7 @@ func testAccKubernetesDaemonSetV1ConfigWithResourceRequirementsRequestsOnly(depl
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }

--- a/kubernetes/resource_kubernetes_deployment_v1_test.go
+++ b/kubernetes/resource_kubernetes_deployment_v1_test.go
@@ -1296,6 +1296,7 @@ func testAccKubernetesDeploymentV1Config_minimal(name, imageName string) string 
           name    = "tf-acc-test"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1365,6 +1366,7 @@ func testAccKubernetesDeploymentV1Config_basic(name, imageName string) string {
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1479,6 +1481,7 @@ resource "kubernetes_deployment_v1" "test" {
             "%s",
           ]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1565,6 +1568,7 @@ func testAccKubernetesDeploymentV1Config_modified(name, imageName string) string
           name  = "tf-acc-test"
           args  = ["test-webserver"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1608,6 +1612,7 @@ func testAccKubernetesDeploymentV1Config_generatedName(prefix, imageName string)
           name    = "tf-acc-test"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1652,6 +1657,7 @@ func testAccKubernetesDeploymentV1ConfigWithSecurityContext(deploymentName, imag
           name    = "containername"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1697,6 +1703,7 @@ func testAccKubernetesDeploymentV1ConfigWithSecurityContextRunAsGroup(deployment
           name    = "containername"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1746,6 +1753,7 @@ func testAccKubernetesDeploymentV1ConfigWithSecurityContextSysctl(deploymentName
           name    = "containername"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1800,6 +1808,7 @@ func testAccKubernetesDeploymentV1ConfigWithTolerations(deploymentName, imageNam
           name    = "containername"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1846,6 +1855,7 @@ func testAccKubernetesDeploymentV1ConfigWithLivenessProbeUsingExec(deploymentNam
             period_seconds        = 5
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1898,6 +1908,7 @@ func testAccKubernetesDeploymentV1ConfigWithLivenessProbeUsingHTTPGet(deployment
             period_seconds        = 3
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1944,6 +1955,7 @@ func testAccKubernetesDeploymentV1ConfigWithLivenessProbeUsingTCP(deploymentName
             period_seconds        = 3
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -1995,6 +2007,7 @@ func testAccKubernetesDeploymentV1ConfigWithLifeCycle(deploymentName, imageName 
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2065,6 +2078,7 @@ func testAccKubernetesDeploymentV1ConfigWithContainerSecurityContext(deploymentN
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2115,12 +2129,14 @@ func testAccKubernetesDeploymentV1ConfigWithContainerSecurityContextRunAsGroup(d
         container {
           name    = "container2"
           image   = "%s"
-          command = ["sh", "-c", "echo The app is running! && sleep 3600"]
+          command = ["sh", "-c", "echo The app is running! && sleep 300"]
           security_context {
             run_as_group = 200
             run_as_user  = 201
           }
         }
+
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2169,6 +2185,7 @@ func testAccKubernetesDeploymentV1ConfigWithContainerSecurityContextSeccompProfi
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2219,6 +2236,7 @@ func testAccKubernetesDeploymentV1ConfigWithContainerSecurityContextSeccompProfi
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2227,7 +2245,7 @@ func testAccKubernetesDeploymentV1ConfigWithContainerSecurityContextSeccompProfi
 }
 
 func testAccKubernetesDeploymentV1ConfigWithVolumeMounts(secretName, deploymentName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2276,9 +2294,10 @@ resource "kubernetes_deployment_v1" "test" {
           name = "db"
 
           secret {
-            secret_name = "${kubernetes_secret.test.metadata.0.name}"
+            secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2287,7 +2306,7 @@ resource "kubernetes_deployment_v1" "test" {
 }
 
 func testAccKubernetesDeploymentV1ConfigWithVolumeMountsNone(secretName, deploymentName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2331,9 +2350,11 @@ resource "kubernetes_deployment_v1" "test" {
           name = "db"
 
           secret {
-            secret_name = "${kubernetes_secret.test.metadata.0.name}"
+            secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
           }
         }
+
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2384,6 +2405,7 @@ func testAccKubernetesDeploymentV1ConfigWithResourceRequirements(deploymentName,
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2427,6 +2449,7 @@ func testAccKubernetesDeploymentV1ConfigWithEmptyResourceRequirements(deployment
             requests = {}
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2472,6 +2495,7 @@ func testAccKubernetesDeploymentV1ConfigWithResourceRequirementsLimitsOnly(deplo
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2517,6 +2541,7 @@ func testAccKubernetesDeploymentV1ConfigWithResourceRequirementsRequestsOnly(dep
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2569,6 +2594,8 @@ func testAccKubernetesDeploymentV1ConfigWithEmptyDirVolumes(deploymentName, imag
             medium = "Memory"
           }
         }
+
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2620,6 +2647,8 @@ func testAccKubernetesDeploymentV1ConfigWithEmptyDirVolumesModified(deploymentNa
             size_limit = "128Mi"
           }
         }
+
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2661,6 +2690,7 @@ func testAccKubernetesDeploymentV1ConfigWithDeploymentStrategy(deploymentName, s
           name    = "containername"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2704,6 +2734,7 @@ func testAccKubernetesDeploymentV1ConfigWithShareProcessNamespace(deploymentName
           name    = "containername2"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2750,6 +2781,7 @@ func testAccKubernetesDeploymentV1ConfigWithDeploymentStrategyRollingUpdate(depl
           name    = "containername"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2817,6 +2849,8 @@ func testAccKubernetesDeploymentV1ConfigHostAliases(name string, imageName strin
           ip        = "127.0.0.6"
           hostnames = ["xyz.com"]
         }
+
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2850,6 +2884,7 @@ func testAccKubernetesDeploymentV1ConfigWithAutomountServiceAccountToken(deploym
           image   = "%s"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2858,7 +2893,7 @@ func testAccKubernetesDeploymentV1ConfigWithAutomountServiceAccountToken(deploym
 }
 
 func testAccKubernetesDeploymentV1Config_ForceNew(secretName, label, name, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = %[1]q
   }
@@ -2907,9 +2942,11 @@ resource "kubernetes_deployment_v1" "test" {
           name = "db"
 
           secret {
-            secret_name = "${kubernetes_secret.test.metadata.0.name}"
+            secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
           }
         }
+
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -2958,6 +2995,7 @@ func testAccKubernetesDeploymentV1ConfigWithResourceFieldSelector(rcName, imageN
             }
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
   }

--- a/kubernetes/resource_kubernetes_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_job_v1_test.go
@@ -72,7 +72,7 @@ func TestAccKubernetesJobV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.active_deadline_seconds", "120"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.backoff_limit", "10"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.completions", "10"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.completions", "4"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
@@ -125,7 +125,7 @@ func TestAccKubernetesJobV1_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.active_deadline_seconds", "120"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.backoff_limit", "10"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.completions", "10"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.completions", "4"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
@@ -134,7 +134,7 @@ func TestAccKubernetesJobV1_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "10", "false", "2"),
+				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "4", "false", "2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf2),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.active_deadline_seconds", "121"),
@@ -142,15 +142,15 @@ func TestAccKubernetesJobV1_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "11", "false", "2"),
+				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "5", "false", "2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf2),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.backoff_limit", "11"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.backoff_limit", "5"),
 					testAccCheckKubernetesJobV1ForceNew(&conf1, &conf2, false),
 				),
 			},
 			{
-				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "11", "true", "2"),
+				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "5", "true", "2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf2),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.manual_selector", "true"),
@@ -158,7 +158,7 @@ func TestAccKubernetesJobV1_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "11", "true", "3"),
+				Config: testAccKubernetesJobV1Config_updateMutableFields(name, imageName, "121", "5", "true", "3"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf2),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.parallelism", "3"),
@@ -166,15 +166,15 @@ func TestAccKubernetesJobV1_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesJobV1Config_updateImmutableFields(name, imageName, "12"),
+				Config: testAccKubernetesJobV1Config_updateImmutableFields(name, imageName, "6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf2),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.completions", "12"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.completions", "6"),
 					testAccCheckKubernetesJobV1ForceNew(&conf1, &conf2, true),
 				),
 			},
 			{
-				Config: testAccKubernetesJobV1Config_updateImmutableFields(name, imageName1, "12"),
+				Config: testAccKubernetesJobV1Config_updateImmutableFields(name, imageName1, "6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf3),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.image", imageName1),
@@ -305,7 +305,7 @@ func testAccKubernetesJobV1Config_basic(name, imageName string) string {
   spec {
     active_deadline_seconds = 120
     backoff_limit           = 10
-    completions             = 10
+    completions             = 4
     parallelism             = 2
     template {
       metadata {}
@@ -331,7 +331,7 @@ func testAccKubernetesJobV1Config_updateMutableFields(name, imageName, activeDea
   spec {
     active_deadline_seconds = %s
     backoff_limit           = %s
-    completions             = 10
+    completions             = 4
     manual_selector         = %s
     parallelism             = %s
     template {
@@ -380,7 +380,7 @@ func testAccKubernetesJobV1Config_ttl_seconds_after_finished(name, imageName str
   }
   spec {
     backoff_limit              = 10
-    completions                = 10
+    completions                = 4
     parallelism                = 2
     ttl_seconds_after_finished = "60"
     template {

--- a/kubernetes/resource_kubernetes_pod_v1_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_test.go
@@ -190,9 +190,9 @@ func TestAccKubernetesPodV1_updateArgsForceNew(t *testing.T) {
 
 	podName := acctest.RandomWithPrefix("tf-acc-test")
 
-	imageName := "hashicorp/http-echo:latest"
-	argsBefore := `["-listen=:80", "-text='before modification'"]`
-	argsAfter := `["-listen=:80", "-text='after modification'"]`
+	imageName := busyboxImage
+	argsBefore := `["sleep", "60"]`
+	argsAfter := `["sleep", "300"]`
 	resourceName := "kubernetes_pod_v1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -211,8 +211,8 @@ func TestAccKubernetesPodV1_updateArgsForceNew(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.image", imageName),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.0", "-listen=:80"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.1", "-text='before modification'"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.0", "sleep"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.1", "60"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.name", "containername"),
 				),
 			},
@@ -233,8 +233,8 @@ func TestAccKubernetesPodV1_updateArgsForceNew(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.image", imageName),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.0", "-listen=:80"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.1", "-text='after modification'"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.0", "sleep"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.args.1", "300"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.name", "containername"),
 					testAccCheckKubernetesPodForceNew(&conf1, &conf2, true),
 				),
@@ -1098,7 +1098,7 @@ func TestAccKubernetesPodV1_config_with_automount_service_account_token(t *testi
 			{
 				Config: testAccKubernetesPodV1ConfigWithAutomountServiceAccountToken(saName, podName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesServiceAccountV1Exists("kubernetes_service_account.test", &confSA),
+					testAccCheckKubernetesServiceAccountV1Exists("kubernetes_service_account_v1.test", &confSA),
 					testAccCheckKubernetesPodV1Exists(resourceName, &confPod),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.automount_service_account_token", "true"),
 				),
@@ -1701,7 +1701,7 @@ func testAccCheckKubernetesPersistentVolumeClaimCreated(name string, obj *api.Pe
 }
 
 func testAccKubernetesPodV1ConfigBasic(secretName, configMapName, podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -1711,7 +1711,7 @@ func testAccKubernetesPodV1ConfigBasic(secretName, configMapName, podName, image
   }
 }
 
-resource "kubernetes_secret" "test_from" {
+resource "kubernetes_secret_v1" "test_from" {
   metadata {
     name = "%s-from"
   }
@@ -1722,7 +1722,7 @@ resource "kubernetes_secret" "test_from" {
   }
 }
 
-resource "kubernetes_config_map" "test" {
+resource "kubernetes_config_map_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -1732,7 +1732,7 @@ resource "kubernetes_config_map" "test" {
   }
 }
 
-resource "kubernetes_config_map" "test_from" {
+resource "kubernetes_config_map_v1" "test_from" {
   metadata {
     name = "%s-from"
   }
@@ -1763,7 +1763,7 @@ resource "kubernetes_pod_v1" "test" {
 
         value_from {
           secret_key_ref {
-            name     = "${kubernetes_secret.test.metadata.0.name}"
+            name     = "${kubernetes_secret_v1.test.metadata.0.name}"
             key      = "one"
             optional = true
           }
@@ -1773,7 +1773,7 @@ resource "kubernetes_pod_v1" "test" {
         name = "EXPORTED_VARIABLE_FROM_CONFIG_MAP"
         value_from {
           config_map_key_ref {
-            name     = "${kubernetes_config_map.test.metadata.0.name}"
+            name     = "${kubernetes_config_map_v1.test.metadata.0.name}"
             key      = "one"
             optional = true
           }
@@ -1782,14 +1782,14 @@ resource "kubernetes_pod_v1" "test" {
 
       env_from {
         config_map_ref {
-          name     = "${kubernetes_config_map.test_from.metadata.0.name}"
+          name     = "${kubernetes_config_map_v1.test_from.metadata.0.name}"
           optional = true
         }
         prefix = "FROM_CM_"
       }
       env_from {
         secret_ref {
-          name     = "${kubernetes_secret.test_from.metadata.0.name}"
+          name     = "${kubernetes_secret_v1.test_from.metadata.0.name}"
           optional = false
         }
         prefix = "FROM_S_"
@@ -1800,7 +1800,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "db"
 
       secret {
-        secret_name = "${kubernetes_secret.test.metadata.0.name}"
+        secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
       }
     }
   }
@@ -1846,7 +1846,7 @@ func testAccKubernetesPodV1ConfigWithInitContainer(podName, image string) string
     container {
       name    = "container"
       image   = "%s"
-      command = ["sh", "-c", "echo The app is running! && sleep 3600"]
+      command = ["sh", "-c", "echo The app is running! && sleep 300"]
 
       resources {
         requests = {
@@ -1868,10 +1868,11 @@ func testAccKubernetesPodV1ConfigWithInitContainer(podName, image string) string
         }
       }
     }
+    termination_grace_period_seconds = 1
   }
 }
 
-resource "kubernetes_service" "test" {
+resource "kubernetes_service_v1" "test" {
   metadata {
     name = "%s-init-service"
   }
@@ -2037,6 +2038,7 @@ func testAccKubernetesPodV1ConfigWithLivenessProbeUsingExec(podName, imageName s
         period_seconds        = 5
       }
     }
+    termination_grace_period_seconds = 1
   }
 }
 `, podName, imageName)
@@ -2208,7 +2210,7 @@ func testAccKubernetesPodV1ConfigWithContainerSecurityContext(podName, imageName
 }
 
 func testAccKubernetesPodV1ConfigWithVolumeMounts(secretName, podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2245,7 +2247,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "db"
 
       secret {
-        secret_name = "${kubernetes_secret.test.metadata.0.name}"
+        secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
       }
     }
   }
@@ -2254,7 +2256,7 @@ resource "kubernetes_pod_v1" "test" {
 }
 
 func testAccKubernetesPodV1ConfigWithSecretItemsVolume(secretName, podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2290,7 +2292,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "db"
 
       secret {
-        secret_name = "${kubernetes_secret.test.metadata.0.name}"
+        secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
 
         items {
           key  = "one"
@@ -2304,7 +2306,7 @@ resource "kubernetes_pod_v1" "test" {
 }
 
 func testAccKubernetesPodV1ConfigWithConfigMapVolume(secretName, podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_config_map" "test" {
+	return fmt.Sprintf(`resource "kubernetes_config_map_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2360,7 +2362,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "cfg"
 
       config_map {
-        name         = "${kubernetes_config_map.test.metadata.0.name}"
+        name         = "${kubernetes_config_map_v1.test.metadata.0.name}"
         default_mode = "0777"
       }
     }
@@ -2369,7 +2371,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "cfg-item"
 
       config_map {
-        name = "${kubernetes_config_map.test.metadata.0.name}"
+        name = "${kubernetes_config_map_v1.test.metadata.0.name}"
 
         items {
           key  = "one"
@@ -2382,7 +2384,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "cfg-item-with-mode"
 
       config_map {
-        name = "${kubernetes_config_map.test.metadata.0.name}"
+        name = "${kubernetes_config_map_v1.test.metadata.0.name}"
 
         items {
           key  = "one"
@@ -2396,7 +2398,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "cfg-binary"
 
       config_map {
-        name = "${kubernetes_config_map.test.metadata.0.name}"
+        name = "${kubernetes_config_map_v1.test.metadata.0.name}"
 
         items {
           key  = "raw"
@@ -2404,13 +2406,14 @@ resource "kubernetes_pod_v1" "test" {
         }
       }
     }
+    termination_grace_period_seconds = 1
   }
 }
 `, secretName, podName, imageName)
 }
 
 func testAccKubernetesPodV1CSIVolume(imageName, podName, secretName, volumeName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test-secret" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test-secret" {
   metadata {
     name = %[3]q
   }
@@ -2431,7 +2434,7 @@ resource "kubernetes_pod_v1" "test" {
     container {
       image   = %[2]q
       name    = %[1]q
-      command = ["sleep", "36000"]
+      command = ["sleep", "300"]
       volume_mount {
         name       = %[4]q
         mount_path = "/volume"
@@ -2452,12 +2455,13 @@ resource "kubernetes_pod_v1" "test" {
         }
       }
     }
+    termination_grace_period_seconds = 1
   }
 }`, podName, imageName, secretName, volumeName)
 }
 
 func testAccKubernetesPodV1ProjectedVolume(cfgMapName, cfgMap2Name, secretName, podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_config_map" "test" {
+	return fmt.Sprintf(`resource "kubernetes_config_map_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2471,7 +2475,7 @@ func testAccKubernetesPodV1ProjectedVolume(cfgMapName, cfgMap2Name, secretName, 
   }
 }
 
-resource "kubernetes_config_map" "test2" {
+resource "kubernetes_config_map_v1" "test2" {
   metadata {
     name = "%s"
   }
@@ -2485,7 +2489,7 @@ resource "kubernetes_config_map" "test2" {
   }
 }
 
-resource "kubernetes_secret" "test" {
+resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2512,7 +2516,7 @@ resource "kubernetes_pod_v1" "test" {
       image = "%s"
       name  = "containername"
 
-      command = ["sleep", "3600"]
+      command = ["sleep", "300"]
 
       lifecycle {
         post_start {
@@ -2534,7 +2538,7 @@ resource "kubernetes_pod_v1" "test" {
         default_mode = "0777"
         sources {
           config_map {
-            name = "${kubernetes_config_map.test.metadata.0.name}"
+            name = "${kubernetes_config_map_v1.test.metadata.0.name}"
             items {
               key  = "raw"
               path = "raw.txt"
@@ -2543,7 +2547,7 @@ resource "kubernetes_pod_v1" "test" {
         }
         sources {
           config_map {
-            name = "${kubernetes_config_map.test2.metadata.0.name}"
+            name = "${kubernetes_config_map_v1.test2.metadata.0.name}"
             items {
               key  = "raw"
               path = "raw-again.txt"
@@ -2552,7 +2556,7 @@ resource "kubernetes_pod_v1" "test" {
         }
         sources {
           secret {
-            name = "${kubernetes_secret.test.metadata.0.name}"
+            name = "${kubernetes_secret_v1.test.metadata.0.name}"
             items {
               key  = "one"
               path = "secret.txt"
@@ -2578,6 +2582,7 @@ resource "kubernetes_pod_v1" "test" {
         }
       }
     }
+    termination_grace_period_seconds = 1
   }
 }
 `, cfgMapName, cfgMap2Name, secretName, podName, imageName)
@@ -2799,6 +2804,7 @@ func testAccKubernetesPodV1ConfigArgsUpdate(podName, imageName, args string) str
       args  = %s
       name  = "containername"
     }
+    termination_grace_period_seconds = 1
   }
 }
 `, podName, imageName, args)
@@ -2826,7 +2832,7 @@ func testAccKubernetesPodV1ConfigEnvUpdate(podName, imageName, val string) strin
 }
 
 func testAccKubernetesPodV1ConfigWithAutomountServiceAccountToken(saName string, podName string, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_service_account" "test" {
+	return fmt.Sprintf(`resource "kubernetes_service_account_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2842,7 +2848,7 @@ resource "kubernetes_pod_v1" "test" {
   }
 
   spec {
-    service_account_name            = kubernetes_service_account.test.metadata.0.name
+    service_account_name            = kubernetes_service_account_v1.test.metadata.0.name
     automount_service_account_token = true
 
     container {
@@ -2968,7 +2974,7 @@ func testAccKubernetesPodV1ConfigEnableServiceLinks(podName, imageName string) s
 }
 
 func testAccKubernetesPodV1ConfigReadinessGate(secretName, configMapName, podName, imageName string) string {
-	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2978,7 +2984,7 @@ func testAccKubernetesPodV1ConfigReadinessGate(secretName, configMapName, podNam
   }
 }
 
-resource "kubernetes_secret" "test_from" {
+resource "kubernetes_secret_v1" "test_from" {
   metadata {
     name = "%s-from"
   }
@@ -2989,7 +2995,7 @@ resource "kubernetes_secret" "test_from" {
   }
 }
 
-resource "kubernetes_config_map" "test" {
+resource "kubernetes_config_map_v1" "test" {
   metadata {
     name = "%s"
   }
@@ -2999,7 +3005,7 @@ resource "kubernetes_config_map" "test" {
   }
 }
 
-resource "kubernetes_config_map" "test_from" {
+resource "kubernetes_config_map_v1" "test_from" {
   metadata {
     name = "%s-from"
   }
@@ -3034,7 +3040,7 @@ resource "kubernetes_pod_v1" "test" {
 
         value_from {
           secret_key_ref {
-            name     = "${kubernetes_secret.test.metadata.0.name}"
+            name     = "${kubernetes_secret_v1.test.metadata.0.name}"
             key      = "one"
             optional = true
           }
@@ -3044,7 +3050,7 @@ resource "kubernetes_pod_v1" "test" {
         name = "EXPORTED_VARIABLE_FROM_CONFIG_MAP"
         value_from {
           config_map_key_ref {
-            name     = "${kubernetes_config_map.test.metadata.0.name}"
+            name     = "${kubernetes_config_map_v1.test.metadata.0.name}"
             key      = "one"
             optional = true
           }
@@ -3053,14 +3059,14 @@ resource "kubernetes_pod_v1" "test" {
 
       env_from {
         config_map_ref {
-          name     = "${kubernetes_config_map.test_from.metadata.0.name}"
+          name     = "${kubernetes_config_map_v1.test_from.metadata.0.name}"
           optional = true
         }
         prefix = "FROM_CM_"
       }
       env_from {
         secret_ref {
-          name     = "${kubernetes_secret.test_from.metadata.0.name}"
+          name     = "${kubernetes_secret_v1.test_from.metadata.0.name}"
           optional = false
         }
         prefix = "FROM_S_"
@@ -3071,7 +3077,7 @@ resource "kubernetes_pod_v1" "test" {
       name = "db"
 
       secret {
-        secret_name = "${kubernetes_secret.test.metadata.0.name}"
+        secret_name = "${kubernetes_secret_v1.test.metadata.0.name}"
       }
     }
   }
@@ -3136,7 +3142,7 @@ func testAccKubernetesPodV1ConfigWithVolume(name, imageName, serviceAccount stri
   storage_provisioner = "k8s.io/minikube-hostpath"
 }
 
-resource "kubernetes_service_account" "test" {
+resource "kubernetes_service_account_v1" "test" {
   metadata {
     name = "test"
   }
@@ -3187,7 +3193,7 @@ resource "kubernetes_pod_v1" "test" {
     container {
       name    = "default"
       image   = "%s"
-      command = ["sleep", "3600s"]
+      command = ["sleep", "300"]
       volume_mount {
         mount_path = "/etc/test"
         name       = "pvc"
@@ -3199,6 +3205,7 @@ resource "kubernetes_pod_v1" "test" {
         claim_name = kubernetes_persistent_volume_claim.test.metadata[0].name
       }
     }
+    termination_grace_period_seconds = 1
   }
 }
 `, name, serviceAccount, imageName)
@@ -3424,6 +3431,7 @@ func testAccKubernetesPodV1EphemeralStorage(podName, imageName, volumeName strin
         }
       }
     }
+    termination_grace_period_seconds = 1
   }
 }
 `, podName, imageName, volumeName)

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -194,11 +194,11 @@ func TestAccKubernetesStatefulSetV1_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesStatefulSetV1ConfigUpdateReplicas(name, imageName, "5"),
+				Config: testAccKubernetesStatefulSetV1ConfigUpdateReplicas(name, imageName, "3"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.replicas", "5"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.replicas", "3"),
 				),
 			},
 			{
@@ -207,7 +207,7 @@ func TestAccKubernetesStatefulSetV1_Update(t *testing.T) {
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
 					// NOTE setting to empty should preserve the current replica count
-					resource.TestCheckResourceAttr(resourceName, "spec.0.replicas", "5"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.replicas", "3"),
 				),
 			},
 			{
@@ -417,6 +417,7 @@ func testAccKubernetesStatefulSetV1ConfigMinimal(name, imageName string) string 
           image   = "%s"
           command = ["sleep", "300"]
         }
+        termination_grace_period_seconds = 1
       }
     }
   }
@@ -739,6 +740,7 @@ func testAccKubernetesStatefulSetV1ConfigUpdateReplicas(name, imageName, replica
             mount_path = "/work-dir"
           }
         }
+        termination_grace_period_seconds = 1
       }
     }
 


### PR DESCRIPTION
### Description

Add argument `termination_grace_period_seconds` to the tests that spin up pods to free up resources faster.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

- https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/6053201832/job/16428185475

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
