### PR TITLE
Implement GetMetadata call in manifest provider

### DIFF
--- a/.changelog/2384.txt
+++ b/.changelog/2384.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`kubernetes_manifest`: Implement response for GetMetadata protocol function
+```

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -54,7 +54,20 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpr
 // GetMetadata function
 func (s *RawProviderServer) GetMetadata(ctx context.Context, req *tfprotov5.GetMetadataRequest) (*tfprotov5.GetMetadataResponse, error) {
 	s.logger.Trace("[GetMetadata][Request]\n%s\n", dump(*req))
-	resp := &tfprotov5.GetMetadataResponse{}
+
+	resp := &tfprotov5.GetMetadataResponse{
+		Resources: []tfprotov5.ResourceMetadata{{
+			TypeName: "kubernetes_manifest",
+		}},
+		DataSources: []tfprotov5.DataSourceMetadata{
+			{
+				TypeName: "kubernetes_resource",
+			},
+			{
+				TypeName: "kubernetes_resources",
+			},
+		},
+	}
 	return resp, nil
 }
 


### PR DESCRIPTION
### Description

This PR implements the `GetMetadata` protocol function in the manifest provider. This was not required in 1.5, but causes an error in 1.6. 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

- https://github.com/hashicorp/terraform-provider-kubernetes/issues/2383

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
