### PR TITLE
Add warning about mixing provider credentials with exec blocks

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -116,7 +116,9 @@ Find more comprehensive `in-cluster` config example [here](https://github.com/ha
 
 ## Exec plugins
 
-Some cloud providers have short-lived authentication tokens that can expire relatively quickly. To ensure the Kubernetes provider is receiving valid credentials, an exec-based plugin can be used to fetch a new token before initializing the provider. For example, on EKS, the command `eks get-token` can be used:
+Some cloud providers have short-lived authentication tokens that can expire relatively quickly. To ensure the Kubernetes provider is receiving valid credentials, an exec-based plugin can be used to fetch a new token before each Terraform operation. For example, on EKS, the command `eks get-token` can be used:
+
+~> IMPORTANT: DO NOT mix `exec` blocks with other credential attributes such as `token` or `client_certificate` in the provider configuration. This leads to undefined behaviour and there is no guarantee about which credential will actually be used.
 
 ```hcl
 provider "kubernetes" {


### PR DESCRIPTION
### Description

This change adds a warning to the provider docs on exec blocks about mixing with other credential sources.

Exec plugins work by retrieving a token and supplying it to the provider dynamically on every provider run. Setting the `token` or other credentials attributes along with exec blocks leads to undefined behaviour as there is more than one source for the token and no guarantee to which one will be used.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
