### PR TITLE
Switch to namespace-aware metadata for cron jobtemplate and sts template

### DIFF
--- a/.changelog/2362.txt
+++ b/.changelog/2362.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+`resource/kubernetes_cron_job_v1`: Change the schema to include a namespace in `jobTemplate`
+`resource/kubernetes_stateful_set_v1`: Change the schema to include a namespace in `template`
+```

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -212,7 +212,7 @@ func testAccKubernetesCronJobV1Config_basic(name, imageName string) string {
         annotations = {
           "cluster-autoscaler.kubernetes.io/safe-to-evict" = "false"
         }
-		namespace = "ns-test"
+        namespace = "ns-test"
       }
       spec {
         backoff_limit = 2
@@ -245,8 +245,8 @@ func testAccKubernetesCronJobV1Config_modified(name, imageName string) string {
     schedule = "1 0 * * *"
     job_template {
       metadata {
-		namespace = "ns-test"
-	  }
+        namespace = "ns-test"
+      }
       spec {
         parallelism = 2
         template {

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -244,7 +244,9 @@ func testAccKubernetesCronJobV1Config_modified(name, imageName string) string {
   spec {
     schedule = "1 0 * * *"
     job_template {
-      metadata {}
+      metadata {
+		namespace = "ns-test"
+	  }
       spec {
         parallelism = 2
         template {

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -52,6 +52,7 @@ func TestAccKubernetesCronJobV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.successful_jobs_history_limit", "10"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.suspend", "true"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.metadata.0.annotations.cluster-autoscaler.kubernetes.io/safe-to-evict", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.metadata.0.namespace", "ns-test"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.parallelism", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.template.0.metadata.0.annotations.controller.kubernetes.io/pod-deletion-cost", "10000"),
@@ -211,6 +212,7 @@ func testAccKubernetesCronJobV1Config_basic(name, imageName string) string {
         annotations = {
           "cluster-autoscaler.kubernetes.io/safe-to-evict" = "false"
         }
+		namespace = "ns-test"
       }
       spec {
         backoff_limit = 2

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -85,6 +85,7 @@ func TestAccKubernetesStatefulSetV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.metadata.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.metadata.0.labels.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.metadata.0.labels.app", "ss-test"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.metadata.0.namespace", "ns-test"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.name", "ss-test"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.port.0.container_port", "80"),
@@ -503,6 +504,7 @@ func testAccKubernetesStatefulSetV1ConfigBasic(name, imageName string) string {
         labels = {
           app = "ss-test"
         }
+        namespace = "ns-test"
       }
 
       spec {

--- a/kubernetes/schema_cron_job_spec_v1.go
+++ b/kubernetes/schema_cron_job_spec_v1.go
@@ -33,7 +33,7 @@ func cronJobSpecFieldsV1() map[string]*schema.Schema {
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"metadata": metadataSchema("jobTemplateSpec", true),
+					"metadata": namespacedMetadataSchema("jobTemplateSpec", true),
 					"spec": {
 						Type:        schema.TypeList,
 						Description: "Specification of the desired behavior of the job",

--- a/kubernetes/schema_pod_template.go
+++ b/kubernetes/schema_pod_template.go
@@ -11,7 +11,7 @@ import (
 
 func podTemplateFields(owner string) map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
-		"metadata": metadataSchema(owner, true),
+		"metadata": namespacedMetadataSchema(owner, true),
 		"spec": {
 			Type:        schema.TypeList,
 			Description: fmt.Sprintf("Spec of the pods owned by the %s", owner),


### PR DESCRIPTION
### Description

Switches the metadata schema to include `namespace`:
- jobTemplate for `kubernetes_cron_job_v1`
- template for `kubernetes_stateful_set_v1`

Tests made to the best of my understanding ...

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
➜ make testacc TESTARGS='-run=TestAccKubernetesCronJobV1'      
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/bernardgrymonpon/Repos/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -vet=off -run=TestAccKubernetesCronJobV1 -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesCronJobV1_basic
=== PAUSE TestAccKubernetesCronJobV1_basic
=== RUN   TestAccKubernetesCronJobV1_extra
=== PAUSE TestAccKubernetesCronJobV1_extra
=== RUN   TestAccKubernetesCronJobV1Beta1_basic
=== PAUSE TestAccKubernetesCronJobV1Beta1_basic
=== RUN   TestAccKubernetesCronJobV1Beta1_extra
=== PAUSE TestAccKubernetesCronJobV1Beta1_extra
=== CONT  TestAccKubernetesCronJobV1_basic
=== CONT  TestAccKubernetesCronJobV1Beta1_basic
=== CONT  TestAccKubernetesCronJobV1Beta1_extra
=== CONT  TestAccKubernetesCronJobV1_extra
=== NAME  TestAccKubernetesCronJobV1Beta1_basic
    provider_test.go:236: This test does not run on cluster versions 1.25.0 and above
--- SKIP: TestAccKubernetesCronJobV1Beta1_basic (0.02s)
=== NAME  TestAccKubernetesCronJobV1Beta1_extra
    provider_test.go:236: This test does not run on cluster versions 1.25.0 and above
--- SKIP: TestAccKubernetesCronJobV1Beta1_extra (0.02s)
--- PASS: TestAccKubernetesCronJobV1_extra (3.99s)
--- PASS: TestAccKubernetesCronJobV1_basic (3.99s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   4.462s

 
➜ make testacc TESTARGS='-run=TestAccKubernetesStatefulSetV1'
==> Checking that code complies with gofmt requirements...
go vet .
TF_ACC=1 go test "/Users/bernardgrymonpon/Repos/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -vet=off -run=TestAccKubernetesStatefulSetV1 -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesStatefulSetV1_minimal
=== PAUSE TestAccKubernetesStatefulSetV1_minimal
=== RUN   TestAccKubernetesStatefulSetV1_basic
=== PAUSE TestAccKubernetesStatefulSetV1_basic
=== RUN   TestAccKubernetesStatefulSetV1_basic_idempotency
=== PAUSE TestAccKubernetesStatefulSetV1_basic_idempotency
=== RUN   TestAccKubernetesStatefulSetV1_Update
=== PAUSE TestAccKubernetesStatefulSetV1_Update
=== RUN   TestAccKubernetesStatefulSetV1_waitForRollout
=== PAUSE TestAccKubernetesStatefulSetV1_waitForRollout
=== CONT  TestAccKubernetesStatefulSetV1_minimal
=== CONT  TestAccKubernetesStatefulSetV1_Update
=== CONT  TestAccKubernetesStatefulSetV1_basic_idempotency
=== CONT  TestAccKubernetesStatefulSetV1_waitForRollout
=== CONT  TestAccKubernetesStatefulSetV1_basic
--- PASS: TestAccKubernetesStatefulSetV1_minimal (18.37s)
--- PASS: TestAccKubernetesStatefulSetV1_basic (18.78s)
--- PASS: TestAccKubernetesStatefulSetV1_waitForRollout (20.06s)
--- PASS: TestAccKubernetesStatefulSetV1_basic_idempotency (29.11s)
--- PASS: TestAccKubernetesStatefulSetV1_Update (67.25s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   67.726s
```

### Release Note

```release-note
- Adds `namespace` to `jobTemplate` within `kubernetes_cron_job_v1` specs.
- Adds `namespace` to `template` within `kubernetes_stateful_set_v1` specs.
```

### References

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2321

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
