### PR TITLE
FIX decoding nil values in manifest_decode()

### DIFF
--- a/.changelog/2461.txt
+++ b/.changelog/2461.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`manifest_decode()`: fix handling of manifests containing null values
+```

--- a/internal/framework/provider/functions/decode.go
+++ b/internal/framework/provider/functions/decode.go
@@ -87,6 +87,8 @@ func decodeSequence(ctx context.Context, s []any) (attr.Value, diag.Diagnostics)
 
 func decodeScalar(ctx context.Context, m any) (value attr.Value, diags diag.Diagnostics) {
 	switch v := m.(type) {
+	case nil:
+		value = types.DynamicNull()
 	case float64:
 		value = types.NumberValue(big.NewFloat(float64(v)))
 	case bool:

--- a/internal/framework/provider/functions/manifest_decode_multi_test.go
+++ b/internal/framework/provider/functions/manifest_decode_multi_test.go
@@ -35,6 +35,7 @@ func TestManifestDecodeMulti(t *testing.T) {
 							}),
 							"kind": knownvalue.StringExact("ConfigMap"),
 							"metadata": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"annotations": knownvalue.Null(),
 								"labels": knownvalue.ObjectExact(map[string]knownvalue.Check{
 									"test": knownvalue.StringExact("test---label"),
 								}),

--- a/internal/framework/provider/functions/manifest_decode_multi_test.go
+++ b/internal/framework/provider/functions/manifest_decode_multi_test.go
@@ -41,6 +41,7 @@ func TestManifestDecodeMulti(t *testing.T) {
 								}),
 								"name": knownvalue.StringExact("test-configmap"),
 							}),
+							"status": knownvalue.Null(),
 						}),
 					})),
 				},

--- a/internal/framework/provider/functions/manifest_decode_test.go
+++ b/internal/framework/provider/functions/manifest_decode_test.go
@@ -39,6 +39,7 @@ func TestManifestDecode(t *testing.T) {
 							}),
 							"name": knownvalue.StringExact("test-configmap"),
 						}),
+						"status": knownvalue.Null(),
 					})),
 				},
 			},

--- a/internal/framework/provider/functions/manifest_decode_test.go
+++ b/internal/framework/provider/functions/manifest_decode_test.go
@@ -33,6 +33,7 @@ func TestManifestDecode(t *testing.T) {
 						}),
 						"kind": knownvalue.StringExact("ConfigMap"),
 						"metadata": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"annotations": knownvalue.Null(),
 							"labels": knownvalue.ObjectExact(map[string]knownvalue.Check{
 								"test": knownvalue.StringExact("test---label"),
 							}),

--- a/internal/framework/provider/functions/testdata/decode_single.yaml
+++ b/internal/framework/provider/functions/testdata/decode_single.yaml
@@ -13,3 +13,4 @@ data:
   configfile: |
     ---
     test: document
+status:

--- a/internal/framework/provider/functions/testdata/decode_single.yaml
+++ b/internal/framework/provider/functions/testdata/decode_single.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-configmap
+  annotations: null
   labels:
     test: "test---label"
 data:


### PR DESCRIPTION
### Description

This PR fixes an error when trying to use `manifest_decode()` with a manifest which contains a null scalar value. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
