### PR TITLE
update tests to run in sustainable areas

### DIFF
--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       location:
         description: 'Location'
-        default: "West US 3"
+        default: "Canada Central"
       nodeCount:
         description: 'Number of nodes to provision'
         default: 2

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       location:
         description: 'Location'
-        default: "Canada Central"
+        default: "Canada East"
       nodeCount:
         description: 'Number of nodes to provision'
         default: 2

--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       region:
         description: The AWS region
-        default: us-east-1
+        default: ca-central-1
       azSpan:
         description: The number of AZs to spread cluster nodes across
         default: 2

--- a/.github/workflows/acceptance_tests_gke.yaml
+++ b/.github/workflows/acceptance_tests_gke.yaml
@@ -5,10 +5,10 @@ on:
     inputs:
       region:
         description: The GKE region
-        default: us-west1
+        default: northamerica-northeast1
       zone:
         description: The GKE zone
-        default: us-west1-c
+        default: northamerica-northeast1-a
       clusterVersion:
         description: The GKE cluster version
         default: 1.27


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

To match the change in keeping software sustainable, this PR will update tests to be run in Canada Central where based on https://app.electricitymaps.com/ is the most sustainable for running tests. This is mentioned in an AWS blog on sustainability. https://aws.amazon.com/blogs/architecture/how-to-select-a-region-for-your-workload-based-on-sustainability-goals/

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
