### PR TITLE
Enable nightly execution of AKS test

### DIFF
--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -18,13 +18,15 @@ on:
       terraformVersion:
         description: Terraform version
         default: 1.4.2
+      schedule:
+        cron: '0 22 * * *'
       runTests:
         description: The regex passed to the -run option of `go test`
         default: ".*"
 
 jobs:
   acceptanceTests:
-    runs-on: ubuntu-latest
+    runs-on: [custom, linux, medium]
     steps:
       - name: Checkout 
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -35,7 +37,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: ${{ inputs.terraformVersion }} 
+          terraform_version: ${{ env.terraformVersion }} 
       - name: Azure login 
         uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
         with:
@@ -47,7 +49,7 @@ jobs:
           terraform apply --auto-approve
       - name: Run Tests  
         env: 
-          TF_ACC_TERRAFORM_VERSION: ${{ inputs.terraformVersion }}
+          TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
           KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks-new/kubeconfig
           TESTARGS: -run '${{ inputs.runTests }}'
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }} 
           terraform_wrapper: false

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -14,10 +14,10 @@ on:
         default: "Standard_A4_v2"
       kubernetes_version:
         description: 'The version of kubernetes'
-        default: "1.27"
+        default: ".*"
       terraformVersion:
         description: Terraform version
-        default: 1.4.2
+        default: 1.5.6
       runTests:
         description: The regex passed to the -run option of `go test`
         default: ".*"
@@ -25,8 +25,12 @@ on:
     - cron: '0 22 * * *'
 
 env:
-  KUBECONFIG: ${{ github.workspace }}/.kube/confi
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}  
+  TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
+  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion }}
+  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
+  TF_VAR_instance_type: ${{ github.event.inputs.instanceType }}
 
 jobs:
   acceptanceTests:
@@ -53,7 +57,6 @@ jobs:
           terraform apply --auto-approve
       - name: Run Tests  
         env: 
-          KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks-new/kubeconfig
           TESTARGS: -run '${{ inputs.runTests }}'
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
         run: |

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -21,12 +21,16 @@ on:
       runTests:
         description: The regex passed to the -run option of `go test`
         default: ".*"
+      parallelRuns:
+        description: The maximum number of tests to run simultaneously
+        default: 8
   schedule:
     - cron: '0 22 * * *'
 
 env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks-new/kubeconfig
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
   TF_VAR_location: ${{ github.event.inputs.location || vars.AZURE_LOCATION }}
   TF_VAR_node_count: ${{ github.event.inputs.nodeCount || vars.AZURE_NODE_COUNT }}
   TF_VAR_vm_size: ${{ github.event.inputs.vmSize || vars.AZURE_VM_SIZE }}  

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -14,7 +14,7 @@ on:
         default: "Standard_A4_v2"
       kubernetes_version:
         description: 'The version of kubernetes'
-        default: ".*"
+        default: "1.27"
       terraformVersion:
         description: Terraform version
         default: 1.5.6
@@ -27,9 +27,9 @@ on:
 env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}  
-  # TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
+  TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion }}
-  # TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
+  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType }}
 
 jobs:

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -14,15 +14,19 @@ on:
         default: "Standard_A4_v2"
       kubernetes_version:
         description: 'The version of kubernetes'
-        default: "1.25.5"
+        default: "1.27"
       terraformVersion:
         description: Terraform version
         default: 1.4.2
-      schedule:
-        cron: '0 22 * * *'
       runTests:
         description: The regex passed to the -run option of `go test`
         default: ".*"
+  schedule:
+    - cron: '0 22 * * *'
+
+env:
+  KUBECONFIG: ${{ github.workspace }}/.kube/confi
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
 
 jobs:
   acceptanceTests:
@@ -37,19 +41,18 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: ${{ env.terraformVersion }} 
+          terraform_version: ${{ env.TERRAFORM_VERSION }} 
       - name: Azure login 
         uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Provision AKS
-        working-directory: ./kubernetes/test-infra/aks-new
+        working-directory: ${{ github.workspace }}/kubernetes/test-infra/aks-new
         run: | 
           terraform init 
           terraform apply --auto-approve
       - name: Run Tests  
         env: 
-          TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
           KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks-new/kubeconfig
           TESTARGS: -run '${{ inputs.runTests }}'
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -6,10 +6,10 @@ on:
       location:
         description: 'Location'
         default: "West Europe"
-      node_count:
+      nodeCount:
         description: 'Number of nodes to provision'
         default: 2
-      vm_size:
+      vmSize:
         description: 'The azure machine size for nodes'
         default: "Standard_A4_v2"
       clusterVersion:
@@ -25,13 +25,13 @@ on:
     - cron: '0 22 * * *'
 
 env:
-  KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}  
-  TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
+  KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks-new/kubeconfig
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  TF_VAR_location: ${{ github.event.inputs.location || vars.AZURE_LOCATION }}
+  TF_VAR_node_count: ${{ github.event.inputs.nodeCount || vars.AZURE_NODE_COUNT }}
+  TF_VAR_vm_size: ${{ github.event.inputs.vmSize || vars.AZURE_VM_SIZE }}  
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION}}
-  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
-  TF_VAR_instance_type: ${{ github.event.inputs.instanceType }}
-
+  
 jobs:
   acceptanceTests:
     runs-on: [custom, linux, medium]
@@ -46,6 +46,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }} 
+          terraform_wrapper: false
       - name: Azure login 
         uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
         with:
@@ -63,6 +64,6 @@ jobs:
           make testacc
       - name: Destroy AKS
         if: always()
-        working-directory: ./kubernetes/test-infra/aks-new 
+        working-directory: ${{ github.workspace }}/kubernetes/test-infra/aks-new 
         run: |
           terraform destroy --auto-approve

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -27,9 +27,9 @@ on:
 env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}  
-  TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
+  # TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion }}
-  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
+  # TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType }}
 
 jobs:

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -12,7 +12,7 @@ on:
       vm_size:
         description: 'The azure machine size for nodes'
         default: "Standard_A4_v2"
-      kubernetes_version:
+      clusterVersion:
         description: 'The version of kubernetes'
         default: "1.27"
       terraformVersion:
@@ -28,7 +28,7 @@ env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}  
   TF_VAR_az_span: ${{ github.event.inputs.azSpan }}
-  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion }}
+  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION}}
   TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType }}
 

--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          aws-region: ${{ github.event.inputs.region }}
+          aws-region: ${{ env.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}

--- a/kubernetes/test-infra/aks-new/main.tf
+++ b/kubernetes/test-infra/aks-new/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test_group.location
   resource_group_name = azurerm_resource_group.test_group.name
   dns_prefix          = "test"
-  kubernetes_version  = var.kubernetes_version
+  kubernetes_version  = var.cluster_version
 
   default_node_pool {
     name       = "default"

--- a/kubernetes/test-infra/aks-new/variables.tf
+++ b/kubernetes/test-infra/aks-new/variables.tf
@@ -16,7 +16,7 @@ variable "vm_size" {
   default = "Standard_A4_v2"
 }
 
-variable "kubernetes_version" {
+variable "cluster_version" {
   type = string
-  default = "1.25.5"
+  default = "1.27"
 }


### PR DESCRIPTION
### Description

- Enable `AKS Test` to run daily on schedule.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
