### PR TITLE
fix: do not format `DefaultMode` & `Mode` to octal representation

### DIFF
--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -508,7 +508,7 @@ func flattenDownwardAPIVolumeFile(in []v1.DownwardAPIVolumeFile) []interface{} {
 func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	if in.DefaultMode != nil {
-		att["default_mode"] = "0" + strconv.FormatInt(int64(*in.DefaultMode), 8)
+		att["default_mode"] = strconv.FormatInt(int64(*in.DefaultMode), 10)
 	}
 	att["name"] = in.Name
 	if len(in.Items) > 0 {
@@ -519,7 +519,7 @@ func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 				m["key"] = v.Key
 			}
 			if v.Mode != nil {
-				m["mode"] = "0" + strconv.FormatInt(int64(*v.Mode), 8)
+				m["mode"] = strconv.FormatInt(int64(*v.Mode), 10)
 			}
 			if v.Path != "" {
 				m["path"] = v.Path


### PR DESCRIPTION
### Description

It looks like the default_mode value actually accepts a decimal number which is then converted to an octal value, for example if the "0420" is specified as a default access mode it's converts to the 272 (which is the result of converting 0420 to 0o272).

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/2541

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
