### PR TITLE
Add expirationSeconds to CertificateSigningRequest

### DIFF
--- a/docs/resources/certificate_signing_request_v1.md
+++ b/docs/resources/certificate_signing_request_v1.md
@@ -97,6 +97,18 @@ Custom signerNames can also be specified. The signer defines:
 
 Optional:
 
+- `expiration_seconds` (Integer) expirationSeconds is the requested duration of validity of the issued certificate.
+
+The certificate signer may issue a certificate with a different validity duration so a client must check the delta between the notBefore and and notAfter fields in the issued certificate to determine the actual duration. The v1.22+ in-tree implementations of the well-known Kubernetes signers will honor this field as long as the requested duration is not greater than the maximum duration they will honor per the --cluster-signing-duration CLI flag to the Kubernetes controller manager.
+
+Certificate signers may not honor this field for various reasons:
+
+1. Old signer that is unaware of the field (such as the in-tree implementations prior to v1.22)
+2. Signer whose configured maximum is shorter than the requested duration
+3. Signer whose configured minimum is longer than the requested duration
+
+The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
+
 - `usages` (Set of String) usages specifies a set of key usages requested in the issued certificate.
 
 Requests for TLS client certificates typically request: "digital signature", "key encipherment", "client auth".

--- a/kubernetes/resource_kubernetes_certificate_signing_request_v1.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_v1.go
@@ -57,6 +57,12 @@ func resourceKubernetesCertificateSigningRequestV1() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"expiration_seconds": {
+							Type:        schema.TypeInt,
+							Description: apiDocSpec["expirationSeconds"],
+							Optional:    true,
+							ForceNew:    true,
+						},
 						"request": {
 							Type:        schema.TypeString,
 							Description: apiDocSpec["request"],

--- a/kubernetes/resource_kubernetes_certificate_signing_request_v1_test.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request_v1_test.go
@@ -39,6 +39,7 @@ func TestAccKubernetesCertificateSigningRequestV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.signer_name", signerName),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.usages.0", usages[0]),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.expiration_seconds", "604800"),
 				),
 			},
 		},
@@ -150,7 +151,8 @@ func testAccKubernetesCertificateSigningRequestV1Config_basic(name, signerName s
   }
   auto_approve = %t
   spec {
-    request     = <<EOT
+    expiration_seconds = 604800 # 1 week
+    request            = <<EOT
 -----BEGIN CERTIFICATE REQUEST-----
 MIHSMIGBAgEAMCoxGDAWBgNVBAoTD2V4YW1wbGUgY2x1c3RlcjEOMAwGA1UEAxMF
 YWRtaW4wTjAQBgcqhkjOPQIBBgUrgQQAIQM6AASSG8S2+hQvfMq5ucngPCzK0m0C
@@ -159,8 +161,8 @@ BAMCA0AAMD0CHQDErNLjX86BVfOsYh/A4zmjmGknZpc2u6/coTHqAhxcR41hEU1I
 DpNPvh30e0Js8/DYn2YUfu/pQU19
 -----END CERTIFICATE REQUEST-----
 EOT
-    signer_name = %q
-    usages      = %q
+    signer_name        = %q
+    usages             = %q
   }
 }
 `, name, autoApprove, signerName, usages)

--- a/kubernetes/structures_certificate_signing_request_v1.go
+++ b/kubernetes/structures_certificate_signing_request_v1.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	certificates "k8s.io/api/certificates/v1"
+	"k8s.io/utils/ptr"
 )
 
 func expandCertificateSigningRequestV1Spec(csr []interface{}) *certificates.CertificateSigningRequestSpec {
@@ -15,6 +16,9 @@ func expandCertificateSigningRequestV1Spec(csr []interface{}) *certificates.Cert
 		return obj
 	}
 	in := csr[0].(map[string]interface{})
+	if v, ok := in["expiration_seconds"].(int); ok && v >= 600 {
+		obj.ExpirationSeconds = ptr.To(int32(v))
+	}
 	obj.Request = []byte(in["request"].(string))
 	if v, ok := in["usages"].(*schema.Set); ok && v.Len() > 0 {
 		obj.Usages = expandCertificateSigningRequestV1Usages(v.List())


### PR DESCRIPTION
### Description

I saw that `expirationSeconds` wasn't available through this provider.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:



<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run="(TestAccKubernetesCertificateSigningRequestV1_basic|TestAccKubernetesCertificateSigningRequestV1_generateName)"'
==> Checking that code complies with gofmt requirements...
go vet ./...
TF_ACC=1 go test "/home/moritz/dev/terraform-provider-kubernetes/add-fields-to-certificate-signing-request/kubernetes" -v -vet=off -run="(TestAccKubernetesCertificateSigningRequestV1_basic|TestAccKubernetesCertificateSigningRequestV1_generateName)" -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesCertificateSigningRequestV1_basic
=== PAUSE TestAccKubernetesCertificateSigningRequestV1_basic
=== RUN   TestAccKubernetesCertificateSigningRequestV1_generateName
=== PAUSE TestAccKubernetesCertificateSigningRequestV1_generateName
=== CONT  TestAccKubernetesCertificateSigningRequestV1_basic
=== CONT  TestAccKubernetesCertificateSigningRequestV1_generateName
--- PASS: TestAccKubernetesCertificateSigningRequestV1_generateName (3.42s)
--- PASS: TestAccKubernetesCertificateSigningRequestV1_basic (3.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	(cached)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:enhancement
`resource/kubernetes_certificate_signing_request_v1`: Add argument `spec.expiration_seconds`
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
