### PR TITLE
add namespace to sa error message

### DIFF
--- a/kubernetes/data_source_kubernetes_service_account_v1.go
+++ b/kubernetes/data_source_kubernetes_service_account_v1.go
@@ -74,7 +74,7 @@ func dataSourceKubernetesServiceAccountV1Read(ctx context.Context, d *schema.Res
 			d.SetId(buildId(sa.ObjectMeta))
 			return nil
 		}
-		return diag.Errorf("Unable to fetch service account from Kubernetes: %s", err)
+		return diag.Errorf(`Unable to fetch service account "%s/%s" from Kubernetes: %s`, metadata.Namespace, metadata.Name, err)
 	}
 
 	defaultSecret, diagMsg := findDefaultServiceAccountV1(ctx, sa, conn)

--- a/kubernetes/resource_kubernetes_service_account_v1.go
+++ b/kubernetes/resource_kubernetes_service_account_v1.go
@@ -421,7 +421,7 @@ func resourceKubernetesServiceAccountV1ImportState(ctx context.Context, d *schem
 
 	sa, err := conn.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Unable to fetch service account from Kubernetes: %s", err)
+		return nil, fmt.Errorf(`Unable to fetch service account "%s/%s" from Kubernetes: %s`, namespace, name, err)
 	}
 
 	defaultSecret, diagMsg := findDefaultServiceAccountV1(ctx, sa, conn)


### PR DESCRIPTION
ServiceAccount name may not be unique across namespaces, so it may be hard to understand which ServiceAccount is being referred.