### PR TITLE
Update stateful_set resource tests

### DIFF
--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -6,12 +6,14 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -349,6 +351,31 @@ func testAccCheckKubernetesStatefulSetV1Destroy(s *terraform.State) error {
 		if err == nil {
 			if resp.Namespace == namespace && resp.Name == name {
 				return fmt.Errorf("StatefulSet still exists: %s: (Generation %#v)", rs.Primary.ID, resp.Status.ObservedGeneration)
+			}
+		}
+
+		// StatefulSet can create a PVC via volumeClaimTemplate. However, once the StatefulSet is removed, the PVC remains.
+		// There is a beta feature(persistentVolumeClaimRetentionPolicy) since 1.27 that aims to address this problem:
+		// - https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/
+		// - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+		// By default, StatefulSetAutoDeletePVC feature is not enabled in the feature gate.
+		// That is why we clean up resources manually here.
+		pvc, err := conn.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("Failed to list PVCs in %q namespace", namespace)
+		}
+		for _, p := range pvc.Items {
+			// PVC gets generated in the following format:
+			// *.volumeClaimTemplate.metatada.name-statefulSet.metatada.name
+			//
+			// Since statefulSet.metatada.name is uniq, we could use it as a match.
+			if strings.Contains(p.Name, name) {
+				err := conn.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, p.Name, metav1.DeleteOptions{})
+				if err != nil {
+					if !errors.IsNotFound(err) {
+						return fmt.Errorf("Failed to delete PVC %q in namespace %q", p.Name, namespace)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description

A `StatefulSet` resource can create a PVC on-demand via `volumeClaimTemplate`. Once the `StatefulSet` is removed, the PVC it created remains in Kubernetes. Although it makes sense for production usage, it produces unnecessary artifacts during testing and increases the test env bills.

There is a beta feature(`spec.persistentVolumeClaimRetentionPolicy`) since 1.27 that aims to address this problem:

- https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/
- https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention

However, by default, `StatefulSetAutoDeletePVC` feature is not enabled in the feature gate.

This PR introduces an update of `testAccCheckKubernetesStatefulSetV1Destroy` clean up remained PVCs.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
