### PR TITLE
manifest: remove forced replacement with `x-kubernetes-preserve-unknown-fields`

### DIFF
--- a/.changelog/2436.txt
+++ b/.changelog/2436.txt
@@ -1,0 +1,3 @@
+```release-note
+`kubernetes_manifest`: add TypeCheck for `x-kubernetes-preserve-unknown-fields` to prevent unnecessary replacement
+```

--- a/.changelog/2436.txt
+++ b/.changelog/2436.txt
@@ -1,3 +1,0 @@
-```release-note
-`kubernetes_manifest`: add TypeCheck for `x-kubernetes-preserve-unknown-fields` to prevent unnecessary replacement
-```

--- a/.changelog/2437.txt
+++ b/.changelog/2437.txt
@@ -1,0 +1,3 @@
+```release-note
+`kubernetes_manifest`: add TypeCheck for `x-kubernetes-preserve-unknown-fields` to prevent unnecessary replacement
+```

--- a/manifest/openapi/schema.go
+++ b/manifest/openapi/schema.go
@@ -114,7 +114,7 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 				return tftypes.String, nil
 			}
 		}
-		return tftypes.DynamicPseudoType, nil
+		return tftypes.DynamicPseudoType, nil // this is where DynamicType is set for when an attribute is tagged as 'x-kubernetes-preserve-unknown-fields'
 
 	case "array":
 		switch {

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -458,7 +458,8 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
 				if hasChanged {
 					h, ok := hints[morph.ValueToTypePath(ap).String()]
-					if ok && h == manifest.PreserveUnknownFieldsLabel {
+					typeChanged := !(wasCfg.(tftypes.Value).Type().Equal(nowCfg.(tftypes.Value).Type()))
+					if ok && h == manifest.PreserveUnknownFieldsLabel && typeChanged {
 						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
 					}

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -458,8 +458,8 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
 				if hasChanged {
 					h, ok := hints[morph.ValueToTypePath(ap).String()]
-					typeChanged := !(wasCfg.(tftypes.Value).Type().Equal(nowCfg.(tftypes.Value).Type()))
-					if ok && h == manifest.PreserveUnknownFieldsLabel && typeChanged {
+					_, diff := wasCfg.(tftypes.Value).Diff(nowCfg.(tftypes.Value)) // passing values of two different types will result in an error.
+					if ok && h == manifest.PreserveUnknownFieldsLabel && diff != nil {
 						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
 						resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -462,6 +462,11 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 					if ok && h == manifest.PreserveUnknownFieldsLabel && typeChanged {
 						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
+						resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+							Severity: tfprotov5.DiagnosticSeverityWarning,
+							Summary:  "This value's type has changed",
+							Detail:   "Changes to the type will cause a forced replacement.",
+						})
 					}
 				}
 				if isComputed {

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -458,8 +458,8 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
 				if hasChanged {
 					h, ok := hints[morph.ValueToTypePath(ap).String()]
-					_, diff := wasCfg.(tftypes.Value).Diff(nowCfg.(tftypes.Value)) // passing values of two different types will result in an error.
-					if ok && h == manifest.PreserveUnknownFieldsLabel && diff != nil {
+					typeChanged := !(wasCfg.(tftypes.Value).Type().Equal(nowCfg.(tftypes.Value).Type()))
+					if ok && h == manifest.PreserveUnknownFieldsLabel && typeChanged {
 						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
 						resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -464,7 +464,7 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
 						resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 							Severity: tfprotov5.DiagnosticSeverityWarning,
-							Summary:  "This value's type has changed",
+							Summary:  fmt.Sprintf("The attribute path %v value's type has changed", morph.ValueToTypePath(ap).String()),
 							Detail:   "Changes to the type will cause a forced replacement.",
 						})
 					}

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -458,14 +458,11 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 				hasChanged = err == nil && len(restPath.Steps()) == 0 && wasCfg.(tftypes.Value).IsKnown() && !wasCfg.(tftypes.Value).Equal(nowCfg.(tftypes.Value))
 				if hasChanged {
 					h, ok := hints[morph.ValueToTypePath(ap).String()]
-					typeChanged := !(wasCfg.(tftypes.Value).Type().Equal(nowCfg.(tftypes.Value).Type()))
-					if ok && h == manifest.PreserveUnknownFieldsLabel && typeChanged {
-						apm := append(tftypes.NewAttributePath().WithAttributeName("manifest").Steps(), ap.Steps()...)
-						resp.RequiresReplace = append(resp.RequiresReplace, tftypes.NewAttributePathWithSteps(apm))
+					if ok && h == manifest.PreserveUnknownFieldsLabel {
 						resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 							Severity: tfprotov5.DiagnosticSeverityWarning,
-							Summary:  fmt.Sprintf("The attribute path %v value's type has changed", morph.ValueToTypePath(ap).String()),
-							Detail:   "Changes to the type will cause a forced replacement.",
+							Summary:  fmt.Sprintf("The attribute path %v value's type is an x-kubernetes-preserve-unknown-field", morph.ValueToTypePath(ap).String()),
+							Detail:   "Changes to the type may cause some unexpected behavior.",
 						})
 					}
 				}

--- a/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
+++ b/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
@@ -134,7 +134,6 @@ func TestKubernetesManifest_CustomResource_x_preserve_unknown_fields(t *testing.
 		},
 	})
 
-
 	tfconfig = loadTerraformConfig(t, "x-kubernetes-preserve-unknown-fields/test-cr-4.tf", tfvars)
 	step1.SetConfig(ctx, string(tfconfig))
 	step1.Apply(ctx)

--- a/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
+++ b/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
@@ -133,4 +133,21 @@ func TestKubernetesManifest_CustomResource_x_preserve_unknown_fields(t *testing.
 			"baz": interface{}("42"),
 		},
 	})
