### PR TITLE
Fix namespace requirement in template metadata

### DIFF
--- a/.changelog/2387.txt
+++ b/.changelog/2387.txt
@@ -1,0 +1,31 @@
+```release-note:bug
+`resource/kubernetes_stateful_set_v1`: fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the resource schema.
+```
+
+```release-note:bug
+`resource/kubernetes_stateful_set`: fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the resource schema.
+```
+
+```release-note:bug
+`resource/kubernetes_daemon_set_v1`: fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the resource schema.
+```
+
+```release-note:bug
+`resource/kubernetes_daemonset`: fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the resource schema.
+```
+
+```release-note:bug
+`resource/kubernetes_cron_job_v1`: fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the resource schema.
+```
+
+```release-note:bug
+`resource/kubernetes_cron_job`: fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the resource schema.
+```
+
+```release-note:note
+Resources `kubernetes_stateful_set_v1`, `kubernetes_stateful_set`, `kubernetes_daemon_set_v1`, and `kubernetes_daemonset` got a new attribute `spec.template.metadata.namespace`. It is a stub attribute that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
+```
+
+```release-note:note
+Resources `kubernetes_cron_job_v1` and `kubernetes_cron_job` got a new attribute `spec.job_template.metadata.namespace`. It is a stub attribute that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
+```

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -52,7 +52,6 @@ func TestAccKubernetesCronJobV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.successful_jobs_history_limit", "10"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.suspend", "true"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.metadata.0.annotations.cluster-autoscaler.kubernetes.io/safe-to-evict", "false"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.metadata.0.namespace", "ns-test"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.parallelism", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.template.0.metadata.0.annotations.controller.kubernetes.io/pod-deletion-cost", "10000"),
@@ -128,6 +127,47 @@ func TestAccKubernetesCronJobV1_extra(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.failed_jobs_history_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.starting_deadline_seconds", "120"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.spec.0.backoff_limit", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesCronJobV1_minimalWithTemplateNamespace(t *testing.T) {
+	var conf1, conf2 batchv1.CronJob
+
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_cron_job_v1.test"
+	imageName := busyboxImage
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesCronJobV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCronJobV1ConfigMinimal(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobV1Exists(resourceName, &conf1),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
+					resource.TestCheckNoResourceAttr(resourceName, "spec.0.job_template.0.spec.0.namespace"),
+				),
+			},
+			{
+				Config: testAccKubernetesCronJobV1ConfigMinimalWithJobTemplateNamespace(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobV1Exists(resourceName, &conf2),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
+					resource.TestCheckResourceAttrSet(resourceName, "spec.0.job_template.0.metadata.0.namespace"),
+					testAccCheckKubernetesCronJobV1ForceNew(&conf1, &conf2, true),
 				),
 			},
 		},
@@ -212,7 +252,6 @@ func testAccKubernetesCronJobV1Config_basic(name, imageName string) string {
         annotations = {
           "cluster-autoscaler.kubernetes.io/safe-to-evict" = "false"
         }
-        namespace = "ns-test"
       }
       spec {
         backoff_limit = 2
@@ -244,9 +283,7 @@ func testAccKubernetesCronJobV1Config_modified(name, imageName string) string {
   spec {
     schedule = "1 0 * * *"
     job_template {
-      metadata {
-        namespace = "ns-test"
-      }
+      metadata {}
       spec {
         parallelism = 2
         template {
@@ -336,7 +373,7 @@ func testAccKubernetesCronJobV1Config_extraModified(name, imageName string) stri
 func testAccCheckKubernetesCronJobV1ForceNew(old, new *batchv1.CronJob, wantNew bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if wantNew {
-			if old.ObjectMeta.UID != new.ObjectMeta.UID {
+			if old.ObjectMeta.UID == new.ObjectMeta.UID {
 				return fmt.Errorf("Expecting forced replacement")
 			}
 		} else {
@@ -346,4 +383,64 @@ func testAccCheckKubernetesCronJobV1ForceNew(old, new *batchv1.CronJob, wantNew 
 		}
 		return nil
 	}
+}
+
+func testAccKubernetesCronJobV1ConfigMinimal(name, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_cron_job_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    schedule = "*/1 * * * *"
+    job_template {
+      metadata {}
+      spec {
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "test"
+              image   = "%s"
+              command = ["sleep", "5"]
+            }
+			termination_grace_period_seconds = 1
+          }
+        }
+      }
+    }
+  }
+}
+`, name, imageName)
+}
+
+func testAccKubernetesCronJobV1ConfigMinimalWithJobTemplateNamespace(name, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_cron_job_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    schedule = "*/1 * * * *"
+    job_template {
+      metadata {
+        // The namespace field is just a stub and does not influence where the Pod will be created.
+        // The Pod will be created within the same Namespace as the Cron Job resource.
+        namespace = "fake" // Doesn't have to exist.
+      }
+      spec {
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "test"
+              image   = "%s"
+              command = ["sleep", "1"]
+            }
+			termination_grace_period_seconds = 1
+          }
+        }
+      }
+    }
+  }
+}
+`, name, imageName)
 }

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -403,7 +403,7 @@ func testAccKubernetesCronJobV1ConfigMinimal(name, imageName string) string {
               image   = "%s"
               command = ["sleep", "5"]
             }
-			termination_grace_period_seconds = 1
+            termination_grace_period_seconds = 1
           }
         }
       }
