### PR TITLE
Add kubernetes_base64 provider parameter

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -134,7 +134,7 @@ func Provider() *schema.Provider {
 			"kubeconfig_base64": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Kubeconfig content in base64 format.",
+				Description: "Kubeconfig content in base64 format",
 				DefaultFunc: schema.EnvDefaultFunc("KUBECONFIG_BASE64", ""),
 			},
 			"exec": {

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -5,6 +5,7 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -93,6 +94,28 @@ func TestProvider_configure_paths(t *testing.T) {
 		"test-fixtures/kube-config-secondary.yaml",
 	}, string(os.PathListSeparator)))
 	os.Setenv("KUBE_CTX", "oidc")
+
+	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
+	p := Provider()
+	diags := p.Configure(ctx, rc)
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+}
+
+func TestProvider_configure_kubeconfig_base64(t *testing.T) {
+	ctx := context.TODO()
+	resetEnv := unsetEnv(t)
+	defer resetEnv()
+
+	k, err := os.ReadFile("test-fixtures/kube-config-sa-token.yaml") // just pass the file name
+	if err != nil {
+		t.Fatal("Can't read kube-config")
+	}
+
+	k64 := base64.StdEncoding.EncodeToString(k)
+
+	os.Setenv("KUBECONFIG_BASE64", string(k64))
 
 	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
 	p := Provider()

--- a/kubernetes/test-fixtures/kube-config-sa-token.yaml
+++ b/kubernetes/test-fixtures/kube-config-sa-token.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: ZHVtbXk=
+    server: https://127.0.0.1
+  name: dummy
+
+current-context: dummy
+
+contexts:
+- context:
+    cluster: dummy
+    user: dummy
+  name: dummy
+
+users:
+- name: dummy
+  user:
+    token: ZHVtbXk=

--- a/manifest/provider/provider_config.go
+++ b/manifest/provider/provider_config.go
@@ -179,6 +179,17 @@ func GetProviderConfigSchema() *tfprotov5.Schema {
 				Deprecated:      false,
 			},
 			{
+				Name:            "kubeconfig_base64",
+				Type:            tftypes.String,
+				Description:     "Kubeconfig content in base64 format",
+				Required:        false,
+				Optional:        true,
+				Computed:        false,
+				Sensitive:       false,
+				DescriptionKind: 0,
+				Deprecated:      false,
+			},
+			{
 				Name:            "ignore_annotations",
 				Type:            tftypes.List{ElementType: tftypes.String},
 				Description:     "List of Kubernetes metadata annotations to ignore across all resources handled by this provider for situations where external systems are managing certain resource annotations. Each item is a regular expression.",


### PR DESCRIPTION
### Description

In some cases kubeconfig is passed to CICD via environment variables, but I would like to use this config when running the provider without creating a kubeconfig file.

For this purpose, the `kubeconfig_base64` paramerter is added to the provider configuration, which contains kubeconfig content in base64 format.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestProvider_configure_kubeconfig_base64'                                                                                                                                                                                                               
==> Checking that code complies with gofmt requirements...
go vet ./...
TF_ACC=1 go test "/home/user/go/src/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -vet=off -run=TestProvider_configure_kubeconfig_base64 -parallel 8 -timeout 3h
=== RUN   TestProvider_configure_kubeconfig_base64
--- PASS: TestProvider_configure_kubeconfig_base64 (0.02s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   0.049s

```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):


```release-note
Added `kubeconfig_base64` provider parameter.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
