### PR TITLE
Improve service account secret docs examples

### DIFF
--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -90,9 +90,12 @@ resource "kubernetes_secret" "example" {
     annotations = {
       "kubernetes.io/service-account.name" = "my-service-account"
     }
+
+    generate_name = "my-service-account-"
   }
 
-  type = "kubernetes.io/service-account-token"
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
 }
 ```
 

--- a/website/docs/r/secret_v1.html.markdown
+++ b/website/docs/r/secret_v1.html.markdown
@@ -90,9 +90,12 @@ resource "kubernetes_secret_v1" "example" {
     annotations = {
       "kubernetes.io/service-account.name" = "my-service-account"
     }
+
+    generate_name = "my-service-account-"
   }
 
-  type = "kubernetes.io/service-account-token"
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
 }
 ```
 

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -19,15 +19,19 @@ resource "kubernetes_service_account" "example" {
   metadata {
     name = "terraform-example"
   }
-  secret {
-    name = "${kubernetes_secret.example.metadata.0.name}"
-  }
 }
 
 resource "kubernetes_secret" "example" {
   metadata {
-    name = "terraform-example"
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account.example.metadata.0.name
+    }
+
+    generate_name = "terraform-example-"
   }
+
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
 }
 ```
 

--- a/website/docs/r/service_account_v1.html.markdown
+++ b/website/docs/r/service_account_v1.html.markdown
@@ -19,15 +19,19 @@ resource "kubernetes_service_account_v1" "example" {
   metadata {
     name = "terraform-example"
   }
-  secret {
-    name = "${kubernetes_secret_v1.example.metadata.0.name}"
-  }
 }
 
 resource "kubernetes_secret_v1" "example" {
   metadata {
-    name = "terraform-example"
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.example.metadata.0.name
+    }
+
+    generate_name = "terraform-example-"
   }
+
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
 }
 ```
 


### PR DESCRIPTION
### Description

The examples currently cause problems for users as per issue https://github.com/hashicorp/terraform-provider-kubernetes/issues/1943

This changes the examples to suggest using:
- generate_name for the secret
- wait_for_service_account_token for the secret
- **not** using the `secret` attribute of the `service_account` terraform resource 
  - which seems to do nothing as it doesn't map to the kubernetes manifest schema
  - creates a dependency in the wrong direction

### Acceptance tests

Only docs changes.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Improve service account secrets docs examples.
```

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1943

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