@@ -435,7 +435,7 @@ func testAccKubernetesCronJobV1ConfigMinimalWithJobTemplateNamespace(name, image
               image   = "%s"
               command = ["sleep", "1"]
             }
-			termination_grace_period_seconds = 1
+            termination_grace_period_seconds = 1
           }
         }
       }

--- a/kubernetes/resource_kubernetes_cron_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1_test.go
@@ -155,7 +155,7 @@ func TestAccKubernetesCronJobV1_minimalWithTemplateNamespace(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
-					resource.TestCheckNoResourceAttr(resourceName, "spec.0.job_template.0.spec.0.namespace"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.metadata.0.namespace", ""),
 				),
 			},
 			{

--- a/kubernetes/resource_kubernetes_cron_job_v1beta1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1beta1_test.go
@@ -126,6 +126,47 @@ func TestAccKubernetesCronJobV1Beta1_extra(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCronJobV1Beta1_minimalWithTemplateNamespace(t *testing.T) {
+	var conf1, conf2 batchv1beta1.CronJob
+
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_cron_job_v1.test"
+	imageName := busyboxImage
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesCronJobV1Beta1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCronJobV1Beta1ConfigMinimal(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobV1Beta1Exists(resourceName, &conf1),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
+					resource.TestCheckNoResourceAttr(resourceName, "spec.0.job_template.0.spec.0.namespace"),
+				),
+			},
+			{
+				Config: testAccKubernetesCronJobV1Beta1ConfigMinimalWithJobTemplateNamespace(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobV1Beta1Exists(resourceName, &conf2),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
+					resource.TestCheckResourceAttrSet(resourceName, "spec.0.job_template.0.metadata.0.namespace"),
+					testAccCheckKubernetesCronJobV1Beta1ForceNew(&conf1, &conf2, true),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesCronJobV1Beta1Destroy(s *terraform.State) error {
 	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
@@ -321,4 +362,66 @@ func testAccCheckKubernetesCronJobV1Beta1ForceNew(old, new *batchv1beta1.CronJob
 		}
 		return nil
 	}
+}
+
+func testAccKubernetesCronJobV1Beta1ConfigMinimal(name, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_cron_job" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    schedule = "*/1 * * * *"
+    job_template {
+      metadata {}
+      spec {
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "test"
+              image   = "%s"
+              command = ["sleep", "5"]
+            }
+			termination_grace_period_seconds = 1
+          }
+        }
+      }
+    }
+  }
+}
+`, name, imageName)
+}
+
+func testAccKubernetesCronJobV1Beta1ConfigMinimalWithJobTemplateNamespace(name, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_cron_job" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    schedule = "*/1 * * * *"
+
+    job_template {
+      metadata {
+        // The namespace field is just a stub and does not influence where the Pod will be created.
+        // The Pod will be created within the same Namespace as the Cron Job resource.
+        namespace = "fake" // Doesn't have to exist.
+      }
+      spec {
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "test"
+              image   = "%s"
+              command = ["sleep", "5"]
+            }
+			termination_grace_period_seconds = 1
+          }
+        }
+      }
+    }
+  }
+}
+`, name, imageName)
 }

