### PR TITLE
`kubernetes_manifest` schema refactor

### DIFF
--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -24,11 +24,11 @@ jobs:
     strategy:
       matrix:
         terraform_version:
-          - "1.0.11"
-          - "1.1.9"
           - "1.2.9"
           - "1.3.9"
           - "1.4.0"
+          - "1.6.0"
+          - "1.7.0"
     env:
       TF_X_KUBERNETES_MANIFEST_RESOURCE: 1
       TERM: linux

--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -333,7 +333,7 @@ func GetDataSourceType(name string) (tftypes.Type, error) {
 
 // GetProviderResourceSchema contains the definitions of all supported resources
 func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
-	return resource["providerSchema"].(map[string]*tfprotov5.Schema)
+	return resources["providerSchema"].(map[string]*tfprotov5.Schema)
 }
 
 // GetProviderDataSourceSchema contains the definitions of all supported data sources

--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -10,11 +10,62 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-var resources = map[string]interface{}{
-	"getMetadata": []tfprotov5.ResourceMetadata{{
-		TypeName: "kubernetes_manifest",
-	}},
-	"providerSchema": map[string]*tfprotov5.Schema{
+// GetObjectTypeFromSchema returns a tftypes.Type that can wholy represent the schema input
+func GetObjectTypeFromSchema(schema *tfprotov5.Schema) tftypes.Type {
+	bm := map[string]tftypes.Type{}
+
+	for _, att := range schema.Block.Attributes {
+		bm[att.Name] = att.Type
+	}
+
+	for _, b := range schema.Block.BlockTypes {
+		a := map[string]tftypes.Type{}
+		for _, att := range b.Block.Attributes {
+			a[att.Name] = att.Type
+		}
+		bm[b.TypeName] = tftypes.List{
+			ElementType: tftypes.Object{AttributeTypes: a},
+		}
+
+		// FIXME we can make this function recursive to handle
+		// n levels of nested blocks
+		for _, bb := range b.Block.BlockTypes {
+			aa := map[string]tftypes.Type{}
+			for _, att := range bb.Block.Attributes {
+				aa[att.Name] = att.Type
+			}
+			a[bb.TypeName] = tftypes.List{
+				ElementType: tftypes.Object{AttributeTypes: aa},
+			}
+		}
+	}
+
+	return tftypes.Object{AttributeTypes: bm}
+}
+
+// GetResourceType returns the tftypes.Type of a resource of type 'name'
+func GetResourceType(name string) (tftypes.Type, error) {
+	sch := GetProviderResourceSchema()
+	rsch, ok := sch[name]
+	if !ok {
+		return tftypes.DynamicPseudoType, fmt.Errorf("unknown resource %s - cannot find schema", name)
+	}
+	return GetObjectTypeFromSchema(rsch), nil
+}
+
+// GetDataSourceType returns the tftypes.Type of a datasource of type 'name'
+func GetDataSourceType(name string) (tftypes.Type, error) {
+	sch := GetProviderDataSourceSchema()
+	rsch, ok := sch[name]
+	if !ok {
+		return tftypes.DynamicPseudoType, fmt.Errorf("unknown data source %q: cannot find schema", name)
+	}
+	return GetObjectTypeFromSchema(rsch), nil
+}
+
+// GetProviderResourceSchema contains the definitions of all supported resources
+func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
+	return map[string]*tfprotov5.Schema{
 		"kubernetes_manifest": {
 			Version: 1,
 			Block: &tfprotov5.SchemaBlock{
@@ -162,18 +213,12 @@ var resources = map[string]interface{}{
 				},
 			},
 		},
-	},
+	}
 }
