### PR TITLE
Switch nightly AWS EKS tests to SPOT instances

### DIFF
--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -36,6 +36,7 @@ env:
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
   TF_VAR_az_span: ${{ github.event.inputs.azSpan || vars.AWS_AZ_NUMBER }}
+  TF_VAR_capacity_type: ${{ vars.AWS_CAPACITY_TYPE }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION }}
   TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz || vars.AWS_NODES_PER_AZ }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType || vars.AWS_INSTANCE_TYPE }}

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -41,6 +41,7 @@ module "eks" {
   eks_managed_node_groups = {
     default_node_group = {
       ami_type                   = "AL2_ARM_64"
+      capacity_type              = var.capacity_type
       desired_size               = local.node_count
       min_size                   = 1
       max_size                   = local.node_count

--- a/kubernetes/test-infra/eks/variables.tf
+++ b/kubernetes/test-infra/eks/variables.tf
@@ -26,3 +26,8 @@ variable "az_span" {
 variable "cluster_name" {
   default = ""
 }
+
+variable "capacity_type" {
+  description = "Type of capacity associated with the EKS Node Group."
+  default     = "ON_DEMAND"
+}


### PR DESCRIPTION
### Description

Switch nightly AWS EKS tests to [SPOT instances](https://aws.amazon.com/ec2/spot/).

The default value remains `ON_DEMAND` for now, if `SPOT` shows good results, we could change that too.

### Acceptance tests

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
