### PR TITLE
🧹 Remove unnecessary error returns and handlings

### DIFF
--- a/kubernetes/resource_kubernetes_certificate_signing_request_v1.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_v1.go
@@ -93,10 +93,7 @@ func resourceKubernetesCertificateSigningRequestV1Create(ctx context.Context, d 
 	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	spec, err := expandCertificateSigningRequestV1Spec(d.Get("spec").([]interface{}))
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	spec := expandCertificateSigningRequestV1Spec(d.Get("spec").([]interface{}))
 
 	csr := certificates.CertificateSigningRequest{
 		ObjectMeta: metadata,

--- a/kubernetes/resource_kubernetes_cron_job_migrate.go
+++ b/kubernetes/resource_kubernetes_cron_job_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesCronJobV0() *schema.Resource {
 }
 
 func resourceKubernetesCronJobUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/resource_kubernetes_csi_driver_v1.go
+++ b/kubernetes/resource_kubernetes_csi_driver_v1.go
@@ -119,10 +119,7 @@ func resourceKubernetesCSIDriverV1Read(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	spec, err := flattenCSIDriverV1Spec(CSIDriver.Spec)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	spec := flattenCSIDriverV1Spec(CSIDriver.Spec)
 
 	err = d.Set("spec", spec)
 	if err != nil {
@@ -141,10 +138,7 @@ func resourceKubernetesCSIDriverV1Update(ctx context.Context, d *schema.Resource
 	name := d.Id()
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
-		diffOps, err := patchCSIDriverV1Spec("spec.0.", "/spec", d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		diffOps := patchCSIDriverV1Spec("spec.0.", "/spec", d)
 		ops = append(ops, *diffOps...)
 	}
 	data, err := ops.MarshalJSON()

--- a/kubernetes/resource_kubernetes_csi_driver_v1beta1.go
+++ b/kubernetes/resource_kubernetes_csi_driver_v1beta1.go
@@ -116,10 +116,7 @@ func resourceKubernetesCSIDriverV1Beta1Read(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	spec, err := flattenCSIDriverSpec(CSIDriver.Spec)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	spec := flattenCSIDriverSpec(CSIDriver.Spec)
 
 	err = d.Set("spec", spec)
 	if err != nil {
@@ -138,10 +135,7 @@ func resourceKubernetesCSIDriverV1Beta1Update(ctx context.Context, d *schema.Res
 	name := d.Id()
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
-		diffOps, err := patchCSIDriverSpec("spec.0.", "/spec", d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		diffOps := patchCSIDriverSpec("spec.0.", "/spec", d)
 		ops = append(ops, *diffOps...)
 	}
 	data, err := ops.MarshalJSON()

--- a/kubernetes/resource_kubernetes_daemonset_migrate.go
+++ b/kubernetes/resource_kubernetes_daemonset_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesDaemonSetV0() *schema.Resource {
 }
 
 func resourceKubernetesDaemonSetUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/resource_kubernetes_deployment_migrate.go
+++ b/kubernetes/resource_kubernetes_deployment_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesDeploymentV0() *schema.Resource {
 }
 
 func resourceKubernetesDeploymentUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/resource_kubernetes_ingress_migrate.go
+++ b/kubernetes/resource_kubernetes_ingress_migrate.go
@@ -5,9 +5,10 @@ package kubernetes
 
 import (
 	"context"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	networking "k8s.io/api/networking/v1beta1"
-	"log"
 )
 
 // resourceKubernetesIngressV0 is a copy of the Kubernetes Ingress schema (before migration).
@@ -140,5 +141,6 @@ func resourceKubernetesIngressV0() *schema.Resource {
 func resourceKubernetesIngressStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	log.Println("[INFO] Found Kubernetes Service state v0; upgrading state to v1")
 	delete(rawState, "load_balancer_ingress")
+	// Return a nil error here to satisfy StateUpgradeFunc signature
 	return rawState, nil
 }

--- a/kubernetes/resource_kubernetes_job_migrate.go
+++ b/kubernetes/resource_kubernetes_job_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesJobV0() *schema.Resource {
 }
 
 func resourceKubernetesJobUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/resource_kubernetes_job_v1.go
+++ b/kubernetes/resource_kubernetes_job_v1.go
@@ -175,10 +175,7 @@ func resourceKubernetesJobV1Update(ctx context.Context, d *schema.ResourceData, 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 
 	if d.HasChange("spec") {
-		specOps, err := patchJobV1Spec("/spec", "spec.0.", d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		specOps := patchJobV1Spec("/spec", "spec.0.", d)
 		ops = append(ops, specOps...)
 	}
 

--- a/kubernetes/resource_kubernetes_pod_migrate.go
+++ b/kubernetes/resource_kubernetes_pod_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesPodV0() *schema.Resource {
 }
 
 func resourceKubernetesPodUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/resource_kubernetes_pod_security_policy_v1beta1.go
+++ b/kubernetes/resource_kubernetes_pod_security_policy_v1beta1.go
@@ -448,10 +448,7 @@ func resourceKubernetesPodSecurityPolicyV1Beta1Update(ctx context.Context, d *sc
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 
 	if d.HasChange("spec") {
-		diffOps, err := patchPodSecurityPolicySpec("spec.0.", "/spec", d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		diffOps := patchPodSecurityPolicySpec("spec.0.", "/spec", d)
 		ops = append(ops, *diffOps...)
 	}
 	data, err := ops.MarshalJSON()

--- a/kubernetes/resource_kubernetes_replication_controller_migrate.go
+++ b/kubernetes/resource_kubernetes_replication_controller_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesReplicationControllerV0() *schema.Resource {
 }
 
 func resourceKubernetesReplicationControllerUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/resource_kubernetes_service_migrate.go
+++ b/kubernetes/resource_kubernetes_service_migrate.go
@@ -176,5 +176,6 @@ func resourceKubernetesServiceV0() *schema.Resource {
 func resourceKubernetesServiceStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	log.Println("[INFO] Found Kubernetes Service state v0; upgrading state to v1")
 	delete(rawState, "load_balancer_ingress")
+	// Return a nil error here to satisfy StateUpgradeFunc signature
 	return rawState, nil
 }

--- a/kubernetes/resource_kubernetes_service_v1.go
+++ b/kubernetes/resource_kubernetes_service_v1.go
@@ -449,10 +449,7 @@ func resourceKubernetesServiceV1Update(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		diffOps, err := patchServiceSpec("spec.0.", "/spec/", d, serverVersion)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		diffOps := patchServiceSpec("spec.0.", "/spec/", d, serverVersion)
 		ops = append(ops, diffOps...)
 	}
 	data, err := ops.MarshalJSON()

--- a/kubernetes/resource_kubernetes_stateful_set_migrate.go
+++ b/kubernetes/resource_kubernetes_stateful_set_migrate.go
@@ -16,5 +16,6 @@ func resourceKubernetesStatefulSetV0() *schema.Resource {
 }
 
 func resourceKubernetesStatefulSetUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta)
+	// Return a nil error here to satisfy StateUpgradeFunc signature
+	return upgradeTemplatePodSpecWithResourcesFieldV0(ctx, rawState, meta), nil
 }

--- a/kubernetes/schema_resources_migrate.go
+++ b/kubernetes/schema_resources_migrate.go
@@ -42,77 +42,77 @@ func patchPodSpecWithResourcesFieldV0(m map[string]*schema.Schema) map[string]*s
 	return m
 }
 
-func upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func upgradeJobTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) map[string]interface{} {
 	s, ok := rawState["spec"].([]interface{})
 	if !ok || len(s) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	spec := s[0].(map[string]interface{})
 	jt, ok := spec["job_template"].([]interface{})
 	if !ok || len(jt) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	jobTemplate := jt[0].(map[string]interface{})
 	js, ok := jobTemplate["spec"].([]interface{})
 	if !ok || len(js) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	jobSpec := js[0].(map[string]interface{})
 	t, ok := jobSpec["template"].([]interface{})
 	if !ok || len(t) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	template := t[0].(map[string]interface{})
 	ps, ok := template["spec"].([]interface{})
 	if !ok || len(ps) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	podSpec := ps[0].(map[string]interface{})
 	template["spec"] = []interface{}{upgradeContainers(podSpec)}
 
-	return rawState, nil
+	return rawState
 }
 
-func upgradeTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func upgradeTemplatePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) map[string]interface{} {
 	s, ok := rawState["spec"].([]interface{})
 	if !ok || len(s) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	spec := s[0].(map[string]interface{})
 	t, ok := spec["template"].([]interface{})
 	if !ok || len(t) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	template := t[0].(map[string]interface{})
 	ps, ok := template["spec"].([]interface{})
 
 	if !ok || len(ps) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	podSpec := ps[0].(map[string]interface{})
 	template["spec"] = []interface{}{upgradeContainers(podSpec)}
 
-	return rawState, nil
+	return rawState
 }
 
-func upgradePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func upgradePodSpecWithResourcesFieldV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) map[string]interface{} {
 	s, ok := rawState["spec"].([]interface{})
 	if !ok || len(s) == 0 {
-		return rawState, nil
+		return rawState
 	}
 
 	spec := s[0].(map[string]interface{})
 	rawState["spec"] = []interface{}{upgradeContainers(spec)}
 
-	return rawState, nil
+	return rawState
 }
 
 func upgradeContainers(rawState map[string]interface{}) map[string]interface{} {

--- a/kubernetes/schema_resources_migrate_test.go
+++ b/kubernetes/schema_resources_migrate_test.go
@@ -132,7 +132,7 @@ func TestUpgradeTemplatePodSpecWithResourcesFieldV0(t *testing.T) {
 		}},
 	}
 
-	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.TODO(), v0, nil)
+	actual := upgradeTemplatePodSpecWithResourcesFieldV0(context.TODO(), v0, nil)
 
 	if !reflect.DeepEqual(v1, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
@@ -190,7 +190,7 @@ func TestUpgradeTemplatePodSpecWithResourcesFieldV0_empty(t *testing.T) {
 		}},
 	}
 
-	actual, _ := upgradeTemplatePodSpecWithResourcesFieldV0(context.TODO(), v0, nil)
+	actual := upgradeTemplatePodSpecWithResourcesFieldV0(context.TODO(), v0, nil)
 
 	if !reflect.DeepEqual(v1, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)

--- a/kubernetes/structure_csi_driver.go
+++ b/kubernetes/structure_csi_driver.go
@@ -38,7 +38,7 @@ func expandCSIDriverVolumeLifecycleModes(l []interface{}) []storage.VolumeLifecy
 	return lifecycleModes
 }
 
-func flattenCSIDriverSpec(in storage.CSIDriverSpec) ([]interface{}, error) {
+func flattenCSIDriverSpec(in storage.CSIDriverSpec) []interface{} {
 	att := make(map[string]interface{})
 
 	att["attach_required"] = in.AttachRequired
@@ -51,10 +51,10 @@ func flattenCSIDriverSpec(in storage.CSIDriverSpec) ([]interface{}, error) {
 		att["volume_lifecycle_modes"] = in.VolumeLifecycleModes
 	}
 
-	return []interface{}{att}, nil
+	return []interface{}{att}
 }
 
-func patchCSIDriverSpec(keyPrefix, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
+func patchCSIDriverSpec(keyPrefix, pathPrefix string, d *schema.ResourceData) *PatchOperations {
 	ops := make(PatchOperations, 0)
 	if d.HasChange(keyPrefix + "attach_required") {
 		ops = append(ops, &ReplaceOperation{
@@ -77,5 +77,5 @@ func patchCSIDriverSpec(keyPrefix, pathPrefix string, d *schema.ResourceData) (*
 		})
 	}
 
-	return &ops, nil
+	return &ops
 }

--- a/kubernetes/structure_csi_driver_v1.go
+++ b/kubernetes/structure_csi_driver_v1.go
@@ -38,7 +38,7 @@ func expandCSIDriverV1VolumeLifecycleModes(l []interface{}) []storage.VolumeLife
 	return lifecycleModes
 }
 
-func flattenCSIDriverV1Spec(in storage.CSIDriverSpec) ([]interface{}, error) {
+func flattenCSIDriverV1Spec(in storage.CSIDriverSpec) []interface{} {
 	att := make(map[string]interface{})
 
 	att["attach_required"] = in.AttachRequired
@@ -51,10 +51,10 @@ func flattenCSIDriverV1Spec(in storage.CSIDriverSpec) ([]interface{}, error) {
 		att["volume_lifecycle_modes"] = in.VolumeLifecycleModes
 	}
 
-	return []interface{}{att}, nil
+	return []interface{}{att}
 }
 
-func patchCSIDriverV1Spec(keyPrefix, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
+func patchCSIDriverV1Spec(keyPrefix, pathPrefix string, d *schema.ResourceData) *PatchOperations {
 	ops := make(PatchOperations, 0)
 	if d.HasChange(keyPrefix + "attach_required") {
 		ops = append(ops, &ReplaceOperation{
@@ -77,5 +77,5 @@ func patchCSIDriverV1Spec(keyPrefix, pathPrefix string, d *schema.ResourceData) 
 		})
 	}
 
-	return &ops, nil
+	return &ops
 }

--- a/kubernetes/structure_hostalias.go
+++ b/kubernetes/structure_hostalias.go
@@ -3,9 +3,9 @@
 
 package kubernetes
 
-import v1 "k8s.io/api/core/v1"
+import corev1 "k8s.io/api/core/v1"
 
-func flattenHostaliases(in []v1.HostAlias) []interface{} {
+func flattenHostaliases(in []corev1.HostAlias) []interface{} {
 	att := make([]interface{}, len(in))
 	for i, v := range in {
 		ha := make(map[string]interface{})
@@ -17,12 +17,12 @@ func flattenHostaliases(in []v1.HostAlias) []interface{} {
 	}
 	return att
 }
-func expandHostaliases(hostalias []interface{}) []v1.HostAlias {
+func expandHostaliases(hostalias []interface{}) []corev1.HostAlias {
 	if len(hostalias) == 0 {
-		return []v1.HostAlias{}
+		return []corev1.HostAlias{}
 	}
 
-	hs := make([]v1.HostAlias, len(hostalias))
+	hs := make([]corev1.HostAlias, len(hostalias))
 	for i, ha := range hostalias {
 		hoas := ha.(map[string]interface{})
 

--- a/kubernetes/structure_hostalias.go
+++ b/kubernetes/structure_hostalias.go
@@ -3,7 +3,7 @@
 
 package kubernetes
 
-import "k8s.io/api/core/v1"
+import v1 "k8s.io/api/core/v1"
 
 func flattenHostaliases(in []v1.HostAlias) []interface{} {
 	att := make([]interface{}, len(in))
@@ -17,9 +17,9 @@ func flattenHostaliases(in []v1.HostAlias) []interface{} {
 	}
 	return att
 }
-func expandHostaliases(hostalias []interface{}) ([]v1.HostAlias, error) {
+func expandHostaliases(hostalias []interface{}) []v1.HostAlias {
 	if len(hostalias) == 0 {
-		return []v1.HostAlias{}, nil
+		return []v1.HostAlias{}
 	}
 
 	hs := make([]v1.HostAlias, len(hostalias))
@@ -34,5 +34,5 @@ func expandHostaliases(hostalias []interface{}) ([]v1.HostAlias, error) {
 			hs[i].Hostnames = expandStringSlice(hostnames)
 		}
 	}
-	return hs, nil
+	return hs
 }

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -111,7 +111,7 @@ func expandJobV1Spec(j []interface{}) (batchv1.JobSpec, error) {
 	return obj, nil
 }
 
-func patchJobV1Spec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOperations, error) {
+func patchJobV1Spec(pathPrefix, prefix string, d *schema.ResourceData) PatchOperations {
 	ops := make([]PatchOperation, 0)
 
 	if d.HasChange(prefix + "active_deadline_seconds") {
@@ -146,7 +146,7 @@ func patchJobV1Spec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOpe
 		})
 	}
 
-	return ops, nil
+	return ops
 }
 
 // removeGeneratedLabels removes server-generated labels

--- a/kubernetes/structure_network_policy.go
+++ b/kubernetes/structure_network_policy.go
@@ -149,7 +149,7 @@ func expandNetworkPolicyV1Ingress(l []interface{}) (*[]networkingv1.NetworkPolic
 		}
 		ingresses[i] = networkingv1.NetworkPolicyIngressRule{}
 		if v, ok := in["ports"].([]interface{}); ok && len(v) > 0 {
-			ingresses[i].Ports = expandNetworkPolicyV1Ports(v)
+			ingresses[i].Ports = *expandNetworkPolicyV1Ports(v)
 		}
 		if v, ok := in["from"].([]interface{}); ok && len(v) > 0 {
 			policyPeers, err := expandNetworkPolicyV1Peer(v)
@@ -174,7 +174,7 @@ func expandNetworkPolicyV1Egress(l []interface{}) (*[]networkingv1.NetworkPolicy
 		}
 		egresses[i] = networkingv1.NetworkPolicyEgressRule{}
 		if v, ok := in["ports"].([]interface{}); ok && len(v) > 0 {
-			egresses[i].Ports = expandNetworkPolicyV1Ports(v)
+			egresses[i].Ports = *expandNetworkPolicyV1Ports(v)
 		}
 		if v, ok := in["to"].([]interface{}); ok && len(v) > 0 {
 			policyPeers, err := expandNetworkPolicyV1Peer(v)
@@ -187,7 +187,7 @@ func expandNetworkPolicyV1Egress(l []interface{}) (*[]networkingv1.NetworkPolicy
 	return &egresses, nil
 }
 
-func expandNetworkPolicyV1Ports(l []interface{}) []networkingv1.NetworkPolicyPort {
+func expandNetworkPolicyV1Ports(l []interface{}) *[]networkingv1.NetworkPolicyPort {
 	policyPorts := make([]networkingv1.NetworkPolicyPort, len(l))
 	for i, port := range l {
 		in, ok := port.(map[string]interface{})
@@ -203,7 +203,7 @@ func expandNetworkPolicyV1Ports(l []interface{}) []networkingv1.NetworkPolicyPor
 			policyPorts[i].Protocol = &v
 		}
 	}
-	return policyPorts
+	return &policyPorts
 }
 
 func expandNetworkPolicyV1Peer(l []interface{}) (*[]networkingv1.NetworkPolicyPeer, error) {

--- a/kubernetes/structure_network_policy_test.go
+++ b/kubernetes/structure_network_policy_test.go
@@ -130,8 +130,8 @@ func TestExpandNetworkPolicyIngressPorts(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output, _ := expandNetworkPolicyV1Ports(tc.Input)
-		if !reflect.DeepEqual(output, &tc.ExpectedOutput) {
+		output := expandNetworkPolicyV1Ports(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)
 		}

--- a/kubernetes/structure_network_policy_test.go
+++ b/kubernetes/structure_network_policy_test.go
@@ -83,7 +83,7 @@ func TestExpandNetworkPolicyIngressPorts(t *testing.T) {
 
 	cases := []struct {
 		Input          []interface{}
-		ExpectedOutput []networkingv1.NetworkPolicyPort
+		ExpectedOutput *[]networkingv1.NetworkPolicyPort
 	}{
 		{
 			[]interface{}{
@@ -92,7 +92,7 @@ func TestExpandNetworkPolicyIngressPorts(t *testing.T) {
 					"protocol": "TCP",
 				},
 			},
-			[]networkingv1.NetworkPolicyPort{{
+			&[]networkingv1.NetworkPolicyPort{{
 				Port:     &portName,
 				Protocol: &protoTCP,
 			}},
@@ -103,7 +103,7 @@ func TestExpandNetworkPolicyIngressPorts(t *testing.T) {
 					"port": "http",
 				},
 			},
-			[]networkingv1.NetworkPolicyPort{{
+			&[]networkingv1.NetworkPolicyPort{{
 				Port: &portName,
 			}},
 		},
@@ -114,18 +114,18 @@ func TestExpandNetworkPolicyIngressPorts(t *testing.T) {
 					"protocol": "UDP",
 				},
 			},
-			[]networkingv1.NetworkPolicyPort{{
+			&[]networkingv1.NetworkPolicyPort{{
 				Port:     &portNumerical,
 				Protocol: &protoUDP,
 			}},
 		},
 		{
 			[]interface{}{map[string]interface{}{}},
-			[]networkingv1.NetworkPolicyPort{{}},
+			&[]networkingv1.NetworkPolicyPort{{}},
 		},
 		{
 			[]interface{}{},
-			[]networkingv1.NetworkPolicyPort{},
+			&[]networkingv1.NetworkPolicyPort{},
 		},
 	}
 

--- a/kubernetes/structure_pod_security_policy_spec.go
+++ b/kubernetes/structure_pod_security_policy_spec.go
@@ -496,7 +496,7 @@ func expandVolumeFSTypeSlice(in []interface{}) []v1beta1.FSType {
 
 // Patchers
 
-func patchPodSecurityPolicySpec(keyPrefix string, pathPrefix string, d *schema.ResourceData) (*PatchOperations, error) {
+func patchPodSecurityPolicySpec(keyPrefix string, pathPrefix string, d *schema.ResourceData) *PatchOperations {
 	ops := make(PatchOperations, 0)
 
 	if d.HasChange(keyPrefix + "allow_privilege_escalation") {
@@ -659,5 +659,5 @@ func patchPodSecurityPolicySpec(keyPrefix string, pathPrefix string, d *schema.R
 		})
 	}
 
-	return &ops, nil
+	return &ops
 }

--- a/kubernetes/structure_service_spec.go
+++ b/kubernetes/structure_service_spec.go
@@ -286,7 +286,7 @@ func expandServiceSpec(l []interface{}) v1.ServiceSpec {
 
 // Patch Ops
 
-func patchServiceSpec(keyPrefix, pathPrefix string, d *schema.ResourceData, kv *gversion.Version) (PatchOperations, error) {
+func patchServiceSpec(keyPrefix, pathPrefix string, d *schema.ResourceData, kv *gversion.Version) PatchOperations {
 	ops := make([]PatchOperation, 0)
 
 	if d.HasChange(keyPrefix + "allocate_load_balancer_node_ports") {
@@ -426,5 +426,5 @@ func patchServiceSpec(keyPrefix, pathPrefix string, d *schema.ResourceData, kv *
 			Value: int32(d.Get(keyPrefix + "health_check_node_port").(int)),
 		})
 	}
-	return ops, nil
+	return ops
 }

--- a/kubernetes/structures_certificate_signing_request_v1.go
+++ b/kubernetes/structures_certificate_signing_request_v1.go
@@ -9,10 +9,10 @@ import (
 	certificates "k8s.io/api/certificates/v1"
 )
 
-func expandCertificateSigningRequestV1Spec(csr []interface{}) (*certificates.CertificateSigningRequestSpec, error) {
+func expandCertificateSigningRequestV1Spec(csr []interface{}) *certificates.CertificateSigningRequestSpec {
 	obj := &certificates.CertificateSigningRequestSpec{}
 	if len(csr) == 0 || csr[0] == nil {
-		return obj, nil
+		return obj
 	}
 	in := csr[0].(map[string]interface{})
 	obj.Request = []byte(in["request"].(string))
@@ -22,7 +22,7 @@ func expandCertificateSigningRequestV1Spec(csr []interface{}) (*certificates.Cer
 	if v, ok := in["signer_name"].(string); ok && v != "" {
 		obj.SignerName = v
 	}
-	return obj, nil
+	return obj
 }
 
 func expandCertificateSigningRequestV1Usages(s []interface{}) []certificates.KeyUsage {

--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -102,10 +102,7 @@ func TestExpandSecretKeyRef(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output, err := expandSecretKeyRef(tc.Input)
-		if err != nil {
-			t.Fatalf("Unexpected failure in expander.\nInput: %#v, error: %#v", tc.Input, err)
-		}
+		output := expandSecretKeyRef(tc.Input)
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)
@@ -205,10 +202,7 @@ func TestExpandConfigMapKeyRef(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output, err := expandConfigMapKeyRef(tc.Input)
-		if err != nil {
-			t.Fatalf("Unexpected failure in expander.\nInput: %#v, error: %#v", tc.Input, err)
-		}
+		output := expandConfigMapKeyRef(tc.Input)
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)
@@ -310,10 +304,7 @@ func TestFlattenContainerVolumeMounts_mountPropogation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output, err := flattenContainerVolumeMounts(tc.Input)
-		if err != nil {
-			t.Fatalf("Unexpected failure in flattener.\nInput: %#v, error: %#v", tc.Input, err)
-		}
+		output := flattenContainerVolumeMounts(tc.Input)
 		if !reflect.DeepEqual(output, tc.Expected) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
 				tc.Expected, output)

--- a/kubernetes/structures_env.go
+++ b/kubernetes/structures_env.go
@@ -23,11 +23,7 @@ func expandEnv(e []interface{}) []map[string]interface{} {
 			newEnv["value"] = value
 		}
 		if v, ok := p["value_from"].([]interface{}); ok && len(v) > 0 {
-			var err error
-			newEnv["valueFrom"], err = expandEnvValueFromMap(v[0])
-			if err != nil {
-				return envs
-			}
+			newEnv["valueFrom"] = expandEnvValueFromMap(v[0])
 		}
 		envs = append(envs, newEnv)
 	}
@@ -35,9 +31,9 @@ func expandEnv(e []interface{}) []map[string]interface{} {
 	return envs
 }
 
-func expandEnvValueFromMap(e interface{}) (map[string]interface{}, error) {
+func expandEnvValueFromMap(e interface{}) map[string]interface{} {
 	if e == nil {
-		return nil, nil
+		return nil
 	}
 
 	in := e.(map[string]interface{})
@@ -56,7 +52,7 @@ func expandEnvValueFromMap(e interface{}) (map[string]interface{}, error) {
 		expandedValues["secretKeyRef"] = v[0]
 	}
 
-	return expandedValues, nil
+	return expandedValues
 }
 
 func expandFieldRefMap(e interface{}) map[string]interface{} {
@@ -117,11 +113,7 @@ func flattenEnv(e []interface{}) []interface{} {
 			newEnv["value"] = value
 		}
 		if v, ok := p["valueFrom"].(map[string]interface{}); ok && len(v) > 0 {
-			var err error
-			newEnv["value_from"], err = flattenEnvValueFromMap(v)
-			if err != nil {
-				return envs
-			}
+			newEnv["value_from"] = flattenEnvValueFromMap(v)
 		}
 		envs = append(envs, newEnv)
 	}
@@ -129,9 +121,9 @@ func flattenEnv(e []interface{}) []interface{} {
 	return envs
 }
 
-func flattenEnvValueFromMap(e interface{}) ([]interface{}, error) {
+func flattenEnvValueFromMap(e interface{}) []interface{} {
 	if e == nil {
-		return nil, nil
+		return nil
 	}
 
 	in := e.(map[string]interface{})
@@ -150,7 +142,7 @@ func flattenEnvValueFromMap(e interface{}) ([]interface{}, error) {
 		expandedValues["secret_key_ref"] = []interface{}{v}
 	}
 
-	return []interface{}{expandedValues}, nil
+	return []interface{}{expandedValues}
 }
 
 func flattenFieldRefMap(e interface{}) []interface{} {

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -338,18 +338,14 @@ func patchUpdateStrategy(keyPrefix, pathPrefix string, d *schema.ResourceData) (
 		}
 
 		if len(o.([]interface{})) > 0 && len(n.([]interface{})) > 0 {
-			r, err := patchUpdateStrategyRollingUpdate(keyPrefix+"rolling_update.0.", pathPrefix+"rollingUpdate/", d)
-			if err != nil {
-				return ops, err
-			}
-			ops = append(ops, r...)
+			ops = append(ops, patchUpdateStrategyRollingUpdate(keyPrefix+"rolling_update.0.", pathPrefix+"rollingUpdate/", d)...)
 		}
 	}
 
 	return ops, nil
 }
 
-func patchUpdateStrategyRollingUpdate(keyPrefix, pathPrefix string, d *schema.ResourceData) (PatchOperations, error) {
+func patchUpdateStrategyRollingUpdate(keyPrefix, pathPrefix string, d *schema.ResourceData) PatchOperations {
 	ops := PatchOperations{}
 	if d.HasChange(keyPrefix + "partition") {
 		log.Printf("[TRACE] StatefulSet.Spec.UpdateStrategy.RollingUpdate.Partition has changes")
@@ -360,5 +356,5 @@ func patchUpdateStrategyRollingUpdate(keyPrefix, pathPrefix string, d *schema.Re
 			})
 		}
 	}
-	return ops, nil
+	return ops
 }

--- a/kubernetes/structures_tokenrequest.go
+++ b/kubernetes/structures_tokenrequest.go
@@ -17,11 +17,7 @@ func flattenTokenRequestV1Spec(in authv1.TokenRequestSpec, d *schema.ResourceDat
 	att["audiences"] = in.Audiences
 
 	if in.BoundObjectRef != nil {
-		bndObjRef, err := flattenBoundObjectReference(*in.BoundObjectRef, d, meta)
-		if err != nil {
-			return nil, err
-		}
-		att["bound_object_ref"] = bndObjRef
+		att["bound_object_ref"] = flattenBoundObjectReference(*in.BoundObjectRef, d, meta)
 	}
 
 	if in.ExpirationSeconds != nil {
@@ -31,7 +27,7 @@ func flattenTokenRequestV1Spec(in authv1.TokenRequestSpec, d *schema.ResourceDat
 	return []interface{}{att}, nil
 }
 
-func flattenBoundObjectReference(in authv1.BoundObjectReference, d *schema.ResourceData, meta interface{}) ([]interface{}, error) {
+func flattenBoundObjectReference(in authv1.BoundObjectReference, d *schema.ResourceData, meta interface{}) []interface{} {
 	att := make(map[string]interface{})
 
 	att["api_version"] = in.APIVersion
@@ -42,7 +38,7 @@ func flattenBoundObjectReference(in authv1.BoundObjectReference, d *schema.Resou
 
 	att["uid"] = in.UID
 
-	return []interface{}{att}, nil
+	return []interface{}{att}
 }
 
 // Expanders
@@ -58,11 +54,7 @@ func expandTokenRequestV1Spec(p []interface{}) *authv1.TokenRequestSpec {
 		obj.Audiences = expandStringSlice(v)
 	}
 
-	bdObjRef, err := expandBoundObjectReference(in["bound_object_ref"].([]interface{}))
-	if err != nil {
-		return obj
-	}
-	obj.BoundObjectRef = bdObjRef
+	obj.BoundObjectRef = expandBoundObjectReference(in["bound_object_ref"].([]interface{}))
 
 	if v, ok := in["expiration_seconds"].(int); v != 0 && ok {
 		obj.ExpirationSeconds = ptrToInt64(int64(v))
@@ -71,10 +63,10 @@ func expandTokenRequestV1Spec(p []interface{}) *authv1.TokenRequestSpec {
 	return obj
 }
 
-func expandBoundObjectReference(p []interface{}) (*authv1.BoundObjectReference, error) {
+func expandBoundObjectReference(p []interface{}) *authv1.BoundObjectReference {
 	obj := &authv1.BoundObjectReference{}
 	if len(p) == 0 || p[0] == nil {
-		return nil, nil
+		return nil
 	}
 	in := p[0].(map[string]interface{})
 
@@ -94,5 +86,5 @@ func expandBoundObjectReference(p []interface{}) (*authv1.BoundObjectReference, 
 		obj.UID = types.UID(v.(string))
 	}
 
-	return obj, nil
+	return obj
 }


### PR DESCRIPTION
### Description

We have a bunch of functions that, according to their signatures, are supposed to return an error, but all return statements within these functions stay with `nil` only at the error place. In this case, it doesn't make much sense to keep them and handle an error on return.

This PR aims to remove unnecessary error returns as well as error handling, as no errors are returned anymore.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
