### PR TITLE
Allow HugePages in emptyDir.medium.

### DIFF
--- a/.changelog/2395.txt
+++ b/.changelog/2395.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`kubernetes/kubernetes_deployment_v1`: Add support for `HugePages` in `emptyDir.medium`
+```

--- a/kubernetes/resource_kubernetes_deployment_v1_test.go
+++ b/kubernetes/resource_kubernetes_deployment_v1_test.go
@@ -820,6 +820,33 @@ func TestAccKubernetesDeploymentV1_with_empty_dir_volume(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesDeploymentV1_with_empty_dir_huge_page(t *testing.T) {
+	var conf appsv1.Deployment
+
+	imageName := busyboxImage
+	deploymentName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_deployment_v1.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesDeploymentV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDeploymentV1ConfigWithEmptyDirHugePage(deploymentName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDeploymentV1Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/cache"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "cache-volume"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.volume.0.empty_dir.0.medium", "HugePages-1Gi"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesDeploymentV1Update_basic(t *testing.T) {
 	var conf1, conf2 appsv1.Deployment
 	resourceName := "kubernetes_deployment_v1.test"
@@ -2597,6 +2624,59 @@ func testAccKubernetesDeploymentV1ConfigWithEmptyDirVolumes(deploymentName, imag
 
           empty_dir {
             medium = "Memory"
+          }
+        }
+
+        termination_grace_period_seconds = 1
+      }
+    }
+  }
+}
+`, deploymentName, imageName)
+}
+
+func testAccKubernetesDeploymentV1ConfigWithEmptyDirHugePage(deploymentName, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_deployment_v1" "test" {
+  metadata {
+    name = "%s"
+
+    labels = {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    replicas = 0  # We request zero replicas, since the K8S backing this test may not have huge pages available.
+    selector {
+      match_labels = {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image   = "%s"
+          name    = "containername"
+          command = ["sleep", "300"]
+
+          volume_mount {
+            mount_path = "/cache"
+            name       = "cache-volume"
+          }
+        }
+
+        volume {
+          name = "cache-volume"
+
+          empty_dir {
+            medium = "HugePages-1Gi"
           }
         }
 

--- a/kubernetes/resource_kubernetes_deployment_v1_test.go
+++ b/kubernetes/resource_kubernetes_deployment_v1_test.go
@@ -2646,7 +2646,7 @@ func testAccKubernetesDeploymentV1ConfigWithEmptyDirHugePage(deploymentName, ima
   }
 
   spec {
-    replicas = 0  # We request zero replicas, since the K8S backing this test may not have huge pages available.
+    replicas = 0 # We request zero replicas, since the K8S backing this test may not have huge pages available.
     selector {
       match_labels = {
         Test = "TfAcceptanceTest"


### PR DESCRIPTION
### Description

Fixes #2302 by allowing the values `HugePages`, `HugePages-2Mi`, and `HugePages-1Gi` in `emptyDir.medium`.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
emptyDir.medium now allows for HugePages
```

### References

#2302 
https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
