### PR TITLE
feat(provider): add config_data_base64 parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,3 +146,36 @@ require (
 )
 
 go 1.21
+
+replace (
+	k8s.io/api => k8s.io/api v0.28.6
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.6
+	k8s.io/apimachinery => k8s.io/apimachinery v0.28.6
+	k8s.io/apiserver => k8s.io/apiserver v0.28.6
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.28.6
+	k8s.io/client-go => k8s.io/client-go v0.28.6
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.28.6
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.28.6
+	k8s.io/code-generator => k8s.io/code-generator v0.28.6
+	k8s.io/component-base => k8s.io/component-base v0.28.6
+	k8s.io/component-helpers => k8s.io/component-helpers v0.28.6
+	k8s.io/controller-manager => k8s.io/controller-manager v0.28.6
+	k8s.io/cri-api => k8s.io/cri-api v0.28.6
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.28.6
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.28.6
+	k8s.io/endpointslice => k8s.io/endpointslice v0.28.6
+	k8s.io/kms => k8s.io/kms v0.28.6
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.28.6
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.28.6
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.28.6
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.28.6
+	k8s.io/kubectl => k8s.io/kubectl v0.28.6
+	k8s.io/kubelet => k8s.io/kubelet v0.28.6
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.28.6
+	k8s.io/metrics => k8s.io/metrics v0.28.6
+	k8s.io/mount-utils => k8s.io/mount-utils v0.28.6
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.28.6
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.28.6
+	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.28.6
+	k8s.io/sample-controller => k8s.io/sample-controller v0.28.6
+)

--- a/go.mod
+++ b/go.mod
@@ -146,36 +146,3 @@ require (
 )
 
 go 1.21
-
-replace (
-	k8s.io/api => k8s.io/api v0.28.6
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.6
-	k8s.io/apimachinery => k8s.io/apimachinery v0.28.6
-	k8s.io/apiserver => k8s.io/apiserver v0.28.6
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.28.6
-	k8s.io/client-go => k8s.io/client-go v0.28.6
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.28.6
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.28.6
-	k8s.io/code-generator => k8s.io/code-generator v0.28.6
-	k8s.io/component-base => k8s.io/component-base v0.28.6
-	k8s.io/component-helpers => k8s.io/component-helpers v0.28.6
-	k8s.io/controller-manager => k8s.io/controller-manager v0.28.6
-	k8s.io/cri-api => k8s.io/cri-api v0.28.6
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.28.6
-	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.28.6
-	k8s.io/endpointslice => k8s.io/endpointslice v0.28.6
-	k8s.io/kms => k8s.io/kms v0.28.6
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.28.6
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.28.6
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.28.6
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.28.6
-	k8s.io/kubectl => k8s.io/kubectl v0.28.6
-	k8s.io/kubelet => k8s.io/kubelet v0.28.6
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.28.6
-	k8s.io/metrics => k8s.io/metrics v0.28.6
-	k8s.io/mount-utils => k8s.io/mount-utils v0.28.6
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.28.6
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.28.6
-	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.28.6
-	k8s.io/sample-controller => k8s.io/sample-controller v0.28.6
-)

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -47,6 +47,8 @@ type KubernetesProviderModel struct {
 
 	ProxyURL types.String `tfsdk:"proxy_url"`
 
+	ConfigDataBase64 types.String `tfsdk:"config_data_base64"`
+
 	IgnoreAnnotations types.List `tfsdk:"ignore_annotations"`
 	IgnoreLabels      types.List `tfsdk:"ignore_labels"`
 
@@ -129,6 +131,10 @@ func (p *KubernetesProvider) Schema(ctx context.Context, req provider.SchemaRequ
 			},
 			"proxy_url": schema.StringAttribute{
 				Description: "URL to the proxy to be used for all API requests",
+				Optional:    true,
+			},
+			"config_data_base64": schema.StringAttribute{
+				Description: "Kubeconfig content in base64 format",
 				Optional:    true,
 			},
 			"ignore_annotations": schema.ListAttribute{

--- a/kubernetes/test-fixtures/kube-config-sa-token.yaml
+++ b/kubernetes/test-fixtures/kube-config-sa-token.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+  - cluster:
+      certificate-authority-data: ZHVtbXk=
+      server: https://127.0.0.1
+    name: dummy
+
+current-context: dummy
+
+contexts:
+  - context:
+      cluster: dummy
+      user: dummy
+    name: dummy
+
+users:
+  - name: dummy
+    user:
+      token: ZHVtbXk=

--- a/manifest/provider/provider_config.go
+++ b/manifest/provider/provider_config.go
@@ -179,6 +179,17 @@ func GetProviderConfigSchema() *tfprotov5.Schema {
 				Deprecated:      false,
 			},
 			{
+				Name:            "config_data_base64",
+				Type:            tftypes.String,
+				Description:     "Kubeconfig content in base64 format",
+				Required:        false,
+				Optional:        true,
+				Computed:        false,
+				Sensitive:       false,
+				DescriptionKind: 0,
+				Deprecated:      false,
+			},
+			{
 				Name:            "ignore_annotations",
 				Type:            tftypes.List{ElementType: tftypes.String},
 				Description:     "List of Kubernetes metadata annotations to ignore across all resources handled by this provider for situations where external systems are managing certain resource annotations. Each item is a regular expression.",

--- a/util/loader.go
+++ b/util/loader.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"encoding/base64"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func NewConfigLoader(loader *clientcmd.ClientConfigLoadingRules, configBase64Data string) *ConfigLoader {
+	return &ConfigLoader{
+		ClientConfigLoadingRules: loader,
+		configBase64Data:         configBase64Data,
+	}
+}
+
+type ConfigLoader struct {
+	*clientcmd.ClientConfigLoadingRules
+	configBase64Data string
+}
+
+func (cl ConfigLoader) Load() (*clientcmdapi.Config, error) {
+	if cl.configBase64Data == "" {
+		return cl.ClientConfigLoadingRules.Load()
+	}
+	data, err := base64.StdEncoding.DecodeString(cl.configBase64Data)
+	if err != nil {
+		return nil, err
+	}
+	cc, err := clientcmd.NewClientConfigFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := cc.RawConfig()
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}


### PR DESCRIPTION
### Description
In some cases kubeconfig is passed to CICD via environment variables, but I would like to use this config when running the provider without creating a kubeconfig file.

For this purpose, the config_data_base64 paramerter is added to the provider configuration, which contains kubeconfig content in base64 format.

Usage examples:
```
provider "kubernetes" {
  config_data_base64 = "base64 config"
}
```
or
`export KUBE_CONFIG_DATA_BASE64="base64 config"`
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestProvider_configure_config_data_base64'
==> Checking that code complies with gofmt requirements...
go vet ./...
TF_ACC=1 go test "/home/yaroslavborbat/work/github/terraform-provider-kubernetes/kubernetes" -v -vet=off -run=TestProvider_configure_config_data_base64 -parallel 8 -timeout 3h
=== RUN   TestProvider_configure_config_data_base64
--- PASS: TestProvider_configure_config_data_base64 (0.01s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   0.034s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added `config_data_base64` provider parameter.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
