### PR TITLE
update `ignore_annotations/labels` doc to include context for regexp in nested metadata objects

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -142,6 +142,8 @@ In certain cases, external systems can add and modify resources annotations and 
 
 Both attributes support RegExp to match metadata objects more effectively.
 
+~> **Note:** RegExp will only work on root metadata objects. This makes using RegExp for ignoring annotations/labels in metadata objects that are nested such as `spec.template.metadata[0].annotations["..."]` not possible.
+
 Please keep in mind that all data sources remain unaffected, and the provider always returns all labels and annotations, despite the `ignore_annotations` and `ignore_labels` settings. The same applies to the pod and job definitions that fall under templates. To ignore certain annotations and/or labels on the template level, please use the `ignore_changes` feature of the [lifecycle](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle) meta-argument.
 
 ### Examples


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Although `ignore_anntoations` and `ignore_labels` have support for `RegExp`. It is not supported for nested metadata objects. This PR would add a note into the docs to prevent any confusion in the event that a user attempts to do this.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
