### PR TITLE
`ceph_fs` deprecation message on clusters newer than 1.28

### DIFF
--- a/kubernetes/schema_volume_source.go
+++ b/kubernetes/schema_volume_source.go
@@ -202,6 +202,7 @@ func commonVolumeSources() map[string]*schema.Schema {
 			Description: "Represents a Ceph FS mount on the host that shares a pod's lifetime",
 			Optional:    true,
 			MaxItems:    1,
+			Deprecated:  "ceph_fs is deprecated on clusters newer than 1.28",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"monitors": {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #2406

Usually we would mark any fields as deprecated with `Deprecated` along with a summary, however this isn't the best UX since any use of the deprecated field will cause a message to pop up, ideally this would only pop up on clusters newer than 1.28

Currently looking for how to make this possible

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