-var dataSources = map[string]interface{}{
-	"getMetadata": []tfprotov5.DataSourceMetadata{
-		{
-			TypeName: "kubernetes_resource",
-		},
-		{
-			TypeName: "kubernetes_resources",
-		},
-	},
-	"providerSchema": map[string]*tfprotov5.Schema{
+
+// GetProviderDataSourceSchema contains the definitions of all supported data sources
+func GetProviderDataSourceSchema() map[string]*tfprotov5.Schema {
+	return map[string]*tfprotov5.Schema{
 		"kubernetes_resource": {
 			Version: 1,
 			Block: &tfprotov5.SchemaBlock{
@@ -275,68 +320,5 @@ var dataSources = map[string]interface{}{
 				},
 			},
 		},
-	},
-}
-
-// GetObjectTypeFromSchema returns a tftypes.Type that can wholy represent the schema input
-func GetObjectTypeFromSchema(schema *tfprotov5.Schema) tftypes.Type {
-	bm := map[string]tftypes.Type{}
-
-	for _, att := range schema.Block.Attributes {
-		bm[att.Name] = att.Type
 	}
-
-	for _, b := range schema.Block.BlockTypes {
-		a := map[string]tftypes.Type{}
-		for _, att := range b.Block.Attributes {
-			a[att.Name] = att.Type
-		}
-		bm[b.TypeName] = tftypes.List{
-			ElementType: tftypes.Object{AttributeTypes: a},
-		}
-
-		// FIXME we can make this function recursive to handle
-		// n levels of nested blocks
-		for _, bb := range b.Block.BlockTypes {
-			aa := map[string]tftypes.Type{}
-			for _, att := range bb.Block.Attributes {
-				aa[att.Name] = att.Type
-			}
-			a[bb.TypeName] = tftypes.List{
-				ElementType: tftypes.Object{AttributeTypes: aa},
-			}
-		}
-	}
-
-	return tftypes.Object{AttributeTypes: bm}
-}
-
-// GetResourceType returns the tftypes.Type of a resource of type 'name'
-func GetResourceType(name string) (tftypes.Type, error) {
-	sch := GetProviderResourceSchema()
-	rsch, ok := sch[name]
-	if !ok {
-		return tftypes.DynamicPseudoType, fmt.Errorf("unknown resource %s - cannot find schema", name)
-	}
-	return GetObjectTypeFromSchema(rsch), nil
-}
-
-// GetDataSourceType returns the tftypes.Type of a datasource of type 'name'
-func GetDataSourceType(name string) (tftypes.Type, error) {
-	sch := GetProviderDataSourceSchema()
-	rsch, ok := sch[name]
-	if !ok {
-		return tftypes.DynamicPseudoType, fmt.Errorf("unknown data source %q: cannot find schema", name)
-	}
-	return GetObjectTypeFromSchema(rsch), nil
-}
-
-// GetProviderResourceSchema contains the definitions of all supported resources
-func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
-	return resources["providerSchema"].(map[string]*tfprotov5.Schema)
-}
-
-// GetProviderDataSourceSchema contains the definitions of all supported data sources
-func GetProviderDataSourceSchema() map[string]*tfprotov5.Schema {
-	return dataSources["providerSchema"].(map[string]*tfprotov5.Schema)
 }

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -55,9 +55,21 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpr
 func (s *RawProviderServer) GetMetadata(ctx context.Context, req *tfprotov5.GetMetadataRequest) (*tfprotov5.GetMetadataResponse, error) {
 	s.logger.Trace("[GetMetadata][Request]\n%s\n", dump(*req))
 
+	sch := GetProviderResourceSchema()
+	rs := make([]tfprotov5.ResourceMetadata, 0, len(sch))
+	for k := range sch {
+		rs = append(rs, tfprotov5.ResourceMetadata{TypeName: k})
+	}
+
+	sch = GetProviderDataSourceSchema()
+	ds := make([]tfprotov5.DataSourceMetadata, 0, len(sch))
+	for k := range sch {
+		ds = append(ds, tfprotov5.DataSourceMetadata{TypeName: k})
+	}
+
 	resp := &tfprotov5.GetMetadataResponse{
-		Resources:   resources["getMetadata"].([]tfprotov5.ResourceMetadata),
-		DataSources: dataSources["getMetadata"].([]tfprotov5.DataSourceMetadata),
+		Resources:   rs,
+		DataSources: ds,
 	}
 	return resp, nil
 }

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -56,17 +56,8 @@ func (s *RawProviderServer) GetMetadata(ctx context.Context, req *tfprotov5.GetM
 	s.logger.Trace("[GetMetadata][Request]\n%s\n", dump(*req))
 
 	resp := &tfprotov5.GetMetadataResponse{
-		Resources: []tfprotov5.ResourceMetadata{{
-			TypeName: "kubernetes_manifest",
-		}},
-		DataSources: []tfprotov5.DataSourceMetadata{
-			{
-				TypeName: "kubernetes_resource",
-			},
-			{
-				TypeName: "kubernetes_resources",
-			},
-		},
+		Resources:   resources["getMetadata"].([]tfprotov5.ResourceMetadata),
+		DataSources: dataSources["getMetadata"].([]tfprotov5.DataSourceMetadata),
 	}
 	return resp, nil
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

With the recent hotfix, the resources and data sources changed from being declared in one area of the code to existing in two parts within manifest. To prevent future issues, this PR refactors code within manifest so that `schema` and `getMetadata` exists in a way where there is only one source of truth.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
