### PR TITLE
Fix nodeTaintsPolicy panic when NodeAffinityPolicy undefined

### DIFF
--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -343,7 +343,7 @@ func flattenTopologySpreadConstraints(tsc []v1.TopologySpreadConstraint) []inter
 		if v.NodeAffinityPolicy != nil && *v.NodeAffinityPolicy != "" {
 			obj["node_affinity_policy"] = string(*v.NodeAffinityPolicy)
 		}
-		if v.NodeTaintsPolicy != nil && *v.NodeAffinityPolicy != "" {
+		if v.NodeTaintsPolicy != nil && *v.NodeTaintsPolicy != "" {
 			obj["node_taints_policy"] = string(*v.NodeTaintsPolicy)
 		}
 		if v.WhenUnsatisfiable != "" {


### PR DESCRIPTION
### Description

Typo causes panic when TopologySpreadConstraints includes nodeTaintsPolicy and not NodeAffinityPolicy. 

### Acceptance tests
Trivially correct, N/A
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### References
https://github.com/hashicorp/terraform-provider-kubernetes/issues/2490 

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
