### PR TITLE
add `windows_options` for spec.container

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -808,6 +808,37 @@ func securityContextSchema(isUpdatable bool) *schema.Resource {
 				Schema: seLinuxOptionsField(isUpdatable),
 			},
 		},
+		"windows_options": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Description: "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"gmsa_credential_spec": {
+						Type:        schema.TypeString,
+						Description: "GMSACredentialSpec is where the GMSA admission webhook inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field",
+						Required:    true,
+					},
+					"gmsa_credential_spec_name": {
+						Type:        schema.TypeString,
+						Description: "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+						Required:    true,
+					},
+					"host_process": {
+						Type:        schema.TypeBool,
+						Description: "HostProcess determines if a container should be run as a 'Host Process' container. Default value is false.",
+						Default:     false,
+						Optional:    true,
+					},
+					"run_as_username": {
+						Type:        schema.TypeString,
+						Description: "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+						Optional:    true,
+					},
+				},
+			},
+		},
 	}
 
 	return &schema.Resource{

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -356,12 +356,12 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 								"gmsa_credential_spec": {
 									Type:        schema.TypeString,
 									Description: "GMSACredentialSpec is where the GMSA admission webhook inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field",
-									Optional:    true,
+									Required:    true,
 								},
 								"gmsa_credential_spec_name": {
 									Type:        schema.TypeString,
 									Description: "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-									Optional:    true,
+									Required:    true,
 								},
 								"host_process": {
 									Type:        schema.TypeBool,

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -51,6 +51,10 @@ func flattenContainerSecurityContext(in *v1.SecurityContext) []interface{} {
 	if in.SELinuxOptions != nil {
 		att["se_linux_options"] = flattenSeLinuxOptions(in.SELinuxOptions)
 	}
+	if in.WindowsOptions != nil {
+		att["windows_options"] = flattenWindowsOptions(*in.WindowsOptions)
+	}
+
 	return []interface{}{att}
 
 }
@@ -633,6 +637,9 @@ func expandContainerSecurityContext(l []interface{}) (*v1.SecurityContext, error
 	}
 	if v, ok := in["se_linux_options"].([]interface{}); ok && len(v) > 0 {
 		obj.SELinuxOptions = expandSeLinuxOptions(v)
+	}
+	if v, ok := in["windows_options"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsOptions = expandWindowsOptions(v)
 	}
 
 	return &obj, nil


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
