### PR TITLE
add `force_update` field to `kubernetes_manifest` schema

### DIFF
--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -185,6 +185,17 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 						Description: "A Kubernetes manifest describing the desired state of the resource in HCL format.",
 					},
 					{
+						Name:            "force_update",
+						Type:            tftypes.Bool,
+						Required:        false,
+						Optional:        true,
+						Computed:        false,
+						Sensitive:       false,
+						Description:     "Force update will replace destroy + create with just a replacement.",
+						DescriptionKind: 0,
+						Deprecated:      false,
+					},
+					{
 						Name:        "object",
 						Type:        tftypes.DynamicPseudoType,
 						Optional:    true,


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

`kubernetes_manifest` would now give users the option to override the `destroy and recreate` action with just a `replacement` in cases where a value in CRD is marked as `x-kubernetes-preserve-unknown-fields`

It should be documented that this field should only be turned on in very specific use cases since `DynamicTypes` can cause some issues.

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2371
Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2375
Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1928

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
