### PR TITLE
Fix typo in manifest documentation

### DIFF
--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -236,6 +236,7 @@ The following arguments are supported:
 - `fields` (Optional) A map of field paths and a corresponding regular expression with a pattern to wait for. The provider will wait until the field's value matches the regular expression. Use `*` for any value.
 
 A field path is a string that describes the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
+
 * Fields of objects are addressed with `.`
 * Keys of a map field are addressed with `["<key-string>"]`
 * Elements of a list or tuple field are addressed with `[<index-numeral>]`
@@ -250,7 +251,7 @@ A field path is a string that describes the fully qualified address of a field w
   }
   ```
 
-  You can use the [`type()`]() Terraform function to determine the type of a field. With the resource created and present in state, run `terraform console` and then the following command:
+  You can use the [`type()`](https://developer.hashicorp.com/terraform/language/functions/type) Terraform function to determine the type of a field. With the resource created and present in state, run `terraform console` and then the following command:
 
   ```hcl
   > type(kubernetes_manifest.my-secret.object.data)

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -238,7 +238,7 @@ The following arguments are supported:
 A field path is a string that describes the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
   * Fields of objects are addressed with `.`
   * Keys of a map field are addressed with `["<key-string>"]`
-  * Elements of a list or tuple field are addresed with `[<index-numeral>]`
+  * Elements of a list or tuple field are addressed with `[<index-numeral>]`
 
   The following example waits for Kubernetes to create a ServiceAccount token in a Secret, where the `data` field of the Secret is a map.
   ```hcl

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -16,9 +16,9 @@ Once applied, the `object` attribute contains the state of the resource as retur
 
 ### Before you use this resource
 
-* This resource requires API access during planning time. This means the cluster has to be accessible at plan time and thus cannot be created in the same apply operation. We recommend only using this resource for custom resources or resources not yet fully supported by the provider.
+- This resource requires API access during planning time. This means the cluster has to be accessible at plan time and thus cannot be created in the same apply operation. We recommend only using this resource for custom resources or resources not yet fully supported by the provider.
 
-* This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out apply operations. A minimum Kubernetes version of 1.16.x is required, but versions 1.17+ are strongly recommended as the SSA implementation in Kubernetes 1.16.x is incomplete and unstable.
+- This resource uses [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to carry out apply operations. A minimum Kubernetes version of 1.16.x is required, but versions 1.17+ are strongly recommended as the SSA implementation in Kubernetes 1.16.x is incomplete and unstable.
 
 
 ### Example: Create a Kubernetes ConfigMap
@@ -237,9 +237,9 @@ The following arguments are supported:
 
 A field path is a string that describes the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
 
-* Fields of objects are addressed with `.`
-* Keys of a map field are addressed with `["<key-string>"]`
-* Elements of a list or tuple field are addressed with `[<index-numeral>]`
+- Fields of objects are addressed with `.`
+- Keys of a map field are addressed with `["<key-string>"]`
+- Elements of a list or tuple field are addressed with `[<index-numeral>]`
 
   The following example waits for Kubernetes to create a ServiceAccount token in a Secret, where the `data` field of the Secret is a map.
 

--- a/website/docs/r/manifest.html.markdown
+++ b/website/docs/r/manifest.html.markdown
@@ -236,11 +236,12 @@ The following arguments are supported:
 - `fields` (Optional) A map of field paths and a corresponding regular expression with a pattern to wait for. The provider will wait until the field's value matches the regular expression. Use `*` for any value.
 
 A field path is a string that describes the fully qualified address of a field within the resource, including its parent fields all the way up to "object". The syntax of a path string follows the rules below:
-  * Fields of objects are addressed with `.`
-  * Keys of a map field are addressed with `["<key-string>"]`
-  * Elements of a list or tuple field are addressed with `[<index-numeral>]`
+* Fields of objects are addressed with `.`
+* Keys of a map field are addressed with `["<key-string>"]`
+* Elements of a list or tuple field are addressed with `[<index-numeral>]`
 
   The following example waits for Kubernetes to create a ServiceAccount token in a Secret, where the `data` field of the Secret is a map.
+
   ```hcl
   wait {
     fields = {
@@ -248,7 +249,9 @@ A field path is a string that describes the fully qualified address of a field w
     }
   }
   ```
+
   You can use the [`type()`]() Terraform function to determine the type of a field. With the resource created and present in state, run `terraform console` and then the following command:
+
   ```hcl
   > type(kubernetes_manifest.my-secret.object.data)
     map(string)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes a typo picked up in automation

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
