### PR TITLE
feat: added "strategy.rolling_update.max_surge" attr to daemonset

### DIFF
--- a/kubernetes/resource_kubernetes_daemon_set_v1.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1.go
@@ -103,6 +103,13 @@ func resourceKubernetesDaemonSetSchemaV1() map[string]*schema.Schema {
 									MaxItems:    1,
 									Elem: &schema.Resource{
 										Schema: map[string]*schema.Schema{
+											"max_surge": {
+												Type:         schema.TypeString,
+												Description:  "The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted.",
+												Optional:     true,
+												Default:      "0",
+												ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
+											},
 											"max_unavailable": {
 												Type:         schema.TypeString,
 												Description:  "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",

--- a/kubernetes/resource_kubernetes_daemon_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1_test.go
@@ -74,6 +74,7 @@ func TestAccKubernetesDaemonSetV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.type", "RollingUpdate"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.0.max_unavailable", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.strategy.0.rolling_update.0.max_surge", "0"),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
 				),
 			},

--- a/kubernetes/structures_daemonset.go
+++ b/kubernetes/structures_daemonset.go
@@ -52,6 +52,9 @@ func flattenDaemonSetStrategyRollingUpdate(in *appsv1.RollingUpdateDaemonSet) []
 	if in.MaxUnavailable != nil {
 		att["max_unavailable"] = in.MaxUnavailable.String()
 	}
+	if in.MaxSurge != nil {
+		att["max_surge"] = in.MaxSurge.String()
+	}
 	return []interface{}{att}
 }
 
@@ -109,6 +112,10 @@ func expandRollingUpdateDaemonSet(p []interface{}) *appsv1.RollingUpdateDaemonSe
 	}
 	in := p[0].(map[string]interface{})
 
+	if v, ok := in["max_surge"].(string); ok {
+		val := intstr.Parse(v)
+		obj.MaxSurge = &val
+	}
 	if v, ok := in["max_unavailable"].(string); ok {
 		val := intstr.Parse(v)
 		obj.MaxUnavailable = &val

--- a/website/docs/r/daemon_set_v1.html.markdown
+++ b/website/docs/r/daemon_set_v1.html.markdown
@@ -127,6 +127,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `max_surge` - The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted.
 * `max_unavailable` - The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
 
 ### `template`

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -127,6 +127,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `max_surge` - The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted.
 * `max_unavailable` - The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
 
 ### `template`


### PR DESCRIPTION
### Description

Enhancement: #2106 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccKubernetesDaemonSetV1_basic'
==> Checking that code complies with gofmt requirements...
go vet ./...
TF_ACC=1 go test "/Users/manjinder_singh/Builds/forks/terraform-provider-kubernetes/kubernetes" -v -vet=off -run=TestAccKubernetesDaemonSetV1_basic -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesDaemonSetV1_basic
=== PAUSE TestAccKubernetesDaemonSetV1_basic
=== CONT  TestAccKubernetesDaemonSetV1_basic
--- PASS: TestAccKubernetesDaemonSetV1_basic (4.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	5.791s

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Updated daemonset resource to support max_surge attribute of rolling_update strategy
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
