### PR TITLE
Fix manifest waiter dropping resource state on un-recoverable errors

### DIFF
--- a/manifest/test/acceptance/testdata/Wait/wait_for_fields_incomplete_path.tf
+++ b/manifest/test/acceptance/testdata/Wait/wait_for_fields_incomplete_path.tf
@@ -1,0 +1,28 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Secret"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+
+      annotations = {
+        "kubernetes.io/service-account.name" = "default"
+      }
+    }
+    type = "kubernetes.io/service-account-token"
+  }
+
+  wait {
+    fields = {
+      "metadata.annotations" = "^.*$",
+    }
+  }
+
+  timeouts {
+    create = "10s"
+  }
+}

--- a/manifest/test/acceptance/wait_test.go
+++ b/manifest/test/acceptance/wait_test.go
@@ -280,3 +280,50 @@ func TestKubernetesManifest_WaitFields_Annotations(t *testing.T) {
 
 	tfstate.AssertOutputExists(t, "test")
 }
+
+func TestKubernetesManifest_WaitFields_IncompletePath(t *testing.T) {
+	ctx := context.Background()
+
+	name := randName()
+	namespace := randName()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
+	tf := tfhelper.RequireNewWorkingDir(ctx, t)
+	tf.SetReattachInfo(ctx, reattachInfo)
+	defer func() {
+		tf.Destroy(ctx)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "secrets", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Wait/wait_for_fields_incomplete_path.tf", tfvars)
+	tf.SetConfig(ctx, tfconfig)
+	tf.Init(ctx)
+
+	tf.Apply(ctx)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "secrets", namespace, name)
+
+	st, err := tf.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to obtain state: %q", err)
+	}
+	tfstate := tfstatehelper.NewHelper(st)
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.wait.0.fields": map[string]interface{}{
+			"metadata.annotations[\"kubernetes.io/service-account.name\"]": "^default$",
+		},
+	})
+
+}


### PR DESCRIPTION
### Description

Fixes an issue with the waiter logic in the `kubernetes_manifest` resource where it aborts the processing of apply entirely on non-recoverable errors, which leads to the resource state not being saved.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -v -tags acceptance -run '^TestKubernetesManifest_WaitFields_IncompletePath$' ./manifest/test/acceptance        
2023/12/04 14:28:01 Testing against Kubernetes API version: v1.27.3
=== RUN   TestKubernetesManifest_WaitFields_IncompletePath
2023-12-04T14:28:02.754+0100 [INFO]  [ApplyResourceChange][Wait] Waiting until ready...

2023-12-04T14:28:02.756+0100 [INFO]  [ApplyResourceChange][Wait] Done waiting.

--- FAIL: TestKubernetesManifest_WaitFields_IncompletePath (1.90s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1041d4bc8]

goroutine 54 [running]:
testing.tRunner.func1.2({0x1047791c0, 0x105a0b290})
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1545 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1548 +0x360
panic({0x1047791c0?, 0x105a0b290?})
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/runtime/panic.go:914 +0x218
github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state.getAttributesValuesFromResource(0x10423cf5e?, {0x14001877770, 0x18})
        /Users/alex/work/terraform-provider-kubernetes/manifest/test/helper/state/state_helper.go:37 +0x28
github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state.(*Helper).GetAttributeValue(0x14000683040?, 0x14000683040, {0x10423cf5e, 0x26})
        /Users/alex/work/terraform-provider-kubernetes/manifest/test/helper/state/state_helper.go:113 +0x60
github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state.(*Helper).AssertAttributeValues(0x10479de00?, 0x14000683040, 0x10423cf5e?)
        /Users/alex/work/terraform-provider-kubernetes/manifest/test/helper/state/state_helper.go:147 +0x98
github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance.TestKubernetesManifest_WaitFields_IncompletePath(0x14000683040)
        /Users/alex/work/terraform-provider-kubernetes/manifest/test/acceptance/wait_test.go:323 +0x62c
testing.tRunner(0x14000683040, 0x104a3f848)
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1648 +0x33c
FAIL    github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     2.492s
FAIL

```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
