### PR TITLE
Release v2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.28.0 (April 8, 2024)
+
+ENHANCEMENTS:
+
+**NOTE: Using [Provider Defined Functions](https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts) requires Terraform version 1.8.0.**
+
+* Add provider defined functions: `manifest_encode`, `manifest_decode`, `manifest_decode_multi` [[GH-2428](https://github.com/hashicorp/terraform-provider-kubernetes/issues/2428)]
+
 ## 2.27.0 (Mar, 6 2024)
 
 ENHANCEMENTS:

--- a/internal/framework/provider/functions/manifest_decode.go
+++ b/internal/framework/provider/functions/manifest_decode.go
@@ -56,6 +56,7 @@ func (f ManifestDecodeFunction) Run(ctx context.Context, req function.RunRequest
 		return
 	} else if len(elems) > 1 {
 		resp.Error = function.NewFuncError("YAML manifest contains multiple resources: use decode_manifest_multi to decode manifests containing more than one resource")
+		return
 	}
 
 	dynamResp := types.DynamicValue(elems[0])

--- a/internal/framework/provider/functions/manifest_decode_test.go
+++ b/internal/framework/provider/functions/manifest_decode_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -39,6 +40,20 @@ func TestManifestDecode(t *testing.T) {
 						}),
 					})),
 				},
+			},
+		},
+	})
+}
+
+func TestManifestDecode_ErrorOnMulti(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testManifestDecodeConfig("testdata/decode_multi.yaml"),
+				ExpectError: regexp.MustCompile(`YAML\s+manifest\s+contains\s+multiple\s+resources`),
 			},
 		},
 	})


### PR DESCRIPTION
### Description

This PR adds the changelog for v2.28.0 and fixes a small bug in the manifest_decode() function where the error was not propogating when a manifest containing multiple resources was supplied. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
