### PR TITLE
Docs improvements for  wait feature.

### DIFF
--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -235,7 +235,7 @@ The following arguments are supported:
 - `condition` (Optional) A set of condition to wait for. You can specify multiple `condition` blocks and it will wait for all of them. 
 - `fields` (Optional) A map of field paths and a corresponding regular expression with a pattern to wait for. The provider will wait until the field's value matches the regular expression. Use `*` for any value.
 
-A field path is a string describing the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
+A field path is a string that describes the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
   * Fields of objects are addressed with `.`
   * Keys of a map field are addressed with `["<key-string>"]`
   * Elements of a list or tuple field are addresed with `[<index-numeral>]`

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -240,7 +240,7 @@ A field path is a string that describes the fully qualified address of a field w
   * Keys of a map field are addressed with `["<key-string>"]`
   * Elements of a list or tuple field are addresed with `[<index-numeral>]`
 
-  For example, to wait for a ServiceAccount token to be created in a Secret, where the `data` field of Secret is a map, do the following:
+  The following example waits for Kubernetes to create a ServiceAccount token in a Secret, where the `data` field of the Secret is a map.
   ```hcl
   wait {
     fields = {

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -223,7 +223,8 @@ The following arguments are supported:
 - `computed_fields` - (Optional) List of paths of fields to be handled as "computed". The user-configured value for the field will be overridden by any different value returned by the API after apply.
 - `manifest` (Required) An object Kubernetes manifest describing the desired state of the resource in HCL format.
 - `object` (Optional) The resulting resource state, as returned by the API server after applying the desired state from `manifest`.
-- `wait_for` (Optional) An object which allows you configure the provider to wait for certain conditions to be met. See below for schema. **DEPRECATED: use `wait` block**.
+- `wait` (Optional) An object which allows you configure the provider to wait for specific fields to reach a desired value or certain conditions to be met. See below for schema.
+- `wait_for` (Optional, Deprecated) An object which allows you configure the provider to wait for certain conditions to be met. See below for schema. **DEPRECATED: use `wait` block**.
 - `field_manager` (Optional) Configure field manager options. See below.
 
 ### `wait`
@@ -232,7 +233,26 @@ The following arguments are supported:
 
 - `rollout` (Optional) When set to `true` will wait for the resource to roll out, equivalent to `kubectl rollout status`. 
 - `condition` (Optional) A set of condition to wait for. You can specify multiple `condition` blocks and it will wait for all of them. 
-- `fields` (Optional) A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use `*` for any value. 
+- `fields` (Optional) A map of field paths and a corresponding regular expression with a pattern to wait for. The provider will wait until the field's value matches the regular expression. Use `*` for any value.
+
+A field path is a string describing the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
+  * Fields of objects are addressed with `.`
+  * Keys of a map field are addressed with `["<key-string>"]`
+  * Elements of a list or tuple field are addresed with `[<index-numeral>]`
+
+  For example, to wait for a ServiceAccount token to be created in a Secret, where the `data` field of Secret is a map, do the following:
+  ```hcl
+  wait {
+    fields = {
+      "data[\"token\"]" = ".+"
+    }
+  }
+  ```
+  If unsure which type a certain field is, the [`type()`]() Terraform function can determine it. With the resource created and present in state, run `terraform console` and then the following command:
+  ```hcl
+  > type(kubernetes_manifest.my-secret.object.data)
+    map(string)
+  ```
 
 ### `wait_for` (deprecated, use `wait`)
 

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -248,7 +248,7 @@ A field path is a string that describes the fully qualified address of a field w
     }
   }
   ```
-  If unsure which type a certain field is, the [`type()`]() Terraform function can determine it. With the resource created and present in state, run `terraform console` and then the following command:
+  You can use the [`type()`]() Terraform function to determine the type of a field. With the resource created and present in state, run `terraform console` and then the following command:
   ```hcl
   > type(kubernetes_manifest.my-secret.object.data)
     map(string)


### PR DESCRIPTION
### Description

Add additional details on using the `wait` feature of `kubernetes_manifest`

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add additional details on using the wait feature of kubernetes_manifest
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
