### PR TITLE
CI: set `TF_ACC_TERRAFORM_VERSION` in workflow instead of repo variable

### DIFF
--- a/.github/workflows/acceptance_test_dfa.yaml
+++ b/.github/workflows/acceptance_test_dfa.yaml
@@ -28,6 +28,6 @@ jobs:
       - name: Run Tests
         env:
           TF_ACC: 1
-          TF_ACC_TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION_EXP }}
+          TF_ACC_TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.9.0-alpha20240516' }}
         run: |
           go test -v -run '^TestAccKubernetesDeferredActions' ./kubernetes/test-dfa


### PR DESCRIPTION
### Description

configuration variables have a limited scope, preventing them from being used in pull requests. This causes the `Deferred Actions` workflow to fail since `${{ vars.TERRAFORM_VERSION_EXP }}` doesn't return the version but instead just an empty string. This is a known issue across github: https://github.com/orgs/community/discussions/44322

This is seen in a recent review of a PR: https://github.com/hashicorp/terraform-provider-helm/actions/runs/9781860920/job/27387198282?pr=1247

Solution is to explicitly set it in the workflow rather than rely on a repo variable.

We can see the new workflow passing here: I triggered a dispatch where the input for the version is empty, this would then use the explicit tf version that's set in this PR. https://github.com/hashicorp/terraform-provider-helm/actions/runs/9959691833/job/27517098279
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