--- a/kubernetes/resource_kubernetes_cron_job_v1beta1_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1beta1_test.go
@@ -130,11 +130,14 @@ func TestAccKubernetesCronJobV1Beta1_minimalWithTemplateNamespace(t *testing.T) 
 	var conf1, conf2 batchv1beta1.CronJob
 
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	resourceName := "kubernetes_cron_job_v1.test"
+	resourceName := "kubernetes_cron_job.test"
 	imageName := busyboxImage
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionGreaterThanOrEqual(t, "1.25.0")
+		},
 		IDRefreshName:     resourceName,
 		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
 		ProviderFactories: testAccProviderFactories,
@@ -148,7 +151,7 @@ func TestAccKubernetesCronJobV1Beta1_minimalWithTemplateNamespace(t *testing.T) 
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
-					resource.TestCheckNoResourceAttr(resourceName, "spec.0.job_template.0.spec.0.namespace"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.job_template.0.metadata.0.namespace", ""),
 				),
 			},
 			{
@@ -382,7 +385,6 @@ func testAccKubernetesCronJobV1Beta1ConfigMinimal(name, imageName string) string
               image   = "%s"
               command = ["sleep", "5"]
             }
-			termination_grace_period_seconds = 1
           }
         }
       }
@@ -416,7 +418,6 @@ func testAccKubernetesCronJobV1Beta1ConfigMinimalWithJobTemplateNamespace(name, 
               image   = "%s"
               command = ["sleep", "5"]
             }
-			termination_grace_period_seconds = 1
           }
         }
       }

