### PR TITLE
feat: Add missing topologySpreadConstraints options in kubernetes_deployment

### DIFF
--- a/kubernetes/resource_kubernetes_pod_v1_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_test.go
@@ -1451,6 +1451,7 @@ func TestAccKubernetesPodV1_topologySpreadConstraint(t *testing.T) {
 					testAccCheckKubernetesPodV1Exists(resourceName, &conf1),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.max_skew", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.min_domains", "3"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.topology_key", "topology.kubernetes.io/zone"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.topology_spread_constraint.0.when_unsatisfiable", "ScheduleAnyway"),
 				),

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -471,6 +471,13 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 						Default:      1,
 						ValidateFunc: validation.IntAtLeast(1),
 					},
+					"min_domains": {
+						Type:         schema.TypeInt,
+						Description:  "indicates a minimum number of eligible domains.",
+						Optional:     true,
+						Default:      1,
+						ValidateFunc: validation.IntAtLeast(1),
+					},
 					"topology_key": {
 						Type:        schema.TypeString,
 						Description: "the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.",

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -341,6 +341,9 @@ func flattenTopologySpreadConstraints(tsc []v1.TopologySpreadConstraint) []inter
 		if v.MaxSkew != 0 {
 			obj["max_skew"] = v.MaxSkew
 		}
+		if v.MinDomains != nil && *v.MinDomains != 0 {
+			obj["min_domains"] = v.MinDomains
+		}
 		if v.WhenUnsatisfiable != "" {
 			obj["when_unsatisfiable"] = string(v.WhenUnsatisfiable)
 		}
@@ -1480,6 +1483,9 @@ func expandTopologySpreadConstraints(tsc []interface{}) ([]*v1.TopologySpreadCon
 			ts[i].MaxSkew = int32(value)
 		}
 
+		if value, ok := m["min_domains"].(*int32); ok {
+			ts[i].MinDomains = value
+		}
 	}
 	return ts, nil
 }

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -864,6 +864,7 @@ The `items` block supports the following:
 #### Arguments
 
 * `max_skew` - (Optional) Describes the degree to which pods may be unevenly distributed. Default value is `1`.
+* `min_domains` - (Optional) Indicates a minimum number of eligible domains. This field is optional. A domain is a particular instance of a topology. An eligible domain is a domain whose nodes match the node selector.
 * `topology_key` - (Optional) The key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 * `when_unsatisfiable` - (Optional) Indicates how to deal with a pod if it doesn't satisfy the spread constraint. Valid values are `DoNotSchedule` and `ScheduleAnyway`. Default value is `DoNotSchedule`.
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.

--- a/website/docs/r/pod_v1.html.markdown
+++ b/website/docs/r/pod_v1.html.markdown
@@ -853,6 +853,7 @@ The `items` block supports the following:
 #### Arguments
 
 * `max_skew` - (Optional) Describes the degree to which pods may be unevenly distributed. Default value is `1`.
+* `min_domains` - (Optional) Indicates a minimum number of eligible domains. This field is optional. A domain is a particular instance of a topology. An eligible domain is a domain whose nodes match the node selector.
 * `topology_key` - (Optional) The key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 * `when_unsatisfiable` - (Optional) Indicates how to deal with a pod if it doesn't satisfy the spread constraint. Valid values are `DoNotSchedule` and `ScheduleAnyway`. Default value is `DoNotSchedule`.
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.


### PR DESCRIPTION

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
