### PR TITLE
Support empty TLS blocks in ingress_v1

### DIFF
--- a/.changelog/2344.txt
+++ b/.changelog/2344.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/kubernetes_ingress`: Fix an issue where the empty `tls` attribute in the configuration does not generate the corresponding Ingress object without any TLS configuration.
+```
+
+```release-note:bug
+`resource/kubernetes_ingress_v1`: Fix an issue where the empty `tls` attribute in the configuration does not generate the corresponding Ingress object without any TLS configuration.
+```

--- a/kubernetes/provider_ignore_metadata_test.go
+++ b/kubernetes/provider_ignore_metadata_test.go
@@ -44,8 +44,7 @@ func TestAccKubernetesIgnoreKubernetesMetadata_basic(t *testing.T) {
 }
 
 func testAccKubernetesIgnoreKubernetesMetadataProviderConfig(namespaceName string, ignoreKubernetesMetadata string) string {
-	return fmt.Sprintf(`
-provider "kubernetes" {
+	return fmt.Sprintf(`provider "kubernetes" {
   ignore_annotations = [
     "%s",
   ]

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_test.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_test.go
@@ -216,8 +216,7 @@ func testAccCheckKubernetesMutatingWebhookConfigurationExists(n string) resource
 }
 
 func testAccKubernetesMutatingWebhookConfigurationConfig_basic(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_mutating_webhook_configuration" "test" {
+	return fmt.Sprintf(`resource "kubernetes_mutating_webhook_configuration" "test" {
   metadata {
     name = %q
   }
@@ -254,8 +253,7 @@ resource "kubernetes_mutating_webhook_configuration" "test" {
 }
 
 func testAccKubernetesMutatingWebhookConfigurationConfig_modified(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_mutating_webhook_configuration" "test" {
+	return fmt.Sprintf(`resource "kubernetes_mutating_webhook_configuration" "test" {
   metadata {
     name = %q
   }
@@ -306,8 +304,7 @@ resource "kubernetes_mutating_webhook_configuration" "test" {
 }
 
 func testAccKubernetesMutatingWebhookConfigurationConfig_without_rules(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_mutating_webhook_configuration" "test" {
+	return fmt.Sprintf(`resource "kubernetes_mutating_webhook_configuration" "test" {
   metadata {
     name = %q
   }

--- a/kubernetes/resource_kubernetes_node_taint_test.go
+++ b/kubernetes/resource_kubernetes_node_taint_test.go
@@ -155,8 +155,7 @@ func testAccKubernetesNodeTaintExists(n string) resource.TestCheckFunc {
 }
 
 func testAccKubernetesNodeTaintConfig_basic() string {
-	return fmt.Sprintf(`
-data "kubernetes_nodes" "test" {}
+	return fmt.Sprintf(`data "kubernetes_nodes" "test" {}
 
 resource "kubernetes_node_taint" "test" {
   metadata {
@@ -173,8 +172,7 @@ resource "kubernetes_node_taint" "test" {
 }
 
 func testAccKubernetesNodeTaintConfig_multipleBasic() string {
-	return fmt.Sprintf(`
-data "kubernetes_nodes" "test" {}
+	return fmt.Sprintf(`data "kubernetes_nodes" "test" {}
 
 resource "kubernetes_node_taint" "test" {
   metadata {
@@ -201,8 +199,7 @@ resource "kubernetes_node_taint" "test" {
 }
 
 func testAccKubernetesNodeTaintConfig_updateTaint() string {
-	return fmt.Sprintf(`
-data "kubernetes_nodes" "test" {}
+	return fmt.Sprintf(`data "kubernetes_nodes" "test" {}
 
 resource "kubernetes_node_taint" "test" {
   metadata {
@@ -229,8 +226,7 @@ resource "kubernetes_node_taint" "test" {
 }
 
 func testAccKubernetesNodeTaintConfig_removeTaint() string {
-	return fmt.Sprintf(`
-data "kubernetes_nodes" "test" {}
+	return fmt.Sprintf(`data "kubernetes_nodes" "test" {}
 
 resource "kubernetes_node_taint" "test" {
   metadata {

--- a/kubernetes/resource_kubernetes_pod_v1_test.go
+++ b/kubernetes/resource_kubernetes_pod_v1_test.go
@@ -1949,8 +1949,7 @@ func testAccKubernetesPodV1ConfigWithSecurityContextRunAsGroup(podName, imageNam
 }
 
 func testAccKubernetesPodV1ConfigWithSecurityContextSeccompProfile(podName, imageName, seccompProfileType string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"
@@ -1982,8 +1981,7 @@ resource "kubernetes_pod_v1" "test" {
 }
 
 func testAccKubernetesPodV1ConfigWithSecurityContextSeccompProfileLocalhost(podName, imageName string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_pod_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_pod_v1" "test" {
   metadata {
     labels = {
       app = "pod_label"

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1_test.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1_test.go
@@ -198,8 +198,7 @@ func testAccCheckKubernetesValidatingWebhookConfigurationV1Exists(n string) reso
 }
 
 func testAccKubernetesValidatingWebhookConfigurationV1Config_basic(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_validating_webhook_configuration_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_validating_webhook_configuration_v1" "test" {
   metadata {
     name = %q
   }
@@ -235,8 +234,7 @@ resource "kubernetes_validating_webhook_configuration_v1" "test" {
 }
 
 func testAccKubernetesValidatingWebhookConfigurationV1Config_modified(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_validating_webhook_configuration_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_validating_webhook_configuration_v1" "test" {
   metadata {
     name = %q
   }
@@ -291,8 +289,7 @@ resource "kubernetes_validating_webhook_configuration_v1" "test" {
 }
 
 func testAccKubernetesValidatingWebhookConfigurationV1Config_without_rules(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_validating_webhook_configuration_v1" "test" {
+	return fmt.Sprintf(`resource "kubernetes_validating_webhook_configuration_v1" "test" {
   metadata {
     name = %q
   }

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1beta1_test.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1beta1_test.go
@@ -192,8 +192,7 @@ func testAccCheckKubernetesValidatingWebhookConfigurationV1Beta1Exists(n string)
 }
 
 func testAccKubernetesValidatingWebhookConfigurationV1Beta1Config_basic(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_validating_webhook_configuration" "test" {
+	return fmt.Sprintf(`resource "kubernetes_validating_webhook_configuration" "test" {
   metadata {
     name = %q
   }
@@ -229,8 +228,7 @@ resource "kubernetes_validating_webhook_configuration" "test" {
 }
 
 func testAccKubernetesValidatingWebhookConfigurationV1Beta1Config_modified(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_validating_webhook_configuration" "test" {
+	return fmt.Sprintf(`resource "kubernetes_validating_webhook_configuration" "test" {
   metadata {
     name = %q
   }

--- a/kubernetes/structure_ingress_spec.go
+++ b/kubernetes/structure_ingress_spec.go
@@ -194,12 +194,15 @@ func expandIngressBackend(l []interface{}) *v1beta1.IngressBackend {
 }
 
 func expandIngressTLS(l []interface{}) []v1beta1.IngressTLS {
-	if len(l) == 0 || l[0] == nil {
+	if len(l) == 0 {
 		return nil
 	}
 
 	tlsList := make([]v1beta1.IngressTLS, len(l))
 	for i, t := range l {
+		if t == nil {
+			t = map[string]interface{}{}
+		}
 		in := t.(map[string]interface{})
 		obj := v1beta1.IngressTLS{}
 

--- a/kubernetes/structure_ingress_spec_v1.go
+++ b/kubernetes/structure_ingress_spec_v1.go
@@ -252,12 +252,15 @@ func expandIngressV1Backend(l []interface{}) *networking.IngressBackend {
 }
 
 func expandIngressV1TLS(l []interface{}) []networking.IngressTLS {
-	if len(l) == 0 || l[0] == nil {
+	if len(l) == 0 {
 		return nil
 	}
 
 	tlsList := make([]networking.IngressTLS, len(l))
 	for i, t := range l {
+		if t == nil {
+			t = map[string]interface{}{}
+		}
 		in := t.(map[string]interface{})
 		obj := networking.IngressTLS{}
 


### PR DESCRIPTION
### Description

Fix an issue where the empty `tls` attribute in the configuration does not generate the corresponding Ingress object without any TLS configuration.

The following TF code:
```hcl
resource "kubernetes_ingress_v1" "this" {
  metadata {
    name = "this"
  }
  spec {
    default_backend {
      service {
        name = "app"
        port {
          number = 443
        }
      }
    }
    tls {}
  }
}
```

Should produce the following Ingress object:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  creationTimestamp: "2023-12-04T08:57:33Z"
  generation: 1
  name: this
  namespace: default
  resourceVersion: "491"
  uid: 97330b8c-5ebf-4037-a206-8ca2928b242f
spec:
  defaultBackend:
    service:
      name: app
      port:
        number: 443
  tls:
  - {}
status:
  loadBalancer: {}
```

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
# make testacc TESTARGS='-run=TestAccKubernetesIngressV1_'
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/root/terraform-provider-kubernetes/kubernetes" -v -vet=off -run=TestAccKubernetesIngressV1_ -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesIngressV1_serviceBackend
=== PAUSE TestAccKubernetesIngressV1_serviceBackend
=== RUN   TestAccKubernetesIngressV1_resourceBackend
=== PAUSE TestAccKubernetesIngressV1_resourceBackend
=== RUN   TestAccKubernetesIngressV1_TLS
=== PAUSE TestAccKubernetesIngressV1_TLS
=== RUN   TestAccKubernetesIngressV1_emptyTLS
=== PAUSE TestAccKubernetesIngressV1_emptyTLS
=== RUN   TestAccKubernetesIngressV1_InternalKey
=== PAUSE TestAccKubernetesIngressV1_InternalKey
=== RUN   TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud
=== PAUSE TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud
=== RUN   TestAccKubernetesIngressV1_hostOnlyRule
=== PAUSE TestAccKubernetesIngressV1_hostOnlyRule
=== RUN   TestAccKubernetesIngressV1_multipleRulesDifferentHosts
=== PAUSE TestAccKubernetesIngressV1_multipleRulesDifferentHosts
=== RUN   TestAccKubernetesIngressV1_defaultIngressClass
=== PAUSE TestAccKubernetesIngressV1_defaultIngressClass
=== CONT  TestAccKubernetesIngressV1_serviceBackend
=== CONT  TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud
=== CONT  TestAccKubernetesIngressV1_multipleRulesDifferentHosts
=== CONT  TestAccKubernetesIngressV1_hostOnlyRule
=== CONT  TestAccKubernetesIngressV1_defaultIngressClass
=== CONT  TestAccKubernetesIngressV1_emptyTLS
=== CONT  TestAccKubernetesIngressV1_TLS
=== CONT  TestAccKubernetesIngressV1_InternalKey
=== NAME  TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud
    provider_test.go:261: The Kubernetes endpoint must come from GKE for this test to run - skipping
--- SKIP: TestAccKubernetesIngressV1_WaitForLoadBalancerGoogleCloud (0.10s)
=== CONT  TestAccKubernetesIngressV1_resourceBackend
--- PASS: TestAccKubernetesIngressV1_resourceBackend (20.73s)
--- PASS: TestAccKubernetesIngressV1_emptyTLS (20.91s)
--- PASS: TestAccKubernetesIngressV1_multipleRulesDifferentHosts (21.23s)
--- PASS: TestAccKubernetesIngressV1_hostOnlyRule (21.27s)
--- PASS: TestAccKubernetesIngressV1_defaultIngressClass (27.42s)
--- PASS: TestAccKubernetesIngressV1_serviceBackend (34.11s)
--- PASS: TestAccKubernetesIngressV1_TLS (34.41s)
--- PASS: TestAccKubernetesIngressV1_InternalKey (45.46s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   45.832s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/kubernetes_ingress: Fix an issue where the empty `tls` attribute in the configuration does not generate the corresponding Ingress object without any TLS configuration.

resource/kubernetes_ingress_v1: Fix an issue where the empty `tls` attribute in the configuration does not generate the corresponding Ingress object without any TLS configuration.
```

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/2343

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
