### PR TITLE
Add restart_policy option for init containers

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -582,7 +582,7 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			MaxItems:    1,
 			ForceNew:    !isUpdatable,
 			Computed:    true,
-			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",			
+			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
 			Elem: &schema.Resource{
 				Schema: resourcesFieldV1(isUpdatable),
 			},

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -582,10 +582,23 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			MaxItems:    1,
 			ForceNew:    !isUpdatable,
 			Computed:    true,
-			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/",
 			Elem: &schema.Resource{
 				Schema: resourcesFieldV1(isUpdatable),
 			},
+		},
+		"restart_policy": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    isComputed,
+			ForceNew:    !isUpdatable,
+			Default:     conditionalDefault(!isComputed, string(corev1.RestartPolicyAlways)),
+			Description: "Restart policy for init container. One of Always, OnFailure, Never. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.",
+			ValidateFunc: validation.StringInSlice([]string{
+				string(corev1.RestartPolicyAlways),
+				string(corev1.RestartPolicyOnFailure),
+				string(corev1.RestartPolicyNever),
+			}, false),
 		},
 		"security_context": {
 			Type:        schema.TypeList,

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -582,7 +582,8 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			MaxItems:    1,
 			ForceNew:    !isUpdatable,
 			Computed:    true,
-			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",			Elem: &schema.Resource{
+			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",			
+			Elem: &schema.Resource{
 				Schema: resourcesFieldV1(isUpdatable),
 			},
 		},

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -582,8 +582,7 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			MaxItems:    1,
 			ForceNew:    !isUpdatable,
 			Computed:    true,
-			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/",
-			Elem: &schema.Resource{
+			Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",			Elem: &schema.Resource{
 				Schema: resourcesFieldV1(isUpdatable),
 			},
 		},


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Resolve #2446 
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
