### PR TITLE
🚀 Clean up tests

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_v1_test.go
+++ b/kubernetes/resource_kubernetes_deployment_v1_test.go
@@ -398,7 +398,7 @@ func TestAccKubernetesDeploymentV1_with_container_liveness_probe_using_exec(t *t
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
 				),
 			},
 		},
@@ -1359,7 +1359,8 @@ func testAccKubernetesDeploymentV1Config_basic(name, imageName string) string {
           }
 
           readiness_probe {
-            initial_delay_seconds = 5
+            initial_delay_seconds = 3
+            period_seconds        = 1
             http_get {
               path = "/"
               port = 80
@@ -1857,9 +1858,8 @@ func testAccKubernetesDeploymentV1ConfigWithLivenessProbeUsingExec(deploymentNam
             exec {
               command = ["cat", "/tmp/healthy"]
             }
-
-            initial_delay_seconds = 5
-            period_seconds        = 5
+            initial_delay_seconds = 3
+            period_seconds        = 1
           }
         }
         termination_grace_period_seconds = 1
@@ -1910,9 +1910,8 @@ func testAccKubernetesDeploymentV1ConfigWithLivenessProbeUsingHTTPGet(deployment
                 value = "Awesome"
               }
             }
-
             initial_delay_seconds = 3
-            period_seconds        = 3
+            period_seconds        = 1
           }
         }
         termination_grace_period_seconds = 1
@@ -1957,9 +1956,8 @@ func testAccKubernetesDeploymentV1ConfigWithLivenessProbeUsingTCP(deploymentName
             tcp_socket {
               port = 8080
             }
-
             initial_delay_seconds = 3
-            period_seconds        = 3
+            period_seconds        = 1
           }
         }
         termination_grace_period_seconds = 1

--- a/kubernetes/resource_kubernetes_persistent_volume_v1_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_v1_test.go
@@ -446,7 +446,6 @@ func TestAccKubernetesPersistentVolumeV1_hostPath_volumeSource(t *testing.T) {
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,
-		ExternalProviders: testAccExternalProviders,
 		CheckDestroy:      testAccCheckKubernetesPersistentVolumeV1Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -600,7 +599,6 @@ func TestAccKubernetesPersistentVolumeV1_storageClass(t *testing.T) {
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,
-		ExternalProviders: testAccExternalProviders,
 		CheckDestroy:      testAccCheckKubernetesPersistentVolumeV1Destroy,
 		Steps: []resource.TestStep{
 			{

--- a/kubernetes/resource_kubernetes_persistent_volume_v1_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_v1_test.go
@@ -599,6 +599,7 @@ func TestAccKubernetesPersistentVolumeV1_storageClass(t *testing.T) {
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,
+		ExternalProviders: testAccExternalProviders,
 		CheckDestroy:      testAccCheckKubernetesPersistentVolumeV1Destroy,
 		Steps: []resource.TestStep{
 			{

--- a/kubernetes/resource_kubernetes_pod_v1_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_test.go
@@ -522,7 +522,7 @@ func TestAccKubernetesPodV1_with_container_liveness_probe_using_exec(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.liveness_probe.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
 				),
 			},
 			{
@@ -2036,9 +2036,8 @@ func testAccKubernetesPodV1ConfigWithLivenessProbeUsingExec(podName, imageName s
         exec {
           command = ["cat", "/tmp/healthy"]
         }
-
-        initial_delay_seconds = 5
-        period_seconds        = 5
+        initial_delay_seconds = 3
+        period_seconds        = 1
       }
     }
     termination_grace_period_seconds = 1
@@ -2073,9 +2072,8 @@ func testAccKubernetesPodV1ConfigWithLivenessProbeUsingHTTPGet(podName, imageNam
             value = "Awesome"
           }
         }
-
         initial_delay_seconds = 3
-        period_seconds        = 3
+        period_seconds        = 1
       }
     }
   }
@@ -2103,9 +2101,8 @@ func testAccKubernetesPodV1ConfigWithLivenessProbeUsingTCP(podName, imageName st
         tcp_socket {
           port = 8080
         }
-
         initial_delay_seconds = 3
-        period_seconds        = 3
+        period_seconds        = 1
       }
     }
   }
@@ -2134,9 +2131,8 @@ func testAccKubernetesPodV1ConfigWithLivenessProbeUsingGRPC(podName, imageName s
           port    = 8888
           service = "EchoService"
         }
-
-        initial_delay_seconds = 30
-        period_seconds        = 30
+        initial_delay_seconds = 3
+        period_seconds        = 1
       }
     }
   }

--- a/kubernetes/resource_kubernetes_replication_controller_v1_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_v1_test.go
@@ -895,9 +895,8 @@ func testAccKubernetesReplicationControllerV1ConfigWithLivenessProbeUsingExec(rc
             exec {
               command = ["cat", "/tmp/healthy"]
             }
-
-            initial_delay_seconds = 5
-            period_seconds        = 5
+            initial_delay_seconds = 3
+            period_seconds        = 1
           }
         }
       }
@@ -945,9 +944,8 @@ func testAccKubernetesReplicationControllerV1ConfigWithLivenessProbeUsingHTTPGet
                 value = "Awesome"
               }
             }
-
             initial_delay_seconds = 3
-            period_seconds        = 3
+            period_seconds        = 1
           }
         }
       }
@@ -989,9 +987,8 @@ func testAccKubernetesReplicationControllerV1ConfigWithLivenessProbeUsingTCP(rcN
             tcp_socket {
               port = 8080
             }
-
             initial_delay_seconds = 3
-            period_seconds        = 3
+            period_seconds        = 1
           }
         }
       }

--- a/kubernetes/resource_kubernetes_replication_controller_v1_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_v1_test.go
@@ -278,7 +278,7 @@ func TestAccKubernetesReplicationControllerV1_with_container_liveness_probe_usin
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
 				),
 			},
 		},

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -501,7 +501,8 @@ func testAccKubernetesStatefulSetV1ConfigBasic(name, imageName string) string {
           }
 
           readiness_probe {
-            initial_delay_seconds = 5
+            initial_delay_seconds = 3
+            period_seconds        = 1
             http_get {
               path = "/"
               port = 80
@@ -1116,7 +1117,8 @@ func testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, waitFor
           }
 
           readiness_probe {
-            initial_delay_seconds = 5
+            initial_delay_seconds = 3
+            period_seconds        = 1
             tcp_socket {
               port = 80
             }


### PR DESCRIPTION
### Description

The following improvements have been made to speed up tests:

- Remove unnecessary `ExternalProviders` invocation, affect KinD tests.
- Add `period_seconds = 1` to `liveness_probe` and `readiness_probe`, default is `10` which slows down some tests.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

- _GKE_ https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/6665587700
- _AKS_ https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/6665314620
- _EKS_ https://github.com/hashicorp/terraform-provider-kubernetes/actions/runs/6665313091

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