--- a/kubernetes/resource_kubernetes_daemon_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1_test.go
@@ -414,7 +414,7 @@ func TestAccKubernetesDaemonSetV1_minimalWithTemplateNamespace(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
-					resource.TestCheckNoResourceAttr(resourceName, "spec.0.template.0.metadata.0.namespace"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.metadata.0.namespace", ""),
 				),
 			},
 			{

--- a/kubernetes/resource_kubernetes_daemon_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1_test.go
@@ -393,6 +393,46 @@ func TestAccKubernetesDaemonSetV1_with_resource_requirements(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesDaemonSetV1_minimalWithTemplateNamespace(t *testing.T) {
+	var conf1, conf2 appsv1.DaemonSet
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_daemon_set_v1.test"
+	imageName := busyboxImage
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesDaemonSetV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDaemonSetV1Config_minimal(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDaemonSetV1Exists(resourceName, &conf1),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
+					resource.TestCheckNoResourceAttr(resourceName, "spec.0.template.0.metadata.0.namespace"),
+				),
+			},
+			{
+				Config: testAccKubernetesDaemonSetV1ConfigMinimalWithTemplateNamespace(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDaemonSetV1Exists(resourceName, &conf2),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
+					resource.TestCheckResourceAttrSet(resourceName, "spec.0.template.0.metadata.0.namespace"),
+					testAccCheckKubernetesDaemonSetV1ForceNew(&conf1, &conf2, true),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesDaemonSetV1Destroy(s *terraform.State) error {
 	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
@@ -445,6 +485,21 @@ func testAccCheckKubernetesDaemonSetV1Exists(n string, obj *appsv1.DaemonSet) re
 		}
 
 		*obj = *out
+		return nil
+	}
+}
+
+func testAccCheckKubernetesDaemonSetV1ForceNew(old, new *appsv1.DaemonSet, wantNew bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if wantNew {
+			if old.ObjectMeta.UID == new.ObjectMeta.UID {
+				return fmt.Errorf("Expecting new resource for DaemonSet %s", old.ObjectMeta.UID)
+			}
+		} else {
+			if old.ObjectMeta.UID != new.ObjectMeta.UID {
+				return fmt.Errorf("Expecting DaemonSet UIDs to be the same: expected %s got %s", old.ObjectMeta.UID, new.ObjectMeta.UID)
+			}
+		}
 		return nil
 	}
 }
@@ -1090,4 +1145,38 @@ func testAccKubernetesDaemonSetV1ConfigWithResourceRequirementsRequestsOnly(depl
   }
 }
 `, deploymentName, imageName)
+}
+
+func testAccKubernetesDaemonSetV1ConfigMinimalWithTemplateNamespace(name, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_daemon_set_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    selector {
+      match_labels = {
+        foo = "bar"
+      }
+    }
+    template {
+      metadata {
+        // The namespace field is just a stub and does not influence where the Pod will be created.
+        // The Pod will be created within the same Namespace as the Daemon Set resource.
+        namespace = "fake" // Doesn't have to exist.
+        labels = {
+          foo = "bar"
+        }
+      }
+      spec {
+        container {
+          image   = "%s"
+          name    = "tf-acc-test"
+          command = ["sleep", "300"]
+        }
+        termination_grace_period_seconds = 1
+      }
+    }
+  }
+}
+`, name, imageName)
 }

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -347,7 +347,7 @@ func TestAccKubernetesStatefulSetV1_minimalWithTemplateNamespace(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.namespace"),
-					resource.TestCheckNoResourceAttr(resourceName, "spec.0.template.0.spec.0.namespace"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.metadata.0.namespace", ""),
 				),
 			},
 			{

--- a/kubernetes/schema_cron_job_spec_v1.go
+++ b/kubernetes/schema_cron_job_spec_v1.go
@@ -30,7 +30,7 @@ func cronJobSpecFieldsV1() map[string]*schema.Schema {
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"metadata": namespacedMetadataSchema("jobTemplateSpec", true),
+					"metadata": namespacedMetadataSchemaIsTemplate("jobTemplateSpec", true, true),
 					"spec": {
 						Type:        schema.TypeList,
 						Description: "Specification of the desired behavior of the job",

--- a/kubernetes/schema_cron_job_spec_v1beta1.go
+++ b/kubernetes/schema_cron_job_spec_v1beta1.go
@@ -30,7 +30,7 @@ func cronJobSpecFieldsV1Beta1() map[string]*schema.Schema {
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"metadata": metadataSchema("jobTemplateSpec", true),
+					"metadata": namespacedMetadataSchemaIsTemplate("jobTemplateSpec", true, true),
 					"spec": {
 						Type:        schema.TypeList,
 						Description: "Specification of the desired behavior of the job",

--- a/kubernetes/schema_pod_template.go
+++ b/kubernetes/schema_pod_template.go
@@ -11,7 +11,7 @@ import (
 
 func podTemplateFields(owner string) map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
-		"metadata": namespacedMetadataSchema(owner, true),
+		"metadata": namespacedMetadataSchemaIsTemplate(owner, true, true),
 		"spec": {
 			Type:        schema.TypeList,
 			Description: fmt.Sprintf("Spec of the pods owned by the %s", owner),

--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -105,7 +105,7 @@ These arguments are the same as the for the `metadata` block of a Pod with a few
 
 * When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
 
-* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
 
 ### `spec`
 

--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -99,6 +99,14 @@ The following arguments are supported:
 * `metadata` - (Required) Standard object's metadata of the jobs created from this template. For more info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
 * `spec` - (Required) Specification of the desired behavior of the job. For more info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
+### `metadata`
+
+These arguments are the same as the for the `metadata` block of a Pod with a few exceptions:
+
+* When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
+
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+
 ### `spec`
 
 #### Arguments

--- a/website/docs/r/cron_job_v1.html.markdown
+++ b/website/docs/r/cron_job_v1.html.markdown
@@ -101,6 +101,14 @@ The following arguments are supported:
 * `metadata` - (Required) Standard object's metadata of the jobs created from this template. For more info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
 * `spec` - (Required) Specification of the desired behavior of the job. For more info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
+### `metadata`
+
+These arguments are the same as the for the `metadata` block of a Pod with a few exceptions:
+
+* When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
+
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+
 ### `spec`
 
 #### Arguments

--- a/website/docs/r/cron_job_v1.html.markdown
+++ b/website/docs/r/cron_job_v1.html.markdown
@@ -107,7 +107,7 @@ These arguments are the same as the for the `metadata` block of a Pod with a few
 
 * When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
 
-* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
 
 ### `spec`
 

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -136,6 +136,16 @@ The following arguments are supported:
 * `metadata` - (Required) Standard object's metadata. For more info see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata.
 * `spec` - (Required) Specification of the desired behavior of the pod. For more info see https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 
+### template `metadata`
+
+These arguments are the same as the for the `metadata` block of a Pod with a few exceptions:
+
+* When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
+
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+
+Please see the [Pod resource](pod_v1.html#metadata) for reference.
+
 ### template `spec`
 
 #### Arguments

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -142,7 +142,7 @@ These arguments are the same as the for the `metadata` block of a Pod with a few
 
 * When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
 
-* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
 
 Please see the [Pod resource](pod_v1.html#metadata) for reference.
 

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -136,6 +136,16 @@ The following arguments are supported:
 * `metadata` - (Required) Standard object's metadata. For more info see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata.
 * `spec` - (Required) Specification of the desired behavior of the pod. For more info see https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 
+### template `metadata`
+
+These arguments are the same as the for the `metadata` block of a Pod with a few exceptions:
+
+* When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
+
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+
+Please see the [Pod resource](pod_v1.html#metadata) for reference.
+
 ### template `spec`
 
 #### Arguments

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -142,7 +142,7 @@ These arguments are the same as the for the `metadata` block of a Pod with a few
 
 * When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
 
-* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
 
 Please see the [Pod resource](pod_v1.html#metadata) for reference.
 

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -279,13 +279,25 @@ The following arguments are supported:
 
 ## Nested Blocks
 
+### `spec.template.metadata`
+
+#### Arguments
+
+These arguments are the same as the for the `metadata` block of a Pod with a few exceptions:
+
+* When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
+
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+
+Please see the [Pod resource](pod_v1.html#metadata) for reference.
+
 ### `spec.template.spec`
 
 #### Arguments
 
 These arguments are the same as the for the `spec` block of a Pod.
 
-Please see the [Pod resource](pod.html#spec) for reference.
+Please see the [Pod resource](pod_v1.html#spec) for reference.
 
 ## Nested Blocks
 

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -287,7 +287,7 @@ These arguments are the same as the for the `metadata` block of a Pod with a few
 
 * When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
 
-* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
 
 Please see the [Pod resource](pod_v1.html#metadata) for reference.
 

--- a/website/docs/r/stateful_set_v1.html.markdown
+++ b/website/docs/r/stateful_set_v1.html.markdown
@@ -279,13 +279,25 @@ The following arguments are supported:
 
 ## Nested Blocks
 
+### `spec.template.metadata`
+
+#### Arguments
+
+These arguments are the same as the for the `metadata` block of a Pod with a few exceptions:
+
+* When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
+
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+
+Please see the [Pod resource](pod_v1.html#metadata) for reference.
+
 ### `spec.template.spec`
 
 #### Arguments
 
 These arguments are the same as the for the `spec` block of a Pod.
 
-Please see the [Pod resource](pod.html#spec) for reference.
+Please see the [Pod resource](pod_v1.html#spec) for reference.
 
 ## Nested Blocks
 

--- a/website/docs/r/stateful_set_v1.html.markdown
+++ b/website/docs/r/stateful_set_v1.html.markdown
@@ -287,7 +287,7 @@ These arguments are the same as the for the `metadata` block of a Pod with a few
 
 * When `spec.template.metadata.namespace` does not have a default value, it is empty if not set.
 
-* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will necessitate the recreation of the resource.
+* The `spec.template.metadata.namespace` is a stub field that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.
 
 Please see the [Pod resource](pod_v1.html#metadata) for reference.
 


### PR DESCRIPTION
### Description

This PR fix an issue when the provider forces a resource recreation after upgrading to `2.25.0` and `2.25.1` due to changes in the schema of the following resources:

- `kubernetes_stateful_set_v1`
- `kubernetes_stateful_set`
- `kubernetes_daemon_set_v1`
- `kubernetes_daemonset`
- `kubernetes_cron_job_v1`
- `kubernetes_cron_job`

Resources `kubernetes_stateful_set_v1`, `kubernetes_stateful_set`, `kubernetes_daemon_set_v1`, and `kubernetes_daemonset` got a new attribute `spec.template.metadata.namespace`. It is a stub attribute that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.

Resources `kubernetes_cron_job_v1` and `kubernetes_cron_job` got a new attribute `spec.job_template.metadata.namespace`. It is a stub attribute that does not affect the namespace in which the Pod will be created. The Pod will be created in the same namespace as the main resource. However, modifying this field will force the resource recreation.

### Acceptance tests

- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

### References

- https://github.com/hashicorp/terraform-provider-kubernetes/issues/2385

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