+
+
+	tfconfig = loadTerraformConfig(t, "x-kubernetes-preserve-unknown-fields/test-cr-4.tf", tfvars)
+	step1.SetConfig(ctx, string(tfconfig))
+	step1.Apply(ctx)
+
+	s4, err := step1.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform state: %q", err)
+	}
+	tfstate4 := tfstatehelper.NewHelper(s4)
+	tfstate4.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.spec.count":         json.Number("100"),
+		"kubernetes_manifest.test.object.spec.resources":     false,
+	})
 }

--- a/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
+++ b/manifest/test/acceptance/customresource_x_preserve_unknown_fields_test.go
@@ -114,4 +114,23 @@ func TestKubernetesManifest_CustomResource_x_preserve_unknown_fields(t *testing.
 			"baz": interface{}("42"),
 		},
 	})
+
+	tfconfig = loadTerraformConfig(t, "x-kubernetes-preserve-unknown-fields/test-cr-3.tf", tfvars)
+	step1.SetConfig(ctx, string(tfconfig))
+	step1.Apply(ctx)
+
+	s3, err := step1.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform state: %q", err)
+	}
+	tfstate3 := tfstatehelper.NewHelper(s3)
+	tfstate3.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":      name,
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.spec.count":         json.Number("100"),
+		"kubernetes_manifest.test.object.spec.resources": map[string]interface{}{
+			"foo": interface{}([]interface{}{"bar"}),
+			"baz": interface{}("42"),
+		},
+	})
 }

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/crd/test.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/crd/test.tf
@@ -4,14 +4,14 @@
 resource "kubernetes_manifest" "customresourcedefinition_cephrbdmirrors_ceph_rook_io" {
   manifest = {
     apiVersion = "apiextensions.k8s.io/v1"
-    kind = "CustomResourceDefinition"
+    kind       = "CustomResourceDefinition"
     metadata = {
       name = "${var.plural}.${var.group}"
     }
     spec = {
       group = var.group
       names = {
-        kind = var.kind
+        kind   = var.kind
         plural = var.plural
       }
       scope = "Namespaced"
@@ -24,14 +24,14 @@ resource "kubernetes_manifest" "customresourcedefinition_cephrbdmirrors_ceph_roo
                 spec = {
                   properties = {
                     annotations = {
-                      nullable = true
-                      type = "object"
+                      nullable                               = true
+                      type                                   = "object"
                       "x-kubernetes-preserve-unknown-fields" = true
                     }
                     count = {
                       maximum = 100
                       minimum = 1
-                      type = "integer"
+                      type    = "integer"
                     }
                     peers = {
                       properties = {
@@ -45,30 +45,29 @@ resource "kubernetes_manifest" "customresourcedefinition_cephrbdmirrors_ceph_roo
                       type = "object"
                     }
                     placement = {
-                      nullable = true
-                      type = "object"
+                      nullable                               = true
+                      type                                   = "object"
                       "x-kubernetes-preserve-unknown-fields" = true
                     }
                     priorityClassName = {
                       type = "string"
                     }
                     resources = {
-                      nullable = true
-                      type = "object"
+                      nullable                               = true
                       "x-kubernetes-preserve-unknown-fields" = true
                     }
                   }
                   type = "object"
                 }
                 status = {
-                  type = "object"
+                  type                                   = "object"
                   "x-kubernetes-preserve-unknown-fields" = true
                 }
               }
               type = "object"
             }
           }
-          served = true
+          served  = true
           storage = true
           subresources = {
             status = {}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-1.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-1.tf
@@ -4,16 +4,16 @@
 resource "kubernetes_manifest" "test" {
   manifest = {
     apiVersion = var.group_version
-    kind = var.kind
+    kind       = var.kind
     metadata = {
-      name = var.name
+      name      = var.name
       namespace = var.namespace
     }
     spec = {
-        count = 100
-        resources = {
-            foo = "bar"
-        }
+      count = 100
+      resources = {
+        foo = "bar"
+      }
     }
   }
 }

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-3.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-3.tf
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = var.group_version
+    kind = var.kind
+    metadata = {
+      name = var.name
+      namespace = var.namespace
+    }
+    spec = {
+        count = 100
+        resources = {
+            foo = ["bar"]
+            baz = "42"
+        }
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-3.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-3.tf
@@ -4,17 +4,17 @@
 resource "kubernetes_manifest" "test" {
   manifest = {
     apiVersion = var.group_version
-    kind = var.kind
+    kind       = var.kind
     metadata = {
-      name = var.name
+      name      = var.name
       namespace = var.namespace
     }
     spec = {
-        count = 100
-        resources = {
-            foo = ["bar"]
-            baz = "42"
-        }
+      count = 100
+      resources = {
+        foo = ["bar"]
+        baz = "42"
+      }
     }
   }
 }

--- a/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-4.tf
+++ b/manifest/test/acceptance/testdata/x-kubernetes-preserve-unknown-fields/test-cr-4.tf
@@ -10,11 +10,8 @@ resource "kubernetes_manifest" "test" {
       namespace = var.namespace
     }
     spec = {
-      count = 100
-      resources = {
-        foo = "bar"
-        baz = "42"
-      }
+      count     = 100
+      resources = false
     }
   }
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This check will prevent `x-kubernetes-preserve-unknown-fields` to cause a replacement whenever the value is changed. The idea is that it should ONLY cause a replacement if the type itself is changed and not the value. 

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2371
Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2375
Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/1928
Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2410

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
┌─(~/Dev/terraform-provider-kubernetes/manifest)───────────────────────────────────────────────(mau@mau-JKDT676NCP:s077)─┐
└─(14:48:09 on fix-unknownFieldsLogic-manifest ✹ ✭)──> make testacc TESTARGS="-run TestKubernetesManifest_CustomResource_x_preserve_unknown_fields"
go test -count=1 -tags acceptance "./test/acceptance" -v -run TestKubernetesManifest_CustomResource_x_preserve_unknown_fields -timeout 120m
2024/03/12 14:48:28 Testing against Kubernetes API version: v1.27.3
=== RUN   TestKubernetesManifest_CustomResource_x_preserve_unknown_fields
--- PASS: TestKubernetesManifest_CustomResource_x_preserve_unknown_fields (14.23s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     14.832s```
```
### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`kubernetes_manifest`: add TypeCheck for `x-kubernetes-preserve-unknown-fields` to prevent unnecessary replacement
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
