### PR TITLE
Schedule GKE test

### DIFF
--- a/.github/workflows/acceptance_tests_gke.yaml
+++ b/.github/workflows/acceptance_tests_gke.yaml
@@ -23,13 +23,15 @@ on:
         default: ^TestAcc
       terraformVersion:
         description: Terraform version
-        default: 1.4.0
+        default: 1.4.2
 
 env:
   GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
   GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-  GOOGLE_REGION: ${{ github.event.inputs.region }}
-  GOOGLE_ZONE: ${{github.event.inputs.zone}}
+  GOOGLE_REGION: ${{ github.event.inputs.region || vars.GOOGLE_REGION }}
+  GOOGLE_ZONE: ${{github.event.inputs.zone || vars.GOOGLE_ZONE }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   KUBECONFIG: ${{ github.workspace }}/kubernetes/test-infra/gke/kubeconfig
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/gke/kubeconfig
@@ -41,7 +43,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    runs-on: ubuntu-latest
+    runs-on: [custom, linux, medium]
     env:
       KUBECONFIG: ${{ github.workspace }}/kubernetes/test-infra/gke/kubeconfig
     steps:
@@ -106,7 +108,7 @@ jobs:
   acceptance-tests:
     name: "Test"
     needs: [prepare-gke-environment, generate-case-matrix]
-    runs-on: ubuntu-latest
+    runs-on: [custom, linux, medium]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/acceptance_tests_gke.yaml
+++ b/.github/workflows/acceptance_tests_gke.yaml
@@ -24,7 +24,8 @@ on:
       terraformVersion:
         description: Terraform version
         default: 1.4.2
-
+  schedule:
+    - cron: '0 23 * * *'
 env:
   GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
   GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}


### PR DESCRIPTION
### Description

This PR puts the following changes in effect: 
- allows the GKE tests to run on schedule 
- updates the test file to run in parallel.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
