### PR TITLE
Remove ArgoCD operation field to prevent perpetual diff

### DIFF
--- a/manifest/provider/resource.go
+++ b/manifest/provider/resource.go
@@ -184,6 +184,9 @@ func RemoveServerSideFields(in map[string]interface{}) map[string]interface{} {
 	// Remove "status" attribute
 	delete(in, "status")
 
+	// Remove ArgoCD "operation" attribute
+	delete(in, "operation")
+
 	meta := in["metadata"].(map[string]interface{})
 
 	// Remove "uid", "creationTimestamp", "resourceVersion" as


### PR DESCRIPTION
### Description

When using the `kubernetes_manifest` resource to manage an ArgoCD Application, it is possible for the status of Argo's sync operation to show up in the manifest when applying, but not during planning. This shows up under the top-level `operation` field, which is only present when an Argo sync operation is underway, potentially triggered by the Terraform apply.

This commit simply drops the `operation` field from manifests returned by the K8s API and thusly prevents it from being considered when diffing.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Prevent `operation` field in manifests from causing plan/apply diffs
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Issue #2367
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
