### PR TITLE
Fix typo preventing the use of KUBE_PROXY_URL env variable

### DIFF
--- a/.changelog/2485.txt
+++ b/.changelog/2485.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`kubernetes_manifest`: fix issue preventing KUBE_PROXY_URL environment variable from being used in client configuration (#1733)
+```

--- a/manifest/provider/configure.go
+++ b/manifest/provider/configure.go
@@ -523,7 +523,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 		}
 		overrides.ClusterDefaults.ProxyURL = proxyURL
 	}
-	if proxyUrl, ok := os.LookupEnv("KUBE_PROXY_URL"); ok && proxyUrl != "" {
+	if proxyURL, ok := os.LookupEnv("KUBE_PROXY_URL"); ok && proxyURL != "" {
 		overrides.ClusterDefaults.ProxyURL = proxyURL
 	}
 


### PR DESCRIPTION
### Description

Fixes a typo that was shadowing the value extracted from the KUBE_PROXY_URL env var, preventing it from being used in client configuration.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
Fixes #1733

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
