### PR TITLE
fix crash when unexpeceted annotation appears

### DIFF
--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -193,7 +193,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 				return v, nil
 			}
 			if v.IsKnown() {
-				return v, nil
+				return tftypes.NewValue(v.Type(), tftypes.UnknownValue), nil
 			}
 			ppMan, restPath, err := tftypes.WalkAttributePath(plannedStateVal["manifest"], ap)
 			if err != nil {

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -422,6 +422,9 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 		}
 		updatedObj, err := tftypes.Transform(completePropMan, func(ap *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
 			_, isComputed := computedFields[ap.String()]
+			if isComputed {
+				return tftypes.NewValue(v.Type(), tftypes.UnknownValue), nil
+			}
 			if v.IsKnown() { // this is a value from current configuration - include it in the plan
 				hasChanged := false
 				wasCfg, restPath, err := tftypes.WalkAttributePath(priorMan, ap)
@@ -430,20 +433,12 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				}
 				nowCfg, restPath, err := tftypes.WalkAttributePath(ppMan, ap)
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
+
 				if hasChanged {
 					h, ok := hints[morph.ValueToTypePath(ap).String()]
 					if ok && h == manifest.PreserveUnknownFieldsLabel {
 						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
-					}
-				}
-				if isComputed {
-					if hasChanged {
-						return tftypes.NewValue(v.Type(), tftypes.UnknownValue), nil
-					}
-					nowVal, restPath, err := tftypes.WalkAttributePath(proposedVal["object"], ap)
-					if err == nil && len(restPath.Steps()) == 0 {
-						return nowVal.(tftypes.Value), nil
 					}
 				}
 				return v, nil


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

The idea is to treat all values in `computed_field` as an `UnknownValue`, before the values would only be treated as an `UnknownValue` when a change was present. This will insure that values in annotations/labels are covered especially in cases where the user did not set the label/annotation themselves.

Fixes #1591

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
