### PR TITLE
Example OIDC configuration modules for GKE

### DIFF
--- a/.changelog/2319.txt
+++ b/.changelog/2319.txt
@@ -1,0 +1,3 @@
+```release-note:doc
+Add example module for configuring OIDC authentication on GKE
+```

--- a/_examples/eks/eks-oidc/main.tf
+++ b/_examples/eks/eks-oidc/main.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 }
 
 variable "oidc_issuer_url" {
-    default = "https://app.terraform.io"
+  default = "https://app.terraform.io"
 }
 
 variable "oidc_audience" {

--- a/_examples/gke/gke-cluster/variables.tf
+++ b/_examples/gke/gke-cluster/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "kubernetes_version" {
-  default = "1.18"
+  default = "1.27"
 }
 
 variable "workers_count" {
@@ -13,6 +13,7 @@ variable "cluster_name" {
   type = string
 }
 
-locals {
-  google_zone = data.google_compute_zones.available.names[0]
+variable "idp_enabled" {
+  type    = bool
+  default = false
 }

--- a/_examples/gke/gke-oidc/README.md
+++ b/_examples/gke/gke-oidc/README.md
@@ -1,0 +1,32 @@
+# Summary
+
+This module configures a GKE cluster to use Terraform Cloud or Terraform Enterprise as an OIDC identity provider.
+
+# Usage
+
+This module requires a GKE cluster that is up-and-running and has identity services enabled.
+If you already have a GKE , but are unsure if identity services are enabled, you can enable it as described here: https://cloud.google.com/kubernetes-engine/docs/how-to/oidc#enabling_on_a_new_cluster
+
+If you provisioned your cluster with Terraform, you can add the following block to your `resource "google_container_cluster"` configuration and re-apply:
+
+```
+  identity_service_config {
+    enabled = true
+  }
+```
+
+Applying this module will modify an existing custom resource already present in the target cluster, adding the necessary details specific to TFC / TFE. The `authentication.gke.io.v2alpha1.ClientConfig` custom resoruce will only be present in cluster whrere identity service has been enabled (as described above).
+
+To configure the module, the following Terraform variables need to be set. Variables with a default value are optional.
+
+| Variable         | Contents                                                                                     | Default value               |
+| ---------------- | -------------------------------------------------------------------------------------------- | --------------------------- |
+| cluster_name     | Name of the target GKE cluster to configure                                                  |                             |
+| gke_location     | Location (zone or region) of the cluster in GCP                                              |                             |
+| odic_issuer_uri  | Base URL of TFC / TFE endpoint (default to public TFC)                                       | https://app.terraform.io    |
+| oidc_audience    | Audience value as configured in TFC / TFE environment variable                               | kubernetes                  |
+| oidc_user_claim  | Token claim to extract user name from (defaults to 'sub')                                    | sub                         |
+| oidc_group_claim | Token claim to extract the group membership from (defaults to 'terraform_organization_name') | terraform_organization_name |
+| TFE_CA_cert      | CA Certificate for the HTTPS API endpoint of Terraform Enterprise (contents, not filepath)   |                             |
+
+**BEWARE** _Once this module is successfully applied, the `authentication.gke.io.v2alpha1.ClientConfig` CR named "default" in namespace "kube-public" becomes managed by Terraform, as is usual with imported resources. As a consequence, destroying this module will also remove that resource from the cluster._

--- a/_examples/gke/gke-oidc/gke.tf
+++ b/_examples/gke/gke-oidc/gke.tf
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "google_container_cluster" "upstream" {
+  provider = google-beta
+  name     = var.cluster_name
+  location = var.gke_location
+}
+
+data "google_client_config" "provider" {
+  provider = google-beta
+}

--- a/_examples/gke/gke-oidc/k8s.tf
+++ b/_examples/gke/gke-oidc/k8s.tf
@@ -1,0 +1,43 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "kubernetes" {
+  host  = "https://${data.google_container_cluster.upstream.endpoint}"
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.upstream.master_auth[0].cluster_ca_certificate,
+  )
+}
+
+import {
+  // The name of this resource is hardcoded by GKE as described in:
+  // https://cloud.google.com/kubernetes-engine/docs/how-to/oidc#configuring_on_a_cluster
+  //
+  id = "apiVersion=authentication.gke.io/v2alpha1,kind=ClientConfig,namespace=kube-public,name=default"
+  to = kubernetes_manifest.oidc_conf
+}
+
+resource "kubernetes_manifest" "oidc_conf" {
+  manifest = {
+    apiVersion = "authentication.gke.io/v2alpha1"
+    kind       = "ClientConfig"
+    metadata = {
+      name      = "default"
+      namespace = "kube-public"
+    }
+    spec = {
+      authentication = [
+        {
+          name = data.google_container_cluster.upstream.name
+          oidc = {
+            clientID                 = var.oidc_audience
+            issuerURI                = var.odic_issuer_uri
+            userClaim                = var.oidc_user_claim
+            groupClaim               = var.oidc_group_claim
+            certificateAuthorityData = var.TFE_CA_cert
+          }
+        }
+      ]
+    }
+  }
+}

--- a/_examples/gke/gke-oidc/outputs.tf
+++ b/_examples/gke/gke-oidc/outputs.tf
@@ -1,0 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "config_manifest" {
+  value = kubernetes_manifest.oidc_conf.object
+}

--- a/_examples/gke/gke-oidc/variables.tf
+++ b/_examples/gke/gke-oidc/variables.tf
@@ -1,0 +1,42 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "cluster_name" {
+  description = "Name of target GKE cluster"
+  type        = string
+}
+
+variable "gke_location" {
+  description = "Location of target GKE cluster"
+  type        = string
+}
+
+variable "oidc_audience" {
+  description = "Audience value as configured in TFC / TFE environment variable"
+  type        = string
+  default     = "kubernetes"
+}
+
+variable "odic_issuer_uri" {
+  description = "Base URL of TFC / TFE endpoint (default to public TFC)"
+  type        = string
+  default     = "https://app.terraform.io"
+}
+
+variable "oidc_user_claim" {
+  description = "Token claim to extract user name from (defaults to 'sub')"
+  type        = string
+  default     = "sub"
+}
+
+variable "oidc_group_claim" {
+  description = "Token claim to extract the group membership from (defaults to 'terraform_organization_name')"
+  type        = string
+  default     = "terraform_organization_name"
+}
+
+variable "TFE_CA_cert" {
+  description = "CA Certificate for the HTTPS API endpoint of TFE"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Description

These are example modules for configuring a GKE cluster to use TFC / TFE as an identity provider, to make use of their workload identity mechanism.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
