### PR TITLE
Add ClusterRoleBinding and small corrections to GKE OIDC config

### DIFF
--- a/_examples/eks/eks-oidc/main.tf
+++ b/_examples/eks/eks-oidc/main.tf
@@ -21,7 +21,7 @@ variable "rbac_group_oidc_claim" {
   default = "terraform_organization_name"
 }
 
-variable "rbac_admin_group_name" {
+variable "rbac_oidc_group_name" {
   type = string
 }
 
@@ -69,6 +69,6 @@ resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
   subject {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Group"
-    name      = var.rbac_admin_group_name
+    name      = var.rbac_oidc_group_name
   }
 }

--- a/_examples/gke/gke-oidc/k8s.tf
+++ b/_examples/gke/gke-oidc/k8s.tf
@@ -33,11 +33,29 @@ resource "kubernetes_manifest" "oidc_conf" {
             clientID                 = var.oidc_audience
             issuerURI                = var.odic_issuer_uri
             userClaim                = var.oidc_user_claim
-            groupClaim               = var.oidc_group_claim
+            groupsClaim              = var.oidc_group_claim
             certificateAuthorityData = var.TFE_CA_cert
           }
         }
       ]
     }
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
+  metadata {
+    name = "odic-identity"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = var.rbac_group_cluster_role
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.rbac_oidc_group_name
   }
 }

--- a/_examples/gke/gke-oidc/variables.tf
+++ b/_examples/gke/gke-oidc/variables.tf
@@ -40,3 +40,13 @@ variable "TFE_CA_cert" {
   type        = string
   default     = null
 }
+
+variable "rbac_oidc_group_name" {
+  description = "Name of OIDC group (according to 'oidc_group_claim') to be granted the role designated by 'var.rbac_group_cluster_role'"
+  type = string
+}
+
+variable "rbac_group_cluster_role" {
+  description = "Kubernetes role to be bound to the OIDC group designated by 'var.rbac_oidc_group_name'"
+  default = "cluster-admin"
+}


### PR DESCRIPTION
### Description

Add the missing ClusterRoleBinding to grant permissions to the OIDC identity.
Correct typo in ClientConfig configuration.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
