### PR TITLE
`CI`: run tfplugindocs generate to address workflow failure

### DIFF
--- a/docs/data-sources/config_map_v1.md
+++ b/docs/data-sources/config_map_v1.md
@@ -45,6 +45,7 @@ Read-Only:
 
 
 
+
 ~> **Note:** All arguments including the config map data will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 ## Example Usage

--- a/docs/data-sources/ingress_v1.md
+++ b/docs/data-sources/ingress_v1.md
@@ -119,7 +119,7 @@ Read-Only:
 - `service` (List of Object) (see [below for nested schema](#nestedobjatt--spec--rule--http--path--backend--service))
 
 <a id="nestedobjatt--spec--rule--http--path--backend--resource"></a>
-### Nested Schema for `spec.rule.http.path.backend.resource`
+### Nested Schema for `spec.rule.http.path.backend.service`
 
 Read-Only:
 

--- a/docs/data-sources/persistent_volume_v1.md
+++ b/docs/data-sources/persistent_volume_v1.md
@@ -143,7 +143,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.ceph_fs.secret_ref`
+### Nested Schema for `spec.persistent_volume_source.ceph_fs.user`
 
 Optional:
 
@@ -184,7 +184,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--persistent_volume_source--csi--controller_expand_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.controller_expand_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -193,7 +193,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--controller_publish_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.controller_publish_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -202,7 +202,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.node_publish_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -211,7 +211,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--node_stage_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.node_stage_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 

--- a/docs/data-sources/pod.md
+++ b/docs/data-sources/pod.md
@@ -94,23 +94,23 @@ Read-Only:
 - `required_during_scheduling_ignored_during_execution` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Read-Only:
 
-- `preference` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number)
 
-<a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions))
+- `match_fields` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields))
 
-<a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Read-Only:
 
@@ -119,8 +119,8 @@ Read-Only:
 - `values` (Set of String)
 
 
-<a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Read-Only:
 
@@ -147,7 +147,7 @@ Read-Only:
 - `match_fields` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
 <a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Read-Only:
 
@@ -178,32 +178,32 @@ Read-Only:
 - `required_during_scheduling_ignored_during_execution` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Read-Only:
 
-- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number)
 
-<a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Read-Only:
 
-- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String)
 - `topology_key` (String)
 
-<a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions))
 - `match_labels` (Map of String)
 
-<a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key.match_labels`
 
 Read-Only:
 
@@ -233,7 +233,7 @@ Read-Only:
 - `match_labels` (Map of String)
 
 <a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Read-Only:
 
@@ -254,32 +254,32 @@ Read-Only:
 - `required_during_scheduling_ignored_during_execution` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Read-Only:
 
-- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number)
 
-<a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Read-Only:
 
-- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String)
 - `topology_key` (String)
 
-<a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions))
 - `match_labels` (Map of String)
 
-<a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key.match_labels`
 
 Read-Only:
 
@@ -309,7 +309,7 @@ Read-Only:
 - `match_labels` (Map of String)
 
 <a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Read-Only:
 
@@ -419,7 +419,7 @@ Read-Only:
 - `secret_ref` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--env_from--secret_ref))
 
 <a id="nestedobjatt--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.container.env_from.config_map_ref`
+### Nested Schema for `spec.container.env_from.secret_ref`
 
 Read-Only:
 
@@ -446,35 +446,35 @@ Read-Only:
 - `pre_stop` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop))
 
 <a id="nestedobjatt--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.container.lifecycle.post_start`
+### Nested Schema for `spec.container.lifecycle.pre_stop`
 
 Read-Only:
 
-- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--exec))
-- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--exec))
+- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.exec`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.exec`
 
 Read-Only:
 
 - `command` (List of String)
 
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -483,8 +483,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.tcp_socket`
 
 Read-Only:
 
@@ -521,7 +521,7 @@ Read-Only:
 - `scheme` (String)
 
 <a id="nestedobjatt--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -556,7 +556,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.container.liveness_probe.exec`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -564,7 +564,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.container.liveness_probe.grpc`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -573,18 +573,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--liveness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -594,7 +594,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -630,7 +630,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.container.readiness_probe.exec`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -638,7 +638,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.container.readiness_probe.grpc`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -647,18 +647,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--readiness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -668,7 +668,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -701,7 +701,7 @@ Read-Only:
 - `seccomp_profile` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--security_context--seccomp_profile))
 
 <a id="nestedobjatt--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.container.security_context.capabilities`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -710,7 +710,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.container.security_context.se_linux_options`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -746,7 +746,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.container.startup_probe.exec`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -754,7 +754,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.container.startup_probe.grpc`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -763,18 +763,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.container.startup_probe.http_get`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--startup_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--startup_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.startup_probe.http_get.http_header`
+<a id="nestedobjatt--spec--container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.startup_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -784,7 +784,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.startup_probe.tcp_socket`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -938,7 +938,7 @@ Read-Only:
 - `secret_ref` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--env_from--secret_ref))
 
 <a id="nestedobjatt--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.init_container.env_from.config_map_ref`
+### Nested Schema for `spec.init_container.env_from.secret_ref`
 
 Read-Only:
 
@@ -965,35 +965,35 @@ Read-Only:
 - `pre_stop` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop))
 
 <a id="nestedobjatt--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop`
 
 Read-Only:
 
-- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--exec))
+- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.exec`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.exec`
 
 Read-Only:
 
 - `command` (List of String)
 
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -1002,8 +1002,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.tcp_socket`
 
 Read-Only:
 
@@ -1040,7 +1040,7 @@ Read-Only:
 - `scheme` (String)
 
 <a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -1075,7 +1075,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.init_container.liveness_probe.exec`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1083,7 +1083,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.liveness_probe.grpc`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1092,18 +1092,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--liveness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -1113,7 +1113,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1149,7 +1149,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.init_container.readiness_probe.exec`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1157,7 +1157,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.readiness_probe.grpc`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1166,18 +1166,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--readiness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -1187,7 +1187,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1220,7 +1220,7 @@ Read-Only:
 - `seccomp_profile` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--security_context--seccomp_profile))
 
 <a id="nestedobjatt--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.init_container.security_context.capabilities`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -1229,7 +1229,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.init_container.security_context.se_linux_options`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -1265,7 +1265,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.init_container.startup_probe.exec`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1273,7 +1273,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.init_container.startup_probe.grpc`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1282,18 +1282,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--startup_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -1303,7 +1303,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.startup_probe.tcp_socket`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1432,7 +1432,7 @@ Read-Only:
 - `match_labels` (Map of String)
 
 <a id="nestedobjatt--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.topology_spread_constraint.label_selector.match_expressions`
+### Nested Schema for `spec.topology_spread_constraint.label_selector.match_labels`
 
 Read-Only:
 
@@ -1525,7 +1525,7 @@ Read-Only:
 - `user` (String)
 
 <a id="nestedobjatt--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.volume.ceph_fs.user`
 
 Read-Only:
 
@@ -1555,7 +1555,7 @@ Read-Only:
 - `optional` (Boolean)
 
 <a id="nestedobjatt--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.volume.config_map.items`
+### Nested Schema for `spec.volume.config_map.optional`
 
 Read-Only:
 
@@ -1577,7 +1577,7 @@ Read-Only:
 - `volume_attributes` (Map of String)
 
 <a id="nestedobjatt--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.volume.csi.volume_attributes`
 
 Read-Only:
 
@@ -1622,12 +1622,6 @@ Read-Only:
 - `resource` (String)
 
 
-
-* `type` - Indicates which kind of seccomp profile will be applied. Valid options are:
-* `Localhost` - a profile defined in a file on the node should be used.
-* `RuntimeDefault` - the container runtime default profile should be used.
-* `Unconfined` - (Default) no profile should be applied.
-* `localhost_profile` - Indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if `type` is `Localhost`.
 
 
 <a id="nestedobjatt--spec--volume--empty_dir"></a>
@@ -1676,7 +1670,7 @@ Read-Only:
 - `volume_name` (String)
 
 <a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.resources`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Read-Only:
 
@@ -1685,15 +1679,15 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String)
 
-<a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name.match_labels`
 
 Read-Only:
 
@@ -1864,7 +1858,7 @@ Read-Only:
 - `optional` (Boolean)
 
 <a id="nestedobjatt--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.volume.projected.sources.config_map.items`
+### Nested Schema for `spec.volume.projected.sources.config_map.optional`
 
 Read-Only:
 
@@ -1892,7 +1886,7 @@ Read-Only:
 - `resource_field_ref` (List of Object) (see [below for nested schema](#nestedobjatt--spec--volume--projected--sources--downward_api--items--resource_field_ref))
 
 <a id="nestedobjatt--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items.field_ref`
+### Nested Schema for `spec.volume.projected.sources.downward_api.items.resource_field_ref`
 
 Read-Only:
 
@@ -1922,7 +1916,7 @@ Read-Only:
 - `optional` (Boolean)
 
 <a id="nestedobjatt--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.volume.projected.sources.secret.items`
+### Nested Schema for `spec.volume.projected.sources.secret.optional`
 
 Read-Only:
 
@@ -1991,7 +1985,7 @@ Read-Only:
 - `secret_name` (String)
 
 <a id="nestedobjatt--spec--volume--secret--items"></a>
-### Nested Schema for `spec.volume.secret.items`
+### Nested Schema for `spec.volume.secret.secret_name`
 
 Read-Only:
 

--- a/docs/data-sources/pod_v1.md
+++ b/docs/data-sources/pod_v1.md
@@ -94,23 +94,23 @@ Read-Only:
 - `required_during_scheduling_ignored_during_execution` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Read-Only:
 
-- `preference` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number)
 
-<a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions))
+- `match_fields` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields))
 
-<a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Read-Only:
 
@@ -119,8 +119,8 @@ Read-Only:
 - `values` (Set of String)
 
 
-<a id="nestedobjatt--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Read-Only:
 
@@ -147,7 +147,7 @@ Read-Only:
 - `match_fields` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
 <a id="nestedobjatt--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Read-Only:
 
@@ -178,32 +178,32 @@ Read-Only:
 - `required_during_scheduling_ignored_during_execution` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Read-Only:
 
-- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number)
 
-<a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Read-Only:
 
-- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String)
 - `topology_key` (String)
 
-<a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions))
 - `match_labels` (Map of String)
 
-<a id="nestedobjatt--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key.match_labels`
 
 Read-Only:
 
@@ -233,7 +233,7 @@ Read-Only:
 - `match_labels` (Map of String)
 
 <a id="nestedobjatt--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Read-Only:
 
@@ -254,32 +254,32 @@ Read-Only:
 - `required_during_scheduling_ignored_during_execution` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Read-Only:
 
-- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number)
 
-<a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Read-Only:
 
-- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String)
 - `topology_key` (String)
 
-<a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions))
 - `match_labels` (Map of String)
 
-<a id="nestedobjatt--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--topology_key--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.topology_key.match_labels`
 
 Read-Only:
 
@@ -309,7 +309,7 @@ Read-Only:
 - `match_labels` (Map of String)
 
 <a id="nestedobjatt--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Read-Only:
 
@@ -419,7 +419,7 @@ Read-Only:
 - `secret_ref` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--env_from--secret_ref))
 
 <a id="nestedobjatt--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.container.env_from.config_map_ref`
+### Nested Schema for `spec.container.env_from.secret_ref`
 
 Read-Only:
 
@@ -446,35 +446,35 @@ Read-Only:
 - `pre_stop` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop))
 
 <a id="nestedobjatt--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.container.lifecycle.post_start`
+### Nested Schema for `spec.container.lifecycle.pre_stop`
 
 Read-Only:
 
-- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--exec))
-- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--exec))
+- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.exec`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.exec`
 
 Read-Only:
 
 - `command` (List of String)
 
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -483,8 +483,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedobjatt--spec--container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.tcp_socket`
 
 Read-Only:
 
@@ -521,7 +521,7 @@ Read-Only:
 - `scheme` (String)
 
 <a id="nestedobjatt--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -556,7 +556,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.container.liveness_probe.exec`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -564,7 +564,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.container.liveness_probe.grpc`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -573,18 +573,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--liveness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -594,7 +594,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -630,7 +630,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.container.readiness_probe.exec`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -638,7 +638,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.container.readiness_probe.grpc`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -647,18 +647,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--readiness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -668,7 +668,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -701,7 +701,7 @@ Read-Only:
 - `seccomp_profile` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--security_context--seccomp_profile))
 
 <a id="nestedobjatt--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.container.security_context.capabilities`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -710,7 +710,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.container.security_context.se_linux_options`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -746,7 +746,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.container.startup_probe.exec`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -754,7 +754,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.container.startup_probe.grpc`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -763,18 +763,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.container.startup_probe.http_get`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--startup_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--container--startup_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.startup_probe.http_get.http_header`
+<a id="nestedobjatt--spec--container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.startup_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -784,7 +784,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.startup_probe.tcp_socket`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -938,7 +938,7 @@ Read-Only:
 - `secret_ref` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--env_from--secret_ref))
 
 <a id="nestedobjatt--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.init_container.env_from.config_map_ref`
+### Nested Schema for `spec.init_container.env_from.secret_ref`
 
 Read-Only:
 
@@ -965,35 +965,35 @@ Read-Only:
 - `pre_stop` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop))
 
 <a id="nestedobjatt--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop`
 
 Read-Only:
 
-- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--exec))
+- `http_get` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.exec`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.exec`
 
 Read-Only:
 
 - `command` (List of String)
 
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -1002,8 +1002,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.tcp_socket`
 
 Read-Only:
 
@@ -1040,7 +1040,7 @@ Read-Only:
 - `scheme` (String)
 
 <a id="nestedobjatt--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Read-Only:
 
@@ -1075,7 +1075,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.init_container.liveness_probe.exec`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1083,7 +1083,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.liveness_probe.grpc`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1092,18 +1092,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--liveness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -1113,7 +1113,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1149,7 +1149,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.init_container.readiness_probe.exec`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1157,7 +1157,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.readiness_probe.grpc`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1166,18 +1166,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--readiness_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -1187,7 +1187,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1220,7 +1220,7 @@ Read-Only:
 - `seccomp_profile` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--security_context--seccomp_profile))
 
 <a id="nestedobjatt--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.init_container.security_context.capabilities`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -1229,7 +1229,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.init_container.security_context.se_linux_options`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Read-Only:
 
@@ -1265,7 +1265,7 @@ Read-Only:
 - `timeout_seconds` (Number)
 
 <a id="nestedobjatt--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.init_container.startup_probe.exec`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1273,7 +1273,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.init_container.startup_probe.grpc`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1282,18 +1282,18 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
 - `host` (String)
-- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (List of Object) (see [below for nested schema](#nestedobjatt--spec--init_container--startup_probe--timeout_seconds--http_header))
 - `path` (String)
 - `port` (String)
 - `scheme` (String)
 
-<a id="nestedobjatt--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedobjatt--spec--init_container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds.http_header`
 
 Read-Only:
 
@@ -1303,7 +1303,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.startup_probe.tcp_socket`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Read-Only:
 
@@ -1432,7 +1432,7 @@ Read-Only:
 - `match_labels` (Map of String)
 
 <a id="nestedobjatt--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.topology_spread_constraint.label_selector.match_expressions`
+### Nested Schema for `spec.topology_spread_constraint.label_selector.match_labels`
 
 Read-Only:
 
@@ -1525,7 +1525,7 @@ Read-Only:
 - `user` (String)
 
 <a id="nestedobjatt--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.volume.ceph_fs.user`
 
 Read-Only:
 
@@ -1555,7 +1555,7 @@ Read-Only:
 - `optional` (Boolean)
 
 <a id="nestedobjatt--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.volume.config_map.items`
+### Nested Schema for `spec.volume.config_map.optional`
 
 Read-Only:
 
@@ -1577,7 +1577,7 @@ Read-Only:
 - `volume_attributes` (Map of String)
 
 <a id="nestedobjatt--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.volume.csi.volume_attributes`
 
 Read-Only:
 
@@ -1622,12 +1622,6 @@ Read-Only:
 - `resource` (String)
 
 
-
-* `type` - Indicates which kind of seccomp profile will be applied. Valid options are:
-* `Localhost` - a profile defined in a file on the node should be used.
-* `RuntimeDefault` - the container runtime default profile should be used.
-* `Unconfined` - (Default) no profile should be applied.
-* `localhost_profile` - Indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if `type` is `Localhost`.
 
 
 <a id="nestedobjatt--spec--volume--empty_dir"></a>
@@ -1676,7 +1670,7 @@ Read-Only:
 - `volume_name` (String)
 
 <a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.resources`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Read-Only:
 
@@ -1685,15 +1679,15 @@ Read-Only:
 
 
 <a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Read-Only:
 
-- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (List of Object) (see [below for nested schema](#nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String)
 
-<a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedobjatt--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name.match_labels`
 
 Read-Only:
 
@@ -1864,7 +1858,7 @@ Read-Only:
 - `optional` (Boolean)
 
 <a id="nestedobjatt--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.volume.projected.sources.config_map.items`
+### Nested Schema for `spec.volume.projected.sources.config_map.optional`
 
 Read-Only:
 
@@ -1892,7 +1886,7 @@ Read-Only:
 - `resource_field_ref` (List of Object) (see [below for nested schema](#nestedobjatt--spec--volume--projected--sources--downward_api--items--resource_field_ref))
 
 <a id="nestedobjatt--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items.field_ref`
+### Nested Schema for `spec.volume.projected.sources.downward_api.items.resource_field_ref`
 
 Read-Only:
 
@@ -1922,7 +1916,7 @@ Read-Only:
 - `optional` (Boolean)
 
 <a id="nestedobjatt--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.volume.projected.sources.secret.items`
+### Nested Schema for `spec.volume.projected.sources.secret.optional`
 
 Read-Only:
 
@@ -1991,7 +1985,7 @@ Read-Only:
 - `secret_name` (String)
 
 <a id="nestedobjatt--spec--volume--secret--items"></a>
-### Nested Schema for `spec.volume.secret.items`
+### Nested Schema for `spec.volume.secret.secret_name`
 
 Read-Only:
 

--- a/docs/guides/alpha-manifest-migration-guide.markdown
+++ b/docs/guides/alpha-manifest-migration-guide.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+layout: "kubernetes"
 page_title: "Migrating `kubernetes_manifest` resources from the kubernetes-alpha provider"
 description: |-
   This guide covers adopting `kubernetes_manifest` resources created using the kubernetes-alpha provider.

--- a/docs/guides/getting-started.html.markdown
+++ b/docs/guides/getting-started.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+layout: "kubernetes"
 page_title: "Kubernetes: Getting Started with Kubernetes provider"
 description: |-
   This guide focuses on configuring authentication to your existing Kubernetes

--- a/docs/guides/v2-upgrade-guide.markdown
+++ b/docs/guides/v2-upgrade-guide.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+layout: "kubernetes"
 page_title: "Kubernetes: Upgrade Guide for Kubernetes Provider v2.0.0"
 description: |-
   This guide covers the changes introduced in v2.0.0 of the Kubernetes provider and what you may need to do to upgrade your configuration.

--- a/docs/guides/versioned-resources.markdown
+++ b/docs/guides/versioned-resources.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+layout: "kubernetes"
 page_title: "Versioned resource names"
 description: |-
   This guide explains the naming conventions for resources and data sources in the Kubernetes provider. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -195,9 +195,9 @@ The following arguments are supported:
 * `token` - (Optional) Token of your service account. Can be sourced from `KUBE_TOKEN`.
 * `proxy_url` - (Optional) URL to the proxy to be used for all API requests. URLs with "http", "https", and "socks5" schemes are supported. Can be sourced from `KUBE_PROXY_URL`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
-* `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
-* `command` - (Required) Command to execute.
-* `args` - (Optional) List of arguments to pass when executing the plugin.
-* `env` - (Optional) Map of environment variables to set when executing the plugin.
+  * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
+  * `command` - (Required) Command to execute.
+  * `args` - (Optional) List of arguments to pass when executing the plugin.
+  * `env` - (Optional) Map of environment variables to set when executing the plugin.
 * `ignore_annotations` - (Optional) List of Kubernetes metadata annotations to ignore across all resources handled by this provider for situations where external systems are managing certain resource annotations. This option does not affect annotations within a template block. Each item is a regular expression.
 * `ignore_labels` - (Optional) List of Kubernetes metadata labels to ignore across all resources handled by this provider for situations where external systems are managing certain resource labels. This option does not affect annotations within a template block. Each item is a regular expression.

--- a/docs/resources/certificate_signing_request_v1.md
+++ b/docs/resources/certificate_signing_request_v1.md
@@ -97,18 +97,18 @@ Custom signerNames can also be specified. The signer defines:
 
 Optional:
 
-- `expiration_seconds` (Integer) expirationSeconds is the requested duration of validity of the issued certificate.
+- `expiration_seconds` (Number) expirationSeconds is the requested duration of validity of the issued certificate. The certificate signer may issue a certificate with a different validity duration so a client must check the delta between the notBefore and and notAfter fields in the issued certificate to determine the actual duration.
 
-The certificate signer may issue a certificate with a different validity duration so a client must check the delta between the notBefore and and notAfter fields in the issued certificate to determine the actual duration. The v1.22+ in-tree implementations of the well-known Kubernetes signers will honor this field as long as the requested duration is not greater than the maximum duration they will honor per the --cluster-signing-duration CLI flag to the Kubernetes controller manager.
+The v1.22+ in-tree implementations of the well-known Kubernetes signers will honor this field as long as the requested duration is not greater than the maximum duration they will honor per the --cluster-signing-duration CLI flag to the Kubernetes controller manager.
 
 Certificate signers may not honor this field for various reasons:
 
-1. Old signer that is unaware of the field (such as the in-tree implementations prior to v1.22)
-2. Signer whose configured maximum is shorter than the requested duration
-3. Signer whose configured minimum is longer than the requested duration
+  1. Old signer that is unaware of the field (such as the in-tree
+     implementations prior to v1.22)
+  2. Signer whose configured maximum is shorter than the requested duration
+  3. Signer whose configured minimum is longer than the requested duration
 
 The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
-
 - `usages` (Set of String) usages specifies a set of key usages requested in the issued certificate.
 
 Requests for TLS client certificates typically request: "digital signature", "key encipherment", "client auth".

--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -111,18 +111,18 @@ Optional:
 - `ttl_seconds_after_finished` (String) ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.
 
 <a id="nestedblock--spec--job_template--spec--template"></a>
-### Nested Schema for `spec.job_template.spec.template`
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished`
 
 Required:
 
-- `metadata` (Block List, Min: 1, Max: 1) Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata (see [below for nested schema](#nestedblock--spec--job_template--spec--template--metadata))
+- `metadata` (Block List, Min: 1, Max: 1) Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--metadata))
 
 Optional:
 
-- `spec` (Block List, Max: 1) Spec of the pods owned by the job (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec))
+- `spec` (Block List, Max: 1) Spec of the pods owned by the job (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec))
 
-<a id="nestedblock--spec--job_template--spec--template--metadata"></a>
-### Nested Schema for `spec.job_template.spec.template.metadata`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--metadata"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.metadata`
 
 Optional:
 
@@ -138,77 +138,77 @@ Read-Only:
 - `uid` (String) The unique in time and space value for this job. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec`
 
 Optional:
 
 - `active_deadline_seconds` (Number) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
-- `affinity` (Block List, Max: 1) Optional pod scheduling constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity))
+- `affinity` (Block List, Max: 1) Optional pod scheduling constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--affinity))
 - `automount_service_account_token` (Boolean) AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
-- `container` (Block List) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container))
-- `dns_config` (Block List, Max: 1) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--dns_config))
+- `container` (Block List) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--container))
+- `dns_config` (Block List, Max: 1) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--dns_config))
 - `dns_policy` (String) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Defaults to 'ClusterFirst'. More info: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 - `enable_service_links` (Boolean) Enables generating environment variables for service discovery. Defaults to true.
-- `host_aliases` (Block List) List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--host_aliases))
+- `host_aliases` (Block List) List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--host_aliases))
 - `host_ipc` (Boolean) Use the host's ipc namespace. Optional: Defaults to false.
 - `host_network` (Boolean) Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.
 - `host_pid` (Boolean) Use the host's pid namespace.
 - `hostname` (String) Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
-- `image_pull_secrets` (Block List) ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--image_pull_secrets))
-- `init_container` (Block List) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container))
+- `image_pull_secrets` (Block List) ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--image_pull_secrets))
+- `init_container` (Block List) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--init_container))
 - `node_name` (String) NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
 - `node_selector` (Map of String) NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/.
-- `os` (Block List, Max: 1) Specifies the OS of the containers in the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--os))
+- `os` (Block List, Max: 1) Specifies the OS of the containers in the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--os))
 - `priority_class_name` (String) If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
-- `readiness_gate` (Block List) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--readiness_gate))
+- `readiness_gate` (Block List) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--readiness_gate))
 - `restart_policy` (String) Restart policy for all containers within the pod. One of Always, OnFailure, Never. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
 - `runtime_class_name` (String) RuntimeClassName is a feature for selecting the container runtime configuration. The container runtime configuration is used to run a Pod's containers. More info: https://kubernetes.io/docs/concepts/containers/runtime-class
 - `scheduler_name` (String) If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
-- `security_context` (Block List, Max: 1) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context))
+- `security_context` (Block List, Max: 1) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--security_context))
 - `service_account_name` (String) ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md.
 - `share_process_namespace` (Boolean) Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Defaults to false.
 - `subdomain` (String) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 - `termination_grace_period_seconds` (Number) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
-- `toleration` (Block List) If specified, the pod's toleration. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--toleration))
-- `topology_spread_constraint` (Block List) describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint))
-- `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume))
+- `toleration` (Block List) If specified, the pod's toleration. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--toleration))
+- `topology_spread_constraint` (Block List) describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--topology_spread_constraint))
+- `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity`
-
-Optional:
-
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity))
-
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity`
+
+Optional:
+
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.preference`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Optional:
 
@@ -217,8 +217,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Required:
 
@@ -232,23 +232,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -257,8 +257,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -273,24 +273,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -298,19 +298,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -322,8 +322,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -331,19 +331,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -355,24 +355,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -380,19 +380,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -404,8 +404,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -413,19 +413,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -438,8 +438,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--container"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
@@ -449,27 +449,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -478,20 +478,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.config_map_key_ref`
 
 Optional:
 
@@ -500,8 +500,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.field_ref`
 
 Optional:
 
@@ -509,8 +509,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.resource_field_ref`
 
 Required:
 
@@ -522,8 +522,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.secret_key_ref`
 
 Optional:
 
@@ -534,17 +534,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -555,8 +555,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -568,44 +568,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -614,8 +614,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -623,36 +623,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -661,8 +661,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -671,31 +671,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -706,19 +706,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -727,8 +727,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -736,8 +736,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.port`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -751,31 +751,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -786,19 +786,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -807,8 +807,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -816,8 +816,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.resources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
@@ -825,23 +825,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -849,8 +849,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -860,8 +860,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -870,31 +870,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -905,19 +905,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -926,8 +926,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -935,8 +935,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -951,17 +951,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.dns_config`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--dns_config"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--option"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.searches`
 
 Required:
 
@@ -973,8 +973,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.host_aliases`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--host_aliases"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
@@ -982,16 +982,16 @@ Required:
 - `ip` (String) IP address of the host file entry.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.image_pull_secrets`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--image_pull_secrets"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--init_container"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
@@ -1001,27 +1001,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -1030,20 +1030,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.config_map_key_ref`
 
 Optional:
 
@@ -1052,8 +1052,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.field_ref`
 
 Optional:
 
@@ -1061,8 +1061,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.resource_field_ref`
 
 Required:
 
@@ -1074,8 +1074,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.secret_key_ref`
 
 Optional:
 
@@ -1086,17 +1086,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -1107,8 +1107,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -1120,44 +1120,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1166,8 +1166,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -1175,36 +1175,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1213,8 +1213,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -1223,31 +1223,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1258,19 +1258,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -1279,8 +1279,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1288,8 +1288,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.port`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -1303,31 +1303,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1338,19 +1338,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -1359,8 +1359,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1368,8 +1368,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
@@ -1377,23 +1377,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -1401,8 +1401,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -1412,8 +1412,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -1422,31 +1422,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1457,19 +1457,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -1478,8 +1478,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1487,8 +1487,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -1503,24 +1503,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--os"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.os`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--os"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
 - `name` (String) Name is the name of the operating system. The currently supported values are linux and windows.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.readiness_gate`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--readiness_gate"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
 - `condition_type` (String) refers to a condition in the pod's condition list with matching type.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--security_context"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
@@ -1529,14 +1529,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--windows_options))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Optional:
 
@@ -1546,8 +1546,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Optional:
 
@@ -1555,8 +1555,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--sysctl"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Required:
 
@@ -1564,8 +1564,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--windows_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Optional:
 
@@ -1576,8 +1576,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.toleration`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--toleration"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
@@ -1588,12 +1588,12 @@ Optional:
 - `value` (String) Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.topology_spread_constraint`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--topology_spread_constraint"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1602,16 +1602,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.when_unsatisfiable`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--when_unsatisfiable--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--when_unsatisfiable--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.when_unsatisfiable.match_labels`
 
 Optional:
 
@@ -1622,42 +1622,42 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
-- `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--aws_elastic_block_store))
-- `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_disk))
-- `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_file))
-- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs))
-- `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--cinder))
-- `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--config_map))
-- `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--csi))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api))
-- `empty_dir` (Block List, Max: 1) EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--empty_dir))
-- `ephemeral` (Block List, Max: 1) Represents an ephemeral volume that is handled by a normal storage driver. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral))
-- `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--fc))
-- `flex_volume` (Block List, Max: 1) Represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--flex_volume))
-- `flocker` (Block List, Max: 1) Represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--flocker))
-- `gce_persistent_disk` (Block List, Max: 1) Represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--gce_persistent_disk))
-- `git_repo` (Block List, Max: 1) GitRepo represents a git repository at a particular revision. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--git_repo))
-- `glusterfs` (Block List, Max: 1) Represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--glusterfs))
-- `host_path` (Block List, Max: 1) Represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--host_path))
-- `iscsi` (Block List, Max: 1) Represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--iscsi))
-- `local` (Block List, Max: 1) Represents a mounted local storage device such as a disk, partition or directory. Local volumes can only be used as a statically created PersistentVolume. Dynamic provisioning is not supported yet. More info: https://kubernetes.io/docs/concepts/storage/volumes#local (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--local))
+- `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--aws_elastic_block_store))
+- `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_disk))
+- `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ceph_fs))
+- `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--cinder))
+- `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--config_map))
+- `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--csi))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--downward_api))
+- `empty_dir` (Block List, Max: 1) EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--empty_dir))
+- `ephemeral` (Block List, Max: 1) Represents an ephemeral volume that is handled by a normal storage driver. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ephemeral))
+- `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--fc))
+- `flex_volume` (Block List, Max: 1) Represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flex_volume))
+- `flocker` (Block List, Max: 1) Represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flocker))
+- `gce_persistent_disk` (Block List, Max: 1) Represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--gce_persistent_disk))
+- `git_repo` (Block List, Max: 1) GitRepo represents a git repository at a particular revision. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--git_repo))
+- `glusterfs` (Block List, Max: 1) Represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--glusterfs))
+- `host_path` (Block List, Max: 1) Represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--host_path))
+- `iscsi` (Block List, Max: 1) Represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--iscsi))
+- `local` (Block List, Max: 1) Represents a mounted local storage device such as a disk, partition or directory. Local volumes can only be used as a statically created PersistentVolume. Dynamic provisioning is not supported yet. More info: https://kubernetes.io/docs/concepts/storage/volumes#local (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--local))
 - `name` (String) Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-- `nfs` (Block List, Max: 1) Represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--nfs))
-- `persistent_volume_claim` (Block List, Max: 1) The specification of a persistent volume. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--persistent_volume_claim))
-- `photon_persistent_disk` (Block List, Max: 1) Represents a PhotonController persistent disk attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--photon_persistent_disk))
-- `projected` (Block List) Projected represents a single volume that projects several volume sources into the same directory. More info: https://kubernetes.io/docs/concepts/storage/volumes/#projected (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected))
-- `quobyte` (Block List, Max: 1) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--quobyte))
-- `rbd` (Block List, Max: 1) Represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--rbd))
-- `secret` (Block List, Max: 1) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--secret))
-- `vsphere_volume` (Block List, Max: 1) Represents a vSphere volume attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--vsphere_volume))
+- `nfs` (Block List, Max: 1) Represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--nfs))
+- `persistent_volume_claim` (Block List, Max: 1) The specification of a persistent volume. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--persistent_volume_claim))
+- `photon_persistent_disk` (Block List, Max: 1) Represents a PhotonController persistent disk attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--photon_persistent_disk))
+- `projected` (Block List) Projected represents a single volume that projects several volume sources into the same directory. More info: https://kubernetes.io/docs/concepts/storage/volumes/#projected (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--projected))
+- `quobyte` (Block List, Max: 1) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--quobyte))
+- `rbd` (Block List, Max: 1) Represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--rbd))
+- `secret` (Block List, Max: 1) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--secret))
+- `vsphere_volume` (Block List, Max: 1) Represents a vSphere volume attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--aws_elastic_block_store"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.aws_elastic_block_store`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--aws_elastic_block_store"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1670,8 +1670,8 @@ Optional:
 - `read_only` (Boolean) Whether to set the read-only property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--azure_disk"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.azure_disk`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_disk"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1686,8 +1686,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--azure_file"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.azure_file`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_file"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1700,8 +1700,8 @@ Optional:
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1712,11 +1712,11 @@ Optional:
 - `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 - `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
-- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref))
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref))
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.user`
 
 Optional:
 
@@ -1725,8 +1725,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--cinder"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.cinder`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--cinder"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1738,18 +1738,18 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write). More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--config_map"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.config_map`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--config_map"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.config_map.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.optional`
 
 Optional:
 
@@ -1759,8 +1759,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--csi"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.csi`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--csi"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1769,12 +1769,12 @@ Required:
 Optional:
 
 - `fs_type` (String) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-- `node_publish_secret_ref` (Block List, Max: 1) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--csi--node_publish_secret_ref))
+- `node_publish_secret_ref` (Block List, Max: 1) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--node_publish_secret_ref))
 - `read_only` (Boolean) Whether to set the read-only property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#csi
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.csi.node_publish_secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--node_publish_secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_attributes`
 
 Optional:
 
@@ -1782,29 +1782,29 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--downward_api"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.items`
 
 Required:
 
-- `field_ref` (Block List, Min: 1, Max: 1) Required: Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--field_ref))
+- `field_ref` (Block List, Min: 1, Max: 1) Required: Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--field_ref))
 - `path` (String) Path is the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
 
 Optional:
 
 - `mode` (String) Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--resource_field_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api.items.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.items.field_ref`
 
 Optional:
 
@@ -1812,8 +1812,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.items.resource_field_ref`
 
 Required:
 
@@ -1827,8 +1827,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--empty_dir"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.empty_dir`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--empty_dir"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1836,41 +1836,41 @@ Optional:
 - `size_limit` (String) Total amount of local storage required for this EmptyDir volume.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ephemeral"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
-- `volume_claim_template` (Block List, Min: 1, Max: 1) Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template))
+- `volume_claim_template` (Block List, Min: 1, Max: 1) Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template`
 
 Required:
 
-- `spec` (Block List, Min: 1, Max: 1) The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec))
+- `spec` (Block List, Min: 1, Max: 1) The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec))
 
 Optional:
 
-- `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
+- `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--metadata))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--resources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec.volume_name`
 
 Optional:
 
@@ -1878,16 +1878,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec.volume_name.match_labels`
 
 Optional:
 
@@ -1898,8 +1898,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--metadata"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--metadata"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.metadata`
 
 Optional:
 
@@ -1909,8 +1909,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--fc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.fc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--fc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1923,8 +1923,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--flex_volume"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.flex_volume`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flex_volume"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1935,10 +1935,10 @@ Optional:
 - `fs_type` (String) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 - `options` (Map of String) Extra command options if any.
 - `read_only` (Boolean) Whether to force the ReadOnly setting in VolumeMounts. Defaults to false (read/write).
-- `secret_ref` (Block List, Max: 1) Reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--flex_volume--secret_ref))
+- `secret_ref` (Block List, Max: 1) Reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--flex_volume--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.flex_volume.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.secret_ref`
 
 Optional:
 
@@ -1947,8 +1947,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--flocker"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.flocker`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flocker"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1956,8 +1956,8 @@ Optional:
 - `dataset_uuid` (String) UUID of the dataset. This is unique identifier of a Flocker dataset
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--gce_persistent_disk"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.gce_persistent_disk`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--gce_persistent_disk"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1970,8 +1970,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--git_repo"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.git_repo`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--git_repo"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1980,8 +1980,8 @@ Optional:
 - `revision` (String) Commit hash for the specified revision.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--glusterfs"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.glusterfs`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--glusterfs"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1993,8 +1993,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--host_path"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.host_path`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--host_path"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -2002,8 +2002,8 @@ Optional:
 - `type` (String) Type for HostPath volume. Allowed values are "" (default), DirectoryOrCreate, Directory, FileOrCreate, File, Socket, CharDevice and BlockDevice
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--iscsi"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.iscsi`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--iscsi"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2018,16 +2018,16 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--local"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.local`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--local"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `path` (String) Path of the directory on the host. More info: https://kubernetes.io/docs/concepts/storage/volumes#local
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--nfs"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.nfs`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--nfs"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2039,8 +2039,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--persistent_volume_claim"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.persistent_volume_claim`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--persistent_volume_claim"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -2048,8 +2048,8 @@ Optional:
 - `read_only` (Boolean) Will force the ReadOnly setting in VolumeMounts.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--photon_persistent_disk"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.photon_persistent_disk`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--photon_persistent_disk"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2060,38 +2060,38 @@ Optional:
 - `fs_type` (String) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--projected"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
-- `sources` (Block List, Min: 1) Source of the volume to project in the directory. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources))
+- `sources` (Block List, Min: 1) Source of the volume to project in the directory. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--sources))
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--sources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--service_account_token))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.config_map`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.config_map.optional`
 
 Optional:
 
@@ -2101,15 +2101,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api.items`
 
 Required:
 
@@ -2117,12 +2117,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--resource_field_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -2130,8 +2130,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api.items.resource_field_ref`
 
 Required:
 
@@ -2145,17 +2145,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.secret`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.secret.optional`
 
 Optional:
 
@@ -2165,8 +2165,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--service_account_token"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.service_account_token`
 
 Required:
 
@@ -2180,8 +2180,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--quobyte"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.quobyte`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--quobyte"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2195,8 +2195,8 @@ Optional:
 - `user` (String) User to map volume access to Defaults to serivceaccount user
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--rbd"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.rbd`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--rbd"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2210,10 +2210,10 @@ Optional:
 - `rados_user` (String) The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 - `rbd_pool` (String) The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it.
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-- `secret_ref` (Block List, Max: 1) Name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--rbd--secret_ref))
+- `secret_ref` (Block List, Max: 1) Name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--rbd--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.rbd.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.secret_ref`
 
 Optional:
 
@@ -2222,18 +2222,18 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--secret"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.secret`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--secret"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items))
 - `optional` (Boolean) Optional: Specify whether the Secret or its keys must be defined.
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.secret.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.secret_name`
 
 Optional:
 
@@ -2243,8 +2243,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--vsphere_volume"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.vsphere_volume`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2259,23 +2259,23 @@ Optional:
 
 
 <a id="nestedblock--spec--job_template--spec--pod_failure_policy"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy`
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished`
 
 Required:
 
-- `rule` (Block List, Min: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--pod_failure_policy--rule))
+- `rule` (Block List, Min: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule))
 
-<a id="nestedblock--spec--job_template--spec--pod_failure_policy--rule"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy.rule`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.rule`
 
 Optional:
 
 - `action` (String)
-- `on_exit_codes` (Block List, Max: 1) (see [below for nested schema](#nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_exit_codes))
-- `on_pod_condition` (Block List) (see [below for nested schema](#nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_pod_condition))
+- `on_exit_codes` (Block List, Max: 1) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_exit_codes))
+- `on_pod_condition` (Block List) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_pod_condition))
 
-<a id="nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_exit_codes"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy.rule.on_exit_codes`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_exit_codes"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.rule.on_pod_condition`
 
 Required:
 
@@ -2287,8 +2287,8 @@ Optional:
 - `operator` (String)
 
 
-<a id="nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_pod_condition"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy.rule.on_pod_condition`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_pod_condition"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.rule.on_pod_condition`
 
 Optional:
 
@@ -2299,15 +2299,15 @@ Optional:
 
 
 <a id="nestedblock--spec--job_template--spec--selector"></a>
-### Nested Schema for `spec.job_template.spec.selector`
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.match_expressions`
 
 Optional:
 
@@ -2368,5 +2368,5 @@ resource "kubernetes_cron_job" "demo" {
 ## Import 
 
 ```
-$ terraform import kubernetes_cron_job_v1/example default/example
+$ terraform import kubernetes_corn_job_v1/example default/example
 ```

--- a/docs/resources/cron_job_v1.md
+++ b/docs/resources/cron_job_v1.md
@@ -106,18 +106,18 @@ Optional:
 - `ttl_seconds_after_finished` (String) ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.
 
 <a id="nestedblock--spec--job_template--spec--template"></a>
-### Nested Schema for `spec.job_template.spec.template`
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished`
 
 Required:
 
-- `metadata` (Block List, Min: 1, Max: 1) Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata (see [below for nested schema](#nestedblock--spec--job_template--spec--template--metadata))
+- `metadata` (Block List, Min: 1, Max: 1) Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--metadata))
 
 Optional:
 
-- `spec` (Block List, Max: 1) Spec of the pods owned by the job (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec))
+- `spec` (Block List, Max: 1) Spec of the pods owned by the job (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec))
 
-<a id="nestedblock--spec--job_template--spec--template--metadata"></a>
-### Nested Schema for `spec.job_template.spec.template.metadata`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--metadata"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.metadata`
 
 Optional:
 
@@ -133,77 +133,77 @@ Read-Only:
 - `uid` (String) The unique in time and space value for this job. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec`
 
 Optional:
 
 - `active_deadline_seconds` (Number) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
-- `affinity` (Block List, Max: 1) Optional pod scheduling constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity))
+- `affinity` (Block List, Max: 1) Optional pod scheduling constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--affinity))
 - `automount_service_account_token` (Boolean) AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
-- `container` (Block List) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container))
-- `dns_config` (Block List, Max: 1) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--dns_config))
+- `container` (Block List) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--container))
+- `dns_config` (Block List, Max: 1) Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--dns_config))
 - `dns_policy` (String) Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Defaults to 'ClusterFirst'. More info: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 - `enable_service_links` (Boolean) Enables generating environment variables for service discovery. Defaults to true.
-- `host_aliases` (Block List) List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--host_aliases))
+- `host_aliases` (Block List) List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Defaults to empty. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--host_aliases))
 - `host_ipc` (Boolean) Use the host's ipc namespace. Optional: Defaults to false.
 - `host_network` (Boolean) Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.
 - `host_pid` (Boolean) Use the host's pid namespace.
 - `hostname` (String) Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
-- `image_pull_secrets` (Block List) ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--image_pull_secrets))
-- `init_container` (Block List) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container))
+- `image_pull_secrets` (Block List) ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--image_pull_secrets))
+- `init_container` (Block List) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--init_container))
 - `node_name` (String) NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
 - `node_selector` (Map of String) NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/.
-- `os` (Block List, Max: 1) Specifies the OS of the containers in the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--os))
+- `os` (Block List, Max: 1) Specifies the OS of the containers in the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--os))
 - `priority_class_name` (String) If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
-- `readiness_gate` (Block List) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--readiness_gate))
+- `readiness_gate` (Block List) If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--readiness_gate))
 - `restart_policy` (String) Restart policy for all containers within the pod. One of Always, OnFailure, Never. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
 - `runtime_class_name` (String) RuntimeClassName is a feature for selecting the container runtime configuration. The container runtime configuration is used to run a Pod's containers. More info: https://kubernetes.io/docs/concepts/containers/runtime-class
 - `scheduler_name` (String) If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
-- `security_context` (Block List, Max: 1) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context))
+- `security_context` (Block List, Max: 1) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--security_context))
 - `service_account_name` (String) ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md.
 - `share_process_namespace` (Boolean) Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Defaults to false.
 - `subdomain` (String) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 - `termination_grace_period_seconds` (Number) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
-- `toleration` (Block List) If specified, the pod's toleration. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--toleration))
-- `topology_spread_constraint` (Block List) describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint))
-- `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume))
+- `toleration` (Block List) If specified, the pod's toleration. Optional: Defaults to empty (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--toleration))
+- `topology_spread_constraint` (Block List) describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--topology_spread_constraint))
+- `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity`
-
-Optional:
-
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity))
-
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity`
+
+Optional:
+
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.preference`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Optional:
 
@@ -212,8 +212,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Required:
 
@@ -227,23 +227,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -252,8 +252,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -268,24 +268,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -293,19 +293,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -317,8 +317,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -326,19 +326,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -350,24 +350,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -375,19 +375,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -399,8 +399,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -408,19 +408,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -433,8 +433,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--container"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
@@ -444,27 +444,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -473,20 +473,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.config_map_key_ref`
 
 Optional:
 
@@ -495,8 +495,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.field_ref`
 
 Optional:
 
@@ -504,8 +504,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.resource_field_ref`
 
 Required:
 
@@ -517,8 +517,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.secret_key_ref`
 
 Optional:
 
@@ -529,17 +529,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -550,8 +550,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -563,44 +563,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -609,8 +609,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -618,36 +618,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -656,8 +656,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -666,31 +666,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -701,19 +701,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -722,8 +722,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -731,8 +731,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.port`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -746,31 +746,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -781,19 +781,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -802,8 +802,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -811,8 +811,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.resources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
@@ -820,23 +820,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -844,8 +844,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -855,8 +855,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -865,31 +865,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -900,19 +900,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -921,8 +921,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -930,8 +930,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -946,17 +946,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.dns_config`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--dns_config"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--option"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.searches`
 
 Required:
 
@@ -968,8 +968,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.host_aliases`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--host_aliases"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
@@ -977,16 +977,16 @@ Required:
 - `ip` (String) IP address of the host file entry.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.image_pull_secrets`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--image_pull_secrets"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--init_container"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
@@ -996,27 +996,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -1025,20 +1025,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.config_map_key_ref`
 
 Optional:
 
@@ -1047,8 +1047,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.field_ref`
 
 Optional:
 
@@ -1056,8 +1056,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.resource_field_ref`
 
 Required:
 
@@ -1069,8 +1069,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.value_from.secret_key_ref`
 
 Optional:
 
@@ -1081,17 +1081,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--env_from"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--config_map_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -1102,8 +1102,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.secret_ref`
 
 Required:
 
@@ -1115,44 +1115,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--post_start"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1161,8 +1161,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -1170,36 +1170,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1208,8 +1208,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.pre_stop.tcp_socket`
 
 Required:
 
@@ -1218,31 +1218,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1253,19 +1253,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -1274,8 +1274,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1283,8 +1283,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.port`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--port"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -1298,31 +1298,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1333,19 +1333,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -1354,8 +1354,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1363,8 +1363,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--resources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
@@ -1372,23 +1372,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--security_context"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--capabilities"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -1396,8 +1396,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--se_linux_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -1407,8 +1407,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--seccomp_profile"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.seccomp_profile`
 
 Optional:
 
@@ -1417,31 +1417,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--exec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--grpc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1452,19 +1452,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--http_get"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds.http_header`
 
 Optional:
 
@@ -1473,8 +1473,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--working_dir--tcp_socket"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir.timeout_seconds`
 
 Required:
 
@@ -1482,8 +1482,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.working_dir`
 
 Required:
 
@@ -1498,24 +1498,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--os"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.os`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--os"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
 - `name` (String) Name is the name of the operating system. The currently supported values are linux and windows.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.readiness_gate`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--readiness_gate"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Required:
 
 - `condition_type` (String) refers to a condition in the pod's condition list with matching type.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--security_context"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
@@ -1524,14 +1524,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--windows_options))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Optional:
 
@@ -1541,8 +1541,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Optional:
 
@@ -1550,8 +1550,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--sysctl"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Required:
 
@@ -1559,8 +1559,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--windows_options"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.windows_options`
 
 Optional:
 
@@ -1571,8 +1571,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.toleration`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--toleration"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
@@ -1583,12 +1583,12 @@ Optional:
 - `value` (String) Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.topology_spread_constraint`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--topology_spread_constraint"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1597,16 +1597,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--label_selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.when_unsatisfiable`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--when_unsatisfiable--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--when_unsatisfiable--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.when_unsatisfiable.match_labels`
 
 Optional:
 
@@ -1617,42 +1617,42 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume`
 
 Optional:
 
-- `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--aws_elastic_block_store))
-- `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_disk))
-- `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_file))
-- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs))
-- `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--cinder))
-- `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--config_map))
-- `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--csi))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api))
-- `empty_dir` (Block List, Max: 1) EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--empty_dir))
-- `ephemeral` (Block List, Max: 1) Represents an ephemeral volume that is handled by a normal storage driver. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral))
-- `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--fc))
-- `flex_volume` (Block List, Max: 1) Represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--flex_volume))
-- `flocker` (Block List, Max: 1) Represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--flocker))
-- `gce_persistent_disk` (Block List, Max: 1) Represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--gce_persistent_disk))
-- `git_repo` (Block List, Max: 1) GitRepo represents a git repository at a particular revision. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--git_repo))
-- `glusterfs` (Block List, Max: 1) Represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--glusterfs))
-- `host_path` (Block List, Max: 1) Represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--host_path))
-- `iscsi` (Block List, Max: 1) Represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--iscsi))
-- `local` (Block List, Max: 1) Represents a mounted local storage device such as a disk, partition or directory. Local volumes can only be used as a statically created PersistentVolume. Dynamic provisioning is not supported yet. More info: https://kubernetes.io/docs/concepts/storage/volumes#local (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--local))
+- `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--aws_elastic_block_store))
+- `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_disk))
+- `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ceph_fs))
+- `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--cinder))
+- `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--config_map))
+- `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--csi))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--downward_api))
+- `empty_dir` (Block List, Max: 1) EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--empty_dir))
+- `ephemeral` (Block List, Max: 1) Represents an ephemeral volume that is handled by a normal storage driver. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ephemeral))
+- `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--fc))
+- `flex_volume` (Block List, Max: 1) Represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flex_volume))
+- `flocker` (Block List, Max: 1) Represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flocker))
+- `gce_persistent_disk` (Block List, Max: 1) Represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--gce_persistent_disk))
+- `git_repo` (Block List, Max: 1) GitRepo represents a git repository at a particular revision. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--git_repo))
+- `glusterfs` (Block List, Max: 1) Represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--glusterfs))
+- `host_path` (Block List, Max: 1) Represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--host_path))
+- `iscsi` (Block List, Max: 1) Represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--iscsi))
+- `local` (Block List, Max: 1) Represents a mounted local storage device such as a disk, partition or directory. Local volumes can only be used as a statically created PersistentVolume. Dynamic provisioning is not supported yet. More info: https://kubernetes.io/docs/concepts/storage/volumes#local (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--local))
 - `name` (String) Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-- `nfs` (Block List, Max: 1) Represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--nfs))
-- `persistent_volume_claim` (Block List, Max: 1) The specification of a persistent volume. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--persistent_volume_claim))
-- `photon_persistent_disk` (Block List, Max: 1) Represents a PhotonController persistent disk attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--photon_persistent_disk))
-- `projected` (Block List) Projected represents a single volume that projects several volume sources into the same directory. More info: https://kubernetes.io/docs/concepts/storage/volumes/#projected (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected))
-- `quobyte` (Block List, Max: 1) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--quobyte))
-- `rbd` (Block List, Max: 1) Represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--rbd))
-- `secret` (Block List, Max: 1) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--secret))
-- `vsphere_volume` (Block List, Max: 1) Represents a vSphere volume attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--vsphere_volume))
+- `nfs` (Block List, Max: 1) Represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--nfs))
+- `persistent_volume_claim` (Block List, Max: 1) The specification of a persistent volume. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--persistent_volume_claim))
+- `photon_persistent_disk` (Block List, Max: 1) Represents a PhotonController persistent disk attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--photon_persistent_disk))
+- `projected` (Block List) Projected represents a single volume that projects several volume sources into the same directory. More info: https://kubernetes.io/docs/concepts/storage/volumes/#projected (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--projected))
+- `quobyte` (Block List, Max: 1) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--quobyte))
+- `rbd` (Block List, Max: 1) Represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--rbd))
+- `secret` (Block List, Max: 1) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--secret))
+- `vsphere_volume` (Block List, Max: 1) Represents a vSphere volume attached and mounted on kubelets host machine (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--aws_elastic_block_store"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.aws_elastic_block_store`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--aws_elastic_block_store"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1665,8 +1665,8 @@ Optional:
 - `read_only` (Boolean) Whether to set the read-only property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--azure_disk"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.azure_disk`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_disk"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1681,8 +1681,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--azure_file"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.azure_file`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--azure_file"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1695,8 +1695,8 @@ Optional:
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1707,11 +1707,11 @@ Optional:
 - `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 - `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
-- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref))
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref))
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.user`
 
 Optional:
 
@@ -1720,8 +1720,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--cinder"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.cinder`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--cinder"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1733,18 +1733,18 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write). More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--config_map"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.config_map`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--config_map"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.config_map.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.optional`
 
 Optional:
 
@@ -1754,8 +1754,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--csi"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.csi`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--csi"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1764,12 +1764,12 @@ Required:
 Optional:
 
 - `fs_type` (String) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-- `node_publish_secret_ref` (Block List, Max: 1) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--csi--node_publish_secret_ref))
+- `node_publish_secret_ref` (Block List, Max: 1) A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--node_publish_secret_ref))
 - `read_only` (Boolean) Whether to set the read-only property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#csi
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.csi.node_publish_secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--node_publish_secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_attributes`
 
 Optional:
 
@@ -1777,29 +1777,29 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--downward_api"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.items`
 
 Required:
 
-- `field_ref` (Block List, Min: 1, Max: 1) Required: Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--field_ref))
+- `field_ref` (Block List, Min: 1, Max: 1) Required: Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--field_ref))
 - `path` (String) Path is the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
 
 Optional:
 
 - `mode` (String) Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--resource_field_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api.items.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.items.field_ref`
 
 Optional:
 
@@ -1807,8 +1807,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.items.resource_field_ref`
 
 Required:
 
@@ -1822,8 +1822,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--empty_dir"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.empty_dir`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--empty_dir"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1831,41 +1831,41 @@ Optional:
 - `size_limit` (String) Total amount of local storage required for this EmptyDir volume.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--ephemeral"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
-- `volume_claim_template` (Block List, Min: 1, Max: 1) Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template))
+- `volume_claim_template` (Block List, Min: 1, Max: 1) Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template`
 
 Required:
 
-- `spec` (Block List, Min: 1, Max: 1) The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec))
+- `spec` (Block List, Min: 1, Max: 1) The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec))
 
 Optional:
 
-- `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
+- `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--metadata))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--resources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec.volume_name`
 
 Optional:
 
@@ -1873,16 +1873,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--selector"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.spec.volume_name.match_labels`
 
 Optional:
 
@@ -1893,8 +1893,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--metadata"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--volume_claim_template--metadata"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.volume_claim_template.metadata`
 
 Optional:
 
@@ -1904,8 +1904,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--fc"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.fc`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--fc"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1918,8 +1918,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--flex_volume"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.flex_volume`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flex_volume"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1930,10 +1930,10 @@ Optional:
 - `fs_type` (String) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 - `options` (Map of String) Extra command options if any.
 - `read_only` (Boolean) Whether to force the ReadOnly setting in VolumeMounts. Defaults to false (read/write).
-- `secret_ref` (Block List, Max: 1) Reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--flex_volume--secret_ref))
+- `secret_ref` (Block List, Max: 1) Reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--flex_volume--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.flex_volume.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.secret_ref`
 
 Optional:
 
@@ -1942,8 +1942,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--flocker"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.flocker`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--flocker"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1951,8 +1951,8 @@ Optional:
 - `dataset_uuid` (String) UUID of the dataset. This is unique identifier of a Flocker dataset
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--gce_persistent_disk"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.gce_persistent_disk`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--gce_persistent_disk"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1965,8 +1965,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--git_repo"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.git_repo`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--git_repo"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1975,8 +1975,8 @@ Optional:
 - `revision` (String) Commit hash for the specified revision.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--glusterfs"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.glusterfs`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--glusterfs"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -1988,8 +1988,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--host_path"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.host_path`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--host_path"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -1997,8 +1997,8 @@ Optional:
 - `type` (String) Type for HostPath volume. Allowed values are "" (default), DirectoryOrCreate, Directory, FileOrCreate, File, Socket, CharDevice and BlockDevice
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--iscsi"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.iscsi`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--iscsi"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2013,16 +2013,16 @@ Optional:
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--local"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.local`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--local"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `path` (String) Path of the directory on the host. More info: https://kubernetes.io/docs/concepts/storage/volumes#local
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--nfs"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.nfs`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--nfs"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2034,8 +2034,8 @@ Optional:
 - `read_only` (Boolean) Whether to force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--persistent_volume_claim"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.persistent_volume_claim`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--persistent_volume_claim"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
@@ -2043,8 +2043,8 @@ Optional:
 - `read_only` (Boolean) Will force the ReadOnly setting in VolumeMounts.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--photon_persistent_disk"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.photon_persistent_disk`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--photon_persistent_disk"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2055,38 +2055,38 @@ Optional:
 - `fs_type` (String) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--projected"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
-- `sources` (Block List, Min: 1) Source of the volume to project in the directory. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources))
+- `sources` (Block List, Min: 1) Source of the volume to project in the directory. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--sources))
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--sources"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--service_account_token))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.config_map`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--config_map--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.config_map.optional`
 
 Optional:
 
@@ -2096,15 +2096,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api.items`
 
 Required:
 
@@ -2112,12 +2112,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--resource_field_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -2125,8 +2125,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--downward_api--items--resource_field_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.downward_api.items.resource_field_ref`
 
 Required:
 
@@ -2140,17 +2140,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.secret`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--secret--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.secret.optional`
 
 Optional:
 
@@ -2160,8 +2160,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--default_mode--service_account_token"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.default_mode.service_account_token`
 
 Required:
 
@@ -2175,8 +2175,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--quobyte"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.quobyte`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--quobyte"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2190,8 +2190,8 @@ Optional:
 - `user` (String) User to map volume access to Defaults to serivceaccount user
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--rbd"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.rbd`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--rbd"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2205,10 +2205,10 @@ Optional:
 - `rados_user` (String) The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 - `rbd_pool` (String) The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it.
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-- `secret_ref` (Block List, Max: 1) Name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--rbd--secret_ref))
+- `secret_ref` (Block List, Max: 1) Name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref))
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--rbd--secret_ref"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.rbd.secret_ref`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.secret_ref`
 
 Optional:
 
@@ -2217,18 +2217,18 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--secret"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.secret`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--secret"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Optional:
 
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items))
 - `optional` (Boolean) Optional: Specify whether the Secret or its keys must be defined.
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.secret.items`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume--items"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume.secret_name`
 
 Optional:
 
@@ -2238,8 +2238,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--job_template--spec--template--spec--volume--vsphere_volume"></a>
-### Nested Schema for `spec.job_template.spec.template.spec.volume.vsphere_volume`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--spec--volume--vsphere_volume"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.spec.volume.vsphere_volume`
 
 Required:
 
@@ -2254,23 +2254,23 @@ Optional:
 
 
 <a id="nestedblock--spec--job_template--spec--pod_failure_policy"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy`
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished`
 
 Required:
 
-- `rule` (Block List, Min: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--pod_failure_policy--rule))
+- `rule` (Block List, Min: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule))
 
-<a id="nestedblock--spec--job_template--spec--pod_failure_policy--rule"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy.rule`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.rule`
 
 Optional:
 
 - `action` (String)
-- `on_exit_codes` (Block List, Max: 1) (see [below for nested schema](#nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_exit_codes))
-- `on_pod_condition` (Block List) (see [below for nested schema](#nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_pod_condition))
+- `on_exit_codes` (Block List, Max: 1) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_exit_codes))
+- `on_pod_condition` (Block List) (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_pod_condition))
 
-<a id="nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_exit_codes"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy.rule.on_exit_codes`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_exit_codes"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.rule.on_pod_condition`
 
 Required:
 
@@ -2282,8 +2282,8 @@ Optional:
 - `operator` (String)
 
 
-<a id="nestedblock--spec--job_template--spec--pod_failure_policy--rule--on_pod_condition"></a>
-### Nested Schema for `spec.job_template.spec.pod_failure_policy.rule.on_pod_condition`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--rule--on_pod_condition"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.rule.on_pod_condition`
 
 Optional:
 
@@ -2294,15 +2294,15 @@ Optional:
 
 
 <a id="nestedblock--spec--job_template--spec--selector"></a>
-### Nested Schema for `spec.job_template.spec.selector`
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--job_template--spec--ttl_seconds_after_finished--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--job_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.job_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--job_template--spec--ttl_seconds_after_finished--match_expressions"></a>
+### Nested Schema for `spec.job_template.spec.ttl_seconds_after_finished.match_expressions`
 
 Optional:
 

--- a/docs/resources/daemon_set_v1.md
+++ b/docs/resources/daemon_set_v1.md
@@ -124,40 +124,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -166,8 +166,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -181,23 +181,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -206,8 +206,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -222,24 +222,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -247,19 +247,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -271,8 +271,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -280,19 +280,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -304,24 +304,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -329,19 +329,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -353,8 +353,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -362,19 +362,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -388,7 +388,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -398,27 +398,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -427,20 +427,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -449,8 +449,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -458,8 +458,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -471,8 +471,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -483,17 +483,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -504,8 +504,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -517,44 +517,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -563,8 +563,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -572,36 +572,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -610,8 +610,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -620,31 +620,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -655,19 +655,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -676,8 +676,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -685,8 +685,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -700,31 +700,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -735,19 +735,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -756,8 +756,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -765,8 +765,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -774,23 +774,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -798,8 +798,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -809,8 +809,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -819,31 +819,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -854,19 +854,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -875,8 +875,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -884,8 +884,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -901,16 +901,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -923,7 +923,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -932,7 +932,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -940,7 +940,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -950,27 +950,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -979,20 +979,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1001,8 +1001,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1010,8 +1010,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1023,8 +1023,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1035,17 +1035,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1056,8 +1056,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1069,44 +1069,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1115,8 +1115,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1124,36 +1124,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1162,8 +1162,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1172,31 +1172,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1207,19 +1207,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1228,8 +1228,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1237,8 +1237,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1252,31 +1252,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1287,19 +1287,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1308,8 +1308,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1317,8 +1317,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1326,23 +1326,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1350,8 +1350,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1361,8 +1361,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1371,31 +1371,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1406,19 +1406,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1427,8 +1427,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1436,8 +1436,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1453,7 +1453,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1461,7 +1461,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1469,7 +1469,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1478,14 +1478,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1495,8 +1495,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1504,8 +1504,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1513,8 +1513,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1526,7 +1526,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1538,11 +1538,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1551,16 +1551,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1665,7 +1665,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1698,7 +1698,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1723,7 +1723,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1753,7 +1753,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1804,22 +1804,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1827,16 +1827,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2021,26 +2021,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2050,15 +2050,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2066,12 +2066,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2079,8 +2079,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2094,17 +2094,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2114,8 +2114,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2182,7 +2182,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/daemonset.md
+++ b/docs/resources/daemonset.md
@@ -124,40 +124,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -166,8 +166,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -181,23 +181,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -206,8 +206,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -222,24 +222,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -247,19 +247,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -271,8 +271,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -280,19 +280,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -304,24 +304,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -329,19 +329,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -353,8 +353,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -362,19 +362,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -388,7 +388,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -398,27 +398,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -427,20 +427,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -449,8 +449,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -458,8 +458,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -471,8 +471,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -483,17 +483,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -504,8 +504,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -517,44 +517,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -563,8 +563,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -572,36 +572,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -610,8 +610,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -620,31 +620,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -655,19 +655,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -676,8 +676,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -685,8 +685,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -700,31 +700,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -735,19 +735,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -756,8 +756,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -765,8 +765,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -774,23 +774,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -798,8 +798,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -809,8 +809,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -819,31 +819,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -854,19 +854,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -875,8 +875,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -884,8 +884,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -901,16 +901,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -923,7 +923,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -932,7 +932,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -940,7 +940,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -950,27 +950,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -979,20 +979,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1001,8 +1001,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1010,8 +1010,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1023,8 +1023,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1035,17 +1035,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1056,8 +1056,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1069,44 +1069,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1115,8 +1115,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1124,36 +1124,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1162,8 +1162,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1172,31 +1172,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1207,19 +1207,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1228,8 +1228,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1237,8 +1237,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1252,31 +1252,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1287,19 +1287,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1308,8 +1308,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1317,8 +1317,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1326,23 +1326,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1350,8 +1350,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1361,8 +1361,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1371,31 +1371,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1406,19 +1406,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1427,8 +1427,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1436,8 +1436,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1453,7 +1453,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1461,7 +1461,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1469,7 +1469,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1478,14 +1478,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1495,8 +1495,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1504,8 +1504,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1513,8 +1513,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1526,7 +1526,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1538,11 +1538,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1551,16 +1551,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1665,7 +1665,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1698,7 +1698,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1723,7 +1723,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1753,7 +1753,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1804,22 +1804,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1827,16 +1827,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2021,26 +2021,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2050,15 +2050,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2066,12 +2066,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2079,8 +2079,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2094,17 +2094,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2114,8 +2114,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2182,7 +2182,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -124,40 +124,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -166,8 +166,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -181,23 +181,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -206,8 +206,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -222,24 +222,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -247,19 +247,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -271,8 +271,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -280,19 +280,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -304,24 +304,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -329,19 +329,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -353,8 +353,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -362,19 +362,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -388,7 +388,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -398,27 +398,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -427,20 +427,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -449,8 +449,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -458,8 +458,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -471,8 +471,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -483,17 +483,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -504,8 +504,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -517,44 +517,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -563,8 +563,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -572,36 +572,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -610,8 +610,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -620,31 +620,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -655,19 +655,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -676,8 +676,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -685,8 +685,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -700,31 +700,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -735,19 +735,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -756,8 +756,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -765,8 +765,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -774,23 +774,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -798,8 +798,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -809,8 +809,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -819,31 +819,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -854,19 +854,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -875,8 +875,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -884,8 +884,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -901,16 +901,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -923,7 +923,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -932,7 +932,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -940,7 +940,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -950,27 +950,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -979,20 +979,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1001,8 +1001,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1010,8 +1010,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1023,8 +1023,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1035,17 +1035,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1056,8 +1056,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1069,44 +1069,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1115,8 +1115,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1124,36 +1124,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1162,8 +1162,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1172,31 +1172,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1207,19 +1207,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1228,8 +1228,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1237,8 +1237,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1252,31 +1252,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1287,19 +1287,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1308,8 +1308,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1317,8 +1317,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1326,23 +1326,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1350,8 +1350,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1361,8 +1361,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1371,31 +1371,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1406,19 +1406,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1427,8 +1427,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1436,8 +1436,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1453,7 +1453,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1461,7 +1461,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1469,7 +1469,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1478,14 +1478,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1495,8 +1495,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1504,8 +1504,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1513,8 +1513,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1526,7 +1526,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1538,11 +1538,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1551,16 +1551,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1665,7 +1665,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1698,7 +1698,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1723,7 +1723,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1753,7 +1753,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1804,22 +1804,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1827,16 +1827,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2021,26 +2021,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2050,15 +2050,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2066,12 +2066,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2079,8 +2079,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2094,17 +2094,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2114,8 +2114,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2182,7 +2182,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/deployment_v1.md
+++ b/docs/resources/deployment_v1.md
@@ -124,40 +124,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -166,8 +166,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -181,23 +181,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -206,8 +206,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -222,24 +222,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -247,19 +247,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -271,8 +271,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -280,19 +280,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -304,24 +304,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -329,19 +329,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -353,8 +353,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -362,19 +362,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -388,7 +388,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -398,27 +398,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -427,20 +427,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -449,8 +449,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -458,8 +458,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -471,8 +471,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -483,17 +483,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -504,8 +504,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -517,44 +517,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -563,8 +563,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -572,36 +572,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -610,8 +610,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -620,31 +620,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -655,19 +655,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -676,8 +676,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -685,8 +685,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -700,31 +700,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -735,19 +735,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -756,8 +756,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -765,8 +765,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -774,23 +774,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -798,8 +798,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -809,8 +809,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -819,31 +819,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -854,19 +854,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -875,8 +875,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -884,8 +884,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -901,16 +901,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -923,7 +923,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -932,7 +932,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -940,7 +940,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -950,27 +950,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -979,20 +979,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1001,8 +1001,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1010,8 +1010,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1023,8 +1023,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1035,17 +1035,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1056,8 +1056,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1069,44 +1069,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1115,8 +1115,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1124,36 +1124,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1162,8 +1162,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1172,31 +1172,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1207,19 +1207,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1228,8 +1228,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1237,8 +1237,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1252,31 +1252,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1287,19 +1287,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1308,8 +1308,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1317,8 +1317,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1326,23 +1326,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1350,8 +1350,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1361,8 +1361,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1371,31 +1371,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1406,19 +1406,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1427,8 +1427,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1436,8 +1436,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1453,7 +1453,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1461,7 +1461,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1469,7 +1469,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1478,14 +1478,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1495,8 +1495,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1504,8 +1504,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1513,8 +1513,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1526,7 +1526,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1538,11 +1538,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1551,16 +1551,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1665,7 +1665,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1698,7 +1698,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1723,7 +1723,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1753,7 +1753,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1804,22 +1804,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1827,16 +1827,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2021,26 +2021,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2050,15 +2050,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2066,12 +2066,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2079,8 +2079,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2094,17 +2094,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2114,8 +2114,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2182,7 +2182,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/horizontal_pod_autoscaler.md
+++ b/docs/resources/horizontal_pod_autoscaler.md
@@ -88,7 +88,7 @@ Optional:
 - `stabilization_window_seconds` (Number) Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 
 <a id="nestedblock--spec--behavior--scale_down--policy"></a>
-### Nested Schema for `spec.behavior.scale_down.policy`
+### Nested Schema for `spec.behavior.scale_down.stabilization_window_seconds`
 
 Required:
 
@@ -111,7 +111,7 @@ Optional:
 - `stabilization_window_seconds` (Number) Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 
 <a id="nestedblock--spec--behavior--scale_up--policy"></a>
-### Nested Schema for `spec.behavior.scale_up.policy`
+### Nested Schema for `spec.behavior.scale_up.stabilization_window_seconds`
 
 Required:
 
@@ -176,7 +176,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--external--target))
 
 <a id="nestedblock--spec--metric--external--metric"></a>
-### Nested Schema for `spec.metric.external.metric`
+### Nested Schema for `spec.metric.external.target`
 
 Required:
 
@@ -184,18 +184,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--external--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--external--target--selector))
 
-<a id="nestedblock--spec--metric--external--metric--selector"></a>
-### Nested Schema for `spec.metric.external.metric.selector`
+<a id="nestedblock--spec--metric--external--target--selector"></a>
+### Nested Schema for `spec.metric.external.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--external--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--external--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--external--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.external.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--external--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.external.target.selector.match_labels`
 
 Optional:
 
@@ -234,7 +234,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--object--target))
 
 <a id="nestedblock--spec--metric--object--described_object"></a>
-### Nested Schema for `spec.metric.object.described_object`
+### Nested Schema for `spec.metric.object.target`
 
 Required:
 
@@ -244,7 +244,7 @@ Required:
 
 
 <a id="nestedblock--spec--metric--object--metric"></a>
-### Nested Schema for `spec.metric.object.metric`
+### Nested Schema for `spec.metric.object.target`
 
 Required:
 
@@ -252,18 +252,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--object--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--object--target--selector))
 
-<a id="nestedblock--spec--metric--object--metric--selector"></a>
-### Nested Schema for `spec.metric.object.metric.selector`
+<a id="nestedblock--spec--metric--object--target--selector"></a>
+### Nested Schema for `spec.metric.object.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--object--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--object--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--object--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.object.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--object--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.object.target.selector.match_labels`
 
 Optional:
 
@@ -301,7 +301,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--pods--target))
 
 <a id="nestedblock--spec--metric--pods--metric"></a>
-### Nested Schema for `spec.metric.pods.metric`
+### Nested Schema for `spec.metric.pods.target`
 
 Required:
 
@@ -309,18 +309,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--pods--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--pods--target--selector))
 
-<a id="nestedblock--spec--metric--pods--metric--selector"></a>
-### Nested Schema for `spec.metric.pods.metric.selector`
+<a id="nestedblock--spec--metric--pods--target--selector"></a>
+### Nested Schema for `spec.metric.pods.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--pods--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--pods--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--pods--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.pods.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--pods--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.pods.target.selector.match_labels`
 
 Optional:
 

--- a/docs/resources/horizontal_pod_autoscaler_v2.md
+++ b/docs/resources/horizontal_pod_autoscaler_v2.md
@@ -88,7 +88,7 @@ Optional:
 - `stabilization_window_seconds` (Number) Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 
 <a id="nestedblock--spec--behavior--scale_down--policy"></a>
-### Nested Schema for `spec.behavior.scale_down.policy`
+### Nested Schema for `spec.behavior.scale_down.stabilization_window_seconds`
 
 Required:
 
@@ -111,7 +111,7 @@ Optional:
 - `stabilization_window_seconds` (Number) Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 
 <a id="nestedblock--spec--behavior--scale_up--policy"></a>
-### Nested Schema for `spec.behavior.scale_up.policy`
+### Nested Schema for `spec.behavior.scale_up.stabilization_window_seconds`
 
 Required:
 
@@ -176,7 +176,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--external--target))
 
 <a id="nestedblock--spec--metric--external--metric"></a>
-### Nested Schema for `spec.metric.external.metric`
+### Nested Schema for `spec.metric.external.target`
 
 Required:
 
@@ -184,18 +184,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--external--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--external--target--selector))
 
-<a id="nestedblock--spec--metric--external--metric--selector"></a>
-### Nested Schema for `spec.metric.external.metric.selector`
+<a id="nestedblock--spec--metric--external--target--selector"></a>
+### Nested Schema for `spec.metric.external.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--external--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--external--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--external--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.external.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--external--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.external.target.selector.match_labels`
 
 Optional:
 
@@ -234,7 +234,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--object--target))
 
 <a id="nestedblock--spec--metric--object--described_object"></a>
-### Nested Schema for `spec.metric.object.described_object`
+### Nested Schema for `spec.metric.object.target`
 
 Required:
 
@@ -244,7 +244,7 @@ Required:
 
 
 <a id="nestedblock--spec--metric--object--metric"></a>
-### Nested Schema for `spec.metric.object.metric`
+### Nested Schema for `spec.metric.object.target`
 
 Required:
 
@@ -252,18 +252,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--object--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--object--target--selector))
 
-<a id="nestedblock--spec--metric--object--metric--selector"></a>
-### Nested Schema for `spec.metric.object.metric.selector`
+<a id="nestedblock--spec--metric--object--target--selector"></a>
+### Nested Schema for `spec.metric.object.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--object--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--object--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--object--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.object.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--object--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.object.target.selector.match_labels`
 
 Optional:
 
@@ -301,7 +301,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--pods--target))
 
 <a id="nestedblock--spec--metric--pods--metric"></a>
-### Nested Schema for `spec.metric.pods.metric`
+### Nested Schema for `spec.metric.pods.target`
 
 Required:
 
@@ -309,18 +309,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--pods--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--pods--target--selector))
 
-<a id="nestedblock--spec--metric--pods--metric--selector"></a>
-### Nested Schema for `spec.metric.pods.metric.selector`
+<a id="nestedblock--spec--metric--pods--target--selector"></a>
+### Nested Schema for `spec.metric.pods.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--pods--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--pods--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--pods--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.pods.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--pods--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.pods.target.selector.match_labels`
 
 Optional:
 

--- a/docs/resources/horizontal_pod_autoscaler_v2beta2.md
+++ b/docs/resources/horizontal_pod_autoscaler_v2beta2.md
@@ -88,7 +88,7 @@ Optional:
 - `stabilization_window_seconds` (Number) Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 
 <a id="nestedblock--spec--behavior--scale_down--policy"></a>
-### Nested Schema for `spec.behavior.scale_down.policy`
+### Nested Schema for `spec.behavior.scale_down.stabilization_window_seconds`
 
 Required:
 
@@ -111,7 +111,7 @@ Optional:
 - `stabilization_window_seconds` (Number) Number of seconds for which past recommendations should be considered while scaling up or scaling down. This value must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 
 <a id="nestedblock--spec--behavior--scale_up--policy"></a>
-### Nested Schema for `spec.behavior.scale_up.policy`
+### Nested Schema for `spec.behavior.scale_up.stabilization_window_seconds`
 
 Required:
 
@@ -176,7 +176,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--external--target))
 
 <a id="nestedblock--spec--metric--external--metric"></a>
-### Nested Schema for `spec.metric.external.metric`
+### Nested Schema for `spec.metric.external.target`
 
 Required:
 
@@ -184,18 +184,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--external--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--external--target--selector))
 
-<a id="nestedblock--spec--metric--external--metric--selector"></a>
-### Nested Schema for `spec.metric.external.metric.selector`
+<a id="nestedblock--spec--metric--external--target--selector"></a>
+### Nested Schema for `spec.metric.external.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--external--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--external--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--external--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.external.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--external--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.external.target.selector.match_labels`
 
 Optional:
 
@@ -234,7 +234,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--object--target))
 
 <a id="nestedblock--spec--metric--object--described_object"></a>
-### Nested Schema for `spec.metric.object.described_object`
+### Nested Schema for `spec.metric.object.target`
 
 Required:
 
@@ -244,7 +244,7 @@ Required:
 
 
 <a id="nestedblock--spec--metric--object--metric"></a>
-### Nested Schema for `spec.metric.object.metric`
+### Nested Schema for `spec.metric.object.target`
 
 Required:
 
@@ -252,18 +252,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--object--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--object--target--selector))
 
-<a id="nestedblock--spec--metric--object--metric--selector"></a>
-### Nested Schema for `spec.metric.object.metric.selector`
+<a id="nestedblock--spec--metric--object--target--selector"></a>
+### Nested Schema for `spec.metric.object.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--object--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--object--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--object--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.object.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--object--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.object.target.selector.match_labels`
 
 Optional:
 
@@ -301,7 +301,7 @@ Optional:
 - `target` (Block List, Max: 1) target specifies the target value for the given metric (see [below for nested schema](#nestedblock--spec--metric--pods--target))
 
 <a id="nestedblock--spec--metric--pods--metric"></a>
-### Nested Schema for `spec.metric.pods.metric`
+### Nested Schema for `spec.metric.pods.target`
 
 Required:
 
@@ -309,18 +309,18 @@ Required:
 
 Optional:
 
-- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--pods--metric--selector))
+- `selector` (Block List) selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics. (see [below for nested schema](#nestedblock--spec--metric--pods--target--selector))
 
-<a id="nestedblock--spec--metric--pods--metric--selector"></a>
-### Nested Schema for `spec.metric.pods.metric.selector`
+<a id="nestedblock--spec--metric--pods--target--selector"></a>
+### Nested Schema for `spec.metric.pods.target.selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--pods--metric--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--metric--pods--target--selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--metric--pods--metric--selector--match_expressions"></a>
-### Nested Schema for `spec.metric.pods.metric.selector.match_expressions`
+<a id="nestedblock--spec--metric--pods--target--selector--match_expressions"></a>
+### Nested Schema for `spec.metric.pods.target.selector.match_labels`
 
 Optional:
 

--- a/docs/resources/ingress_v1.md
+++ b/docs/resources/ingress_v1.md
@@ -142,7 +142,7 @@ Optional:
 - `service` (Block List, Max: 1) (see [below for nested schema](#nestedblock--spec--rule--http--path--backend--service))
 
 <a id="nestedblock--spec--rule--http--path--backend--resource"></a>
-### Nested Schema for `spec.rule.http.path.backend.resource`
+### Nested Schema for `spec.rule.http.path.backend.service`
 
 Required:
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -132,40 +132,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -174,8 +174,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -189,23 +189,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -214,8 +214,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -230,24 +230,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -255,19 +255,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -279,8 +279,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -288,19 +288,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -312,24 +312,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -337,19 +337,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -361,8 +361,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -370,19 +370,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -396,7 +396,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -406,27 +406,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -435,20 +435,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -457,8 +457,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -466,8 +466,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -479,8 +479,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -491,17 +491,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -512,8 +512,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -525,44 +525,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -571,8 +571,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -580,36 +580,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -618,8 +618,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -628,31 +628,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -663,19 +663,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -684,8 +684,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -693,8 +693,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -708,31 +708,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -743,19 +743,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -764,8 +764,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -773,8 +773,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -782,23 +782,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -806,8 +806,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -817,8 +817,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -827,31 +827,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -862,19 +862,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -883,8 +883,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -892,8 +892,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -909,16 +909,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -931,7 +931,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -940,7 +940,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -948,7 +948,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -958,27 +958,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -987,20 +987,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1009,8 +1009,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1018,8 +1018,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1031,8 +1031,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1043,17 +1043,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1064,8 +1064,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1077,44 +1077,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1123,8 +1123,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1132,36 +1132,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1170,8 +1170,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1180,31 +1180,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1215,19 +1215,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1236,8 +1236,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1245,8 +1245,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1260,31 +1260,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1295,19 +1295,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1316,8 +1316,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1325,8 +1325,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1334,23 +1334,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1358,8 +1358,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1369,8 +1369,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1379,31 +1379,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1414,19 +1414,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1435,8 +1435,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1444,8 +1444,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1461,7 +1461,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1469,7 +1469,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1477,7 +1477,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1486,14 +1486,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1503,8 +1503,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1512,8 +1512,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1521,8 +1521,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1534,7 +1534,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1546,11 +1546,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1559,16 +1559,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1673,7 +1673,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1706,7 +1706,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1731,7 +1731,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1761,7 +1761,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1812,22 +1812,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1835,16 +1835,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2029,26 +2029,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2058,15 +2058,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2074,12 +2074,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2087,8 +2087,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2102,17 +2102,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2122,8 +2122,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2190,7 +2190,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 
@@ -2232,7 +2232,7 @@ Optional:
 - `on_pod_condition` (Block List) (see [below for nested schema](#nestedblock--spec--pod_failure_policy--rule--on_pod_condition))
 
 <a id="nestedblock--spec--pod_failure_policy--rule--on_exit_codes"></a>
-### Nested Schema for `spec.pod_failure_policy.rule.on_exit_codes`
+### Nested Schema for `spec.pod_failure_policy.rule.on_pod_condition`
 
 Required:
 

--- a/docs/resources/job_v1.md
+++ b/docs/resources/job_v1.md
@@ -128,40 +128,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -170,8 +170,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -185,23 +185,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -210,8 +210,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -226,24 +226,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -251,19 +251,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -275,8 +275,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -284,19 +284,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -308,24 +308,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -333,19 +333,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -357,8 +357,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -366,19 +366,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -392,7 +392,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -402,27 +402,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -431,20 +431,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -453,8 +453,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -462,8 +462,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -475,8 +475,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -487,17 +487,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -508,8 +508,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -521,44 +521,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -567,8 +567,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -576,36 +576,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -614,8 +614,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -624,31 +624,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -659,19 +659,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -680,8 +680,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -689,8 +689,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -704,31 +704,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -739,19 +739,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -760,8 +760,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -769,8 +769,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -778,23 +778,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -802,8 +802,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -813,8 +813,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -823,31 +823,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -858,19 +858,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -879,8 +879,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -888,8 +888,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -905,16 +905,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -927,7 +927,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -936,7 +936,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -944,7 +944,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -954,27 +954,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -983,20 +983,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1005,8 +1005,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1014,8 +1014,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1027,8 +1027,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1039,17 +1039,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1060,8 +1060,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1073,44 +1073,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1119,8 +1119,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1128,36 +1128,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1166,8 +1166,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1176,31 +1176,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1211,19 +1211,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1232,8 +1232,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1241,8 +1241,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1256,31 +1256,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1291,19 +1291,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1312,8 +1312,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1321,8 +1321,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1330,23 +1330,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1354,8 +1354,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1365,8 +1365,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1375,31 +1375,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1410,19 +1410,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1431,8 +1431,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1440,8 +1440,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1457,7 +1457,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1465,7 +1465,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1473,7 +1473,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1482,14 +1482,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1499,8 +1499,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1508,8 +1508,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1517,8 +1517,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1530,7 +1530,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1542,11 +1542,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1555,16 +1555,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1669,7 +1669,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1702,7 +1702,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1727,7 +1727,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1757,7 +1757,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1808,22 +1808,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1831,16 +1831,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2025,26 +2025,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2054,15 +2054,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2070,12 +2070,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2083,8 +2083,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2098,17 +2098,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2118,8 +2118,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2186,7 +2186,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 
@@ -2228,7 +2228,7 @@ Optional:
 - `on_pod_condition` (Block List) (see [below for nested schema](#nestedblock--spec--pod_failure_policy--rule--on_pod_condition))
 
 <a id="nestedblock--spec--pod_failure_policy--rule--on_exit_codes"></a>
-### Nested Schema for `spec.pod_failure_policy.rule.on_exit_codes`
+### Nested Schema for `spec.pod_failure_policy.rule.on_pod_condition`
 
 Required:
 

--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -85,6 +85,7 @@ Optional:
 
 Optional:
 
+- `end_port` (Number) endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
 - `port` (String) port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 - `protocol` (String) protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
 
@@ -103,7 +104,7 @@ If podSelector is also set, then the NetworkPolicyPeer as a whole selects the po
 If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace. (see [below for nested schema](#nestedblock--spec--egress--to--pod_selector))
 
 <a id="nestedblock--spec--egress--to--ip_block"></a>
-### Nested Schema for `spec.egress.to.ip_block`
+### Nested Schema for `spec.egress.to.pod_selector`
 
 Optional:
 
@@ -112,15 +113,15 @@ Optional:
 
 
 <a id="nestedblock--spec--egress--to--namespace_selector"></a>
-### Nested Schema for `spec.egress.to.namespace_selector`
+### Nested Schema for `spec.egress.to.pod_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--egress--to--namespace_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--egress--to--pod_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--egress--to--namespace_selector--match_expressions"></a>
-### Nested Schema for `spec.egress.to.namespace_selector.match_expressions`
+<a id="nestedblock--spec--egress--to--pod_selector--match_expressions"></a>
+### Nested Schema for `spec.egress.to.pod_selector.match_expressions`
 
 Optional:
 
@@ -173,7 +174,7 @@ If podSelector is also set, then the NetworkPolicyPeer as a whole selects the po
 If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace. (see [below for nested schema](#nestedblock--spec--ingress--from--pod_selector))
 
 <a id="nestedblock--spec--ingress--from--ip_block"></a>
-### Nested Schema for `spec.ingress.from.ip_block`
+### Nested Schema for `spec.ingress.from.pod_selector`
 
 Optional:
 
@@ -182,15 +183,15 @@ Optional:
 
 
 <a id="nestedblock--spec--ingress--from--namespace_selector"></a>
-### Nested Schema for `spec.ingress.from.namespace_selector`
+### Nested Schema for `spec.ingress.from.pod_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--ingress--from--namespace_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--ingress--from--pod_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--ingress--from--namespace_selector--match_expressions"></a>
-### Nested Schema for `spec.ingress.from.namespace_selector.match_expressions`
+<a id="nestedblock--spec--ingress--from--pod_selector--match_expressions"></a>
+### Nested Schema for `spec.ingress.from.pod_selector.match_expressions`
 
 Optional:
 
@@ -225,9 +226,9 @@ Optional:
 
 Optional:
 
+- `end_port` (Number) endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
 - `port` (String) port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 - `protocol` (String) protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
-- `end_port` - (Optional) The end_port indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. Cannot be defined if port is undefined or if port is defined as a named (string) port.
 
 
 

--- a/docs/resources/network_policy_v1.md
+++ b/docs/resources/network_policy_v1.md
@@ -85,6 +85,7 @@ Optional:
 
 Optional:
 
+- `end_port` (Number) endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
 - `port` (String) port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 - `protocol` (String) protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
 
@@ -103,7 +104,7 @@ If podSelector is also set, then the NetworkPolicyPeer as a whole selects the po
 If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace. (see [below for nested schema](#nestedblock--spec--egress--to--pod_selector))
 
 <a id="nestedblock--spec--egress--to--ip_block"></a>
-### Nested Schema for `spec.egress.to.ip_block`
+### Nested Schema for `spec.egress.to.pod_selector`
 
 Optional:
 
@@ -112,15 +113,15 @@ Optional:
 
 
 <a id="nestedblock--spec--egress--to--namespace_selector"></a>
-### Nested Schema for `spec.egress.to.namespace_selector`
+### Nested Schema for `spec.egress.to.pod_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--egress--to--namespace_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--egress--to--pod_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--egress--to--namespace_selector--match_expressions"></a>
-### Nested Schema for `spec.egress.to.namespace_selector.match_expressions`
+<a id="nestedblock--spec--egress--to--pod_selector--match_expressions"></a>
+### Nested Schema for `spec.egress.to.pod_selector.match_expressions`
 
 Optional:
 
@@ -173,7 +174,7 @@ If podSelector is also set, then the NetworkPolicyPeer as a whole selects the po
 If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace. (see [below for nested schema](#nestedblock--spec--ingress--from--pod_selector))
 
 <a id="nestedblock--spec--ingress--from--ip_block"></a>
-### Nested Schema for `spec.ingress.from.ip_block`
+### Nested Schema for `spec.ingress.from.pod_selector`
 
 Optional:
 
@@ -182,15 +183,15 @@ Optional:
 
 
 <a id="nestedblock--spec--ingress--from--namespace_selector"></a>
-### Nested Schema for `spec.ingress.from.namespace_selector`
+### Nested Schema for `spec.ingress.from.pod_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--ingress--from--namespace_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--ingress--from--pod_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--ingress--from--namespace_selector--match_expressions"></a>
-### Nested Schema for `spec.ingress.from.namespace_selector.match_expressions`
+<a id="nestedblock--spec--ingress--from--pod_selector--match_expressions"></a>
+### Nested Schema for `spec.ingress.from.pod_selector.match_expressions`
 
 Optional:
 
@@ -225,9 +226,9 @@ Optional:
 
 Optional:
 
+- `end_port` (Number) endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
 - `port` (String) port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 - `protocol` (String) protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
-- `end_port` - (Optional) The end_port indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. Cannot be defined if port is undefined or if port is defined as a named (string) port.
 
 
 
@@ -287,7 +288,6 @@ resource "kubernetes_network_policy_v1" "example" {
   }
 }
 ```
-
 
 ## Import
 

--- a/docs/resources/persistent_volume.md
+++ b/docs/resources/persistent_volume.md
@@ -144,7 +144,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.ceph_fs.secret_ref`
+### Nested Schema for `spec.persistent_volume_source.ceph_fs.user`
 
 Optional:
 
@@ -185,7 +185,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--persistent_volume_source--csi--controller_expand_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.controller_expand_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -194,7 +194,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--controller_publish_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.controller_publish_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -203,7 +203,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.node_publish_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -212,7 +212,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--node_stage_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.node_stage_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 

--- a/docs/resources/persistent_volume_v1.md
+++ b/docs/resources/persistent_volume_v1.md
@@ -144,7 +144,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.ceph_fs.secret_ref`
+### Nested Schema for `spec.persistent_volume_source.ceph_fs.user`
 
 Optional:
 
@@ -185,7 +185,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--persistent_volume_source--csi--controller_expand_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.controller_expand_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -194,7 +194,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--controller_publish_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.controller_publish_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -203,7 +203,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.node_publish_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 
@@ -212,7 +212,7 @@ Optional:
 
 
 <a id="nestedblock--spec--persistent_volume_source--csi--node_stage_secret_ref"></a>
-### Nested Schema for `spec.persistent_volume_source.csi.node_stage_secret_ref`
+### Nested Schema for `spec.persistent_volume_source.csi.volume_attributes`
 
 Optional:
 

--- a/docs/resources/pod.md
+++ b/docs/resources/pod.md
@@ -100,23 +100,23 @@ Optional:
 - `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields))
 
-<a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Optional:
 
@@ -125,8 +125,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Required:
 
@@ -156,7 +156,7 @@ Optional:
 - `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
 <a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -190,15 +190,15 @@ Optional:
 - `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -206,19 +206,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -251,7 +251,7 @@ Optional:
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
 <a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -272,15 +272,15 @@ Optional:
 - `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -288,19 +288,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -333,7 +333,7 @@ Optional:
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
 <a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -452,7 +452,7 @@ Optional:
 - `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--container--env_from--secret_ref))
 
 <a id="nestedblock--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.container.env_from.config_map_ref`
+### Nested Schema for `spec.container.env_from.secret_ref`
 
 Required:
 
@@ -485,35 +485,35 @@ Optional:
 - `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop))
 
 <a id="nestedblock--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.container.lifecycle.post_start`
+### Nested Schema for `spec.container.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -522,8 +522,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -560,7 +560,7 @@ Optional:
 - `scheme` (String) Scheme to use for connecting to the host.
 
 <a id="nestedblock--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -595,7 +595,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.container.liveness_probe.exec`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Optional:
 
@@ -603,7 +603,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.container.liveness_probe.grpc`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -615,18 +615,18 @@ Optional:
 
 
 <a id="nestedblock--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -636,7 +636,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -675,7 +675,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.container.readiness_probe.exec`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Optional:
 
@@ -683,7 +683,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.container.readiness_probe.grpc`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -695,18 +695,18 @@ Optional:
 
 
 <a id="nestedblock--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -716,7 +716,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -749,7 +749,7 @@ Optional:
 - `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--container--security_context--seccomp_profile))
 
 <a id="nestedblock--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.container.security_context.capabilities`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Optional:
 
@@ -758,7 +758,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.container.security_context.se_linux_options`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Optional:
 
@@ -794,7 +794,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.container.startup_probe.exec`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Optional:
 
@@ -802,7 +802,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.container.startup_probe.grpc`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -814,18 +814,18 @@ Optional:
 
 
 <a id="nestedblock--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.container.startup_probe.http_get`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.startup_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -835,7 +835,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.startup_probe.tcp_socket`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1004,7 +1004,7 @@ Optional:
 - `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--init_container--env_from--secret_ref))
 
 <a id="nestedblock--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.init_container.env_from.config_map_ref`
+### Nested Schema for `spec.init_container.env_from.secret_ref`
 
 Required:
 
@@ -1037,35 +1037,35 @@ Optional:
 - `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop))
 
 <a id="nestedblock--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1074,8 +1074,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1112,7 +1112,7 @@ Optional:
 - `scheme` (String) Scheme to use for connecting to the host.
 
 <a id="nestedblock--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1147,7 +1147,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.init_container.liveness_probe.exec`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Optional:
 
@@ -1155,7 +1155,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.liveness_probe.grpc`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1167,18 +1167,18 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--init_container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -1188,7 +1188,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1227,7 +1227,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.init_container.readiness_probe.exec`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Optional:
 
@@ -1235,7 +1235,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.readiness_probe.grpc`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1247,18 +1247,18 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--init_container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -1268,7 +1268,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1301,7 +1301,7 @@ Optional:
 - `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--init_container--security_context--seccomp_profile))
 
 <a id="nestedblock--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.init_container.security_context.capabilities`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Optional:
 
@@ -1310,7 +1310,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.init_container.security_context.se_linux_options`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Optional:
 
@@ -1346,7 +1346,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.init_container.startup_probe.exec`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Optional:
 
@@ -1354,7 +1354,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.init_container.startup_probe.grpc`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1366,18 +1366,18 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--init_container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -1387,7 +1387,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.startup_probe.tcp_socket`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1519,7 +1519,7 @@ Optional:
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
 <a id="nestedblock--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.topology_spread_constraint.label_selector.match_expressions`
+### Nested Schema for `spec.topology_spread_constraint.label_selector.match_labels`
 
 Optional:
 
@@ -1624,7 +1624,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1657,7 +1657,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.volume.config_map.items`
+### Nested Schema for `spec.volume.config_map.optional`
 
 Optional:
 
@@ -1682,7 +1682,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1778,7 +1778,7 @@ Optional:
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
 <a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.resources`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Optional:
 
@@ -1787,15 +1787,15 @@ Optional:
 
 
 <a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name.match_labels`
 
 Optional:
 
@@ -1980,26 +1980,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.volume.projected.sources`
+### Nested Schema for `spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.volume.projected.default_mode.config_map`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--config_map--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--volume--projected--default_mode--config_map--items"></a>
+### Nested Schema for `spec.volume.projected.default_mode.config_map.optional`
 
 Optional:
 
@@ -2009,15 +2009,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api--items))
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api--items"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api.items`
 
 Required:
 
@@ -2025,12 +2025,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api--items--resource_field_ref))
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api--items--field_ref"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -2038,8 +2038,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api--items--resource_field_ref"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api.items.resource_field_ref`
 
 Required:
 
@@ -2053,17 +2053,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.volume.projected.default_mode.secret`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--secret--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--volume--projected--default_mode--secret--items"></a>
+### Nested Schema for `spec.volume.projected.default_mode.secret.optional`
 
 Optional:
 
@@ -2073,8 +2073,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2141,7 +2141,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--volume--secret--items"></a>
-### Nested Schema for `spec.volume.secret.items`
+### Nested Schema for `spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/pod_v1.md
+++ b/docs/resources/pod_v1.md
@@ -98,23 +98,23 @@ Optional:
 - `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields))
 
-<a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Optional:
 
@@ -123,8 +123,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--preference--match_fields"></a>
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.preference.match_fields`
 
 Required:
 
@@ -154,7 +154,7 @@ Optional:
 - `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
 <a id="nestedblock--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+### Nested Schema for `spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -188,15 +188,15 @@ Optional:
 - `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -204,19 +204,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -249,7 +249,7 @@ Optional:
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
 <a id="nestedblock--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -270,15 +270,15 @@ Optional:
 - `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
 <a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term`
 
 Required:
 
@@ -286,19 +286,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term--namespaces--match_expressions"></a>
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.pod_affinity_term.namespaces.match_labels`
 
 Optional:
 
@@ -331,7 +331,7 @@ Optional:
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
 <a id="nestedblock--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+### Nested Schema for `spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_labels`
 
 Optional:
 
@@ -450,7 +450,7 @@ Optional:
 - `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--container--env_from--secret_ref))
 
 <a id="nestedblock--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.container.env_from.config_map_ref`
+### Nested Schema for `spec.container.env_from.secret_ref`
 
 Required:
 
@@ -483,35 +483,35 @@ Optional:
 - `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop))
 
 <a id="nestedblock--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.container.lifecycle.post_start`
+### Nested Schema for `spec.container.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -520,8 +520,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.container.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -558,7 +558,7 @@ Optional:
 - `scheme` (String) Scheme to use for connecting to the host.
 
 <a id="nestedblock--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -593,7 +593,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.container.liveness_probe.exec`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Optional:
 
@@ -601,7 +601,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.container.liveness_probe.grpc`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -613,18 +613,18 @@ Optional:
 
 
 <a id="nestedblock--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -634,7 +634,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -673,7 +673,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.container.readiness_probe.exec`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Optional:
 
@@ -681,7 +681,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.container.readiness_probe.grpc`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -693,18 +693,18 @@ Optional:
 
 
 <a id="nestedblock--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -714,7 +714,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -747,7 +747,7 @@ Optional:
 - `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--container--security_context--seccomp_profile))
 
 <a id="nestedblock--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.container.security_context.capabilities`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Optional:
 
@@ -756,7 +756,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.container.security_context.se_linux_options`
+### Nested Schema for `spec.container.security_context.seccomp_profile`
 
 Optional:
 
@@ -792,7 +792,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.container.startup_probe.exec`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Optional:
 
@@ -800,7 +800,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.container.startup_probe.grpc`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -812,18 +812,18 @@ Optional:
 
 
 <a id="nestedblock--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.container.startup_probe.http_get`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--container--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.container.startup_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -833,7 +833,7 @@ Optional:
 
 
 <a id="nestedblock--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.container.startup_probe.tcp_socket`
+### Nested Schema for `spec.container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1002,7 +1002,7 @@ Optional:
 - `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--init_container--env_from--secret_ref))
 
 <a id="nestedblock--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.init_container.env_from.config_map_ref`
+### Nested Schema for `spec.init_container.env_from.secret_ref`
 
 Required:
 
@@ -1035,35 +1035,35 @@ Optional:
 - `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop))
 
 <a id="nestedblock--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.exec`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--lifecycle--pre_stop--http_get--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1072,8 +1072,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1110,7 +1110,7 @@ Optional:
 - `scheme` (String) Scheme to use for connecting to the host.
 
 <a id="nestedblock--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.http_header`
+### Nested Schema for `spec.init_container.lifecycle.pre_stop.http_get.scheme`
 
 Optional:
 
@@ -1145,7 +1145,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.init_container.liveness_probe.exec`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Optional:
 
@@ -1153,7 +1153,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.liveness_probe.grpc`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1165,18 +1165,18 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--init_container--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -1186,7 +1186,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.liveness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1225,7 +1225,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.init_container.readiness_probe.exec`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Optional:
 
@@ -1233,7 +1233,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.init_container.readiness_probe.grpc`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1245,18 +1245,18 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--init_container--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -1266,7 +1266,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.readiness_probe.tcp_socket`
+### Nested Schema for `spec.init_container.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1299,7 +1299,7 @@ Optional:
 - `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--init_container--security_context--seccomp_profile))
 
 <a id="nestedblock--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.init_container.security_context.capabilities`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Optional:
 
@@ -1308,7 +1308,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.init_container.security_context.se_linux_options`
+### Nested Schema for `spec.init_container.security_context.seccomp_profile`
 
 Optional:
 
@@ -1344,7 +1344,7 @@ Optional:
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 <a id="nestedblock--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.init_container.startup_probe.exec`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Optional:
 
@@ -1352,7 +1352,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.init_container.startup_probe.grpc`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1364,18 +1364,18 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--init_container--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--init_container--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds.http_header`
 
 Optional:
 
@@ -1385,7 +1385,7 @@ Optional:
 
 
 <a id="nestedblock--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.init_container.startup_probe.tcp_socket`
+### Nested Schema for `spec.init_container.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1517,7 +1517,7 @@ Optional:
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
 <a id="nestedblock--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.topology_spread_constraint.label_selector.match_expressions`
+### Nested Schema for `spec.topology_spread_constraint.label_selector.match_labels`
 
 Optional:
 
@@ -1622,7 +1622,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1655,7 +1655,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.volume.config_map.items`
+### Nested Schema for `spec.volume.config_map.optional`
 
 Optional:
 
@@ -1680,7 +1680,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1776,7 +1776,7 @@ Optional:
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
 <a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.resources`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Optional:
 
@@ -1785,15 +1785,15 @@ Optional:
 
 
 <a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector`
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.volume_name.match_labels`
 
 Optional:
 
@@ -1978,26 +1978,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.volume.projected.sources`
+### Nested Schema for `spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.volume.projected.default_mode.config_map`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--config_map--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--volume--projected--default_mode--config_map--items"></a>
+### Nested Schema for `spec.volume.projected.default_mode.config_map.optional`
 
 Optional:
 
@@ -2007,15 +2007,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api--items))
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api--items"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api.items`
 
 Required:
 
@@ -2023,12 +2023,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--downward_api--items--resource_field_ref))
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api--items--field_ref"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -2036,8 +2036,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--volume--projected--default_mode--downward_api--items--resource_field_ref"></a>
+### Nested Schema for `spec.volume.projected.default_mode.downward_api.items.resource_field_ref`
 
 Required:
 
@@ -2051,17 +2051,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.volume.projected.default_mode.secret`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--volume--projected--default_mode--secret--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--volume--projected--default_mode--secret--items"></a>
+### Nested Schema for `spec.volume.projected.default_mode.secret.optional`
 
 Optional:
 
@@ -2071,8 +2071,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2139,7 +2139,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--volume--secret--items"></a>
-### Nested Schema for `spec.volume.secret.items`
+### Nested Schema for `spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/replication_controller.md
+++ b/docs/resources/replication_controller.md
@@ -121,40 +121,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -163,8 +163,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -178,23 +178,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -203,8 +203,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -219,24 +219,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -244,19 +244,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -268,8 +268,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -277,19 +277,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -301,24 +301,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -326,19 +326,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -350,8 +350,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -359,19 +359,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -385,7 +385,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -395,27 +395,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -424,20 +424,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -446,8 +446,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -455,8 +455,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -468,8 +468,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -480,17 +480,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -501,8 +501,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -514,44 +514,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -560,8 +560,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -569,36 +569,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -607,8 +607,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -617,31 +617,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -652,19 +652,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -673,8 +673,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -682,8 +682,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -697,31 +697,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -732,19 +732,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -753,8 +753,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -762,8 +762,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -771,23 +771,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -795,8 +795,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -806,8 +806,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -816,31 +816,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -851,19 +851,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -872,8 +872,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -881,8 +881,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -898,16 +898,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -920,7 +920,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -929,7 +929,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -937,7 +937,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -947,27 +947,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -976,20 +976,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -998,8 +998,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1007,8 +1007,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1020,8 +1020,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1032,17 +1032,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1053,8 +1053,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1066,44 +1066,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1112,8 +1112,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1121,36 +1121,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1159,8 +1159,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1169,31 +1169,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1204,19 +1204,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1225,8 +1225,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1234,8 +1234,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1249,31 +1249,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1284,19 +1284,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1305,8 +1305,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1314,8 +1314,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1323,23 +1323,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1347,8 +1347,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1358,8 +1358,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1368,31 +1368,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1403,19 +1403,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1424,8 +1424,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1433,8 +1433,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1450,7 +1450,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1458,7 +1458,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1466,7 +1466,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1475,14 +1475,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1492,8 +1492,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1501,8 +1501,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1510,8 +1510,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1523,7 +1523,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1535,11 +1535,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1548,16 +1548,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1662,7 +1662,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1695,7 +1695,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1720,7 +1720,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1750,7 +1750,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1801,22 +1801,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1824,16 +1824,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2018,26 +2018,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2047,15 +2047,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2063,12 +2063,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2076,8 +2076,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2091,17 +2091,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2111,8 +2111,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2179,7 +2179,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/replication_controller_v1.md
+++ b/docs/resources/replication_controller_v1.md
@@ -119,40 +119,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -161,8 +161,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -176,23 +176,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -201,8 +201,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -217,24 +217,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -242,19 +242,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -266,8 +266,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -275,19 +275,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -299,24 +299,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -324,19 +324,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -348,8 +348,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -357,19 +357,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -383,7 +383,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -393,27 +393,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -422,20 +422,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -444,8 +444,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -453,8 +453,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -466,8 +466,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -478,17 +478,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -499,8 +499,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -512,44 +512,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -558,8 +558,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -567,36 +567,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -605,8 +605,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -615,31 +615,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -650,19 +650,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -671,8 +671,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -680,8 +680,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -695,31 +695,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -730,19 +730,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -751,8 +751,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -760,8 +760,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -769,23 +769,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -793,8 +793,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -804,8 +804,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -814,31 +814,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -849,19 +849,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -870,8 +870,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -879,8 +879,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -896,16 +896,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -918,7 +918,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -927,7 +927,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -935,7 +935,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -945,27 +945,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -974,20 +974,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -996,8 +996,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1005,8 +1005,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1018,8 +1018,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1030,17 +1030,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1051,8 +1051,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1064,44 +1064,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1110,8 +1110,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1119,36 +1119,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1157,8 +1157,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1167,31 +1167,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1202,19 +1202,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1223,8 +1223,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1232,8 +1232,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1247,31 +1247,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1282,19 +1282,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1303,8 +1303,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1312,8 +1312,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1321,23 +1321,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1345,8 +1345,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1356,8 +1356,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1366,31 +1366,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1401,19 +1401,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1422,8 +1422,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1431,8 +1431,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1448,7 +1448,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1456,7 +1456,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1464,7 +1464,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1473,14 +1473,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1490,8 +1490,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1499,8 +1499,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1508,8 +1508,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1521,7 +1521,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1533,11 +1533,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1546,16 +1546,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1660,7 +1660,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1693,7 +1693,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1718,7 +1718,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1748,7 +1748,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1799,22 +1799,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1822,16 +1822,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2016,26 +2016,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2045,15 +2045,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2061,12 +2061,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2074,8 +2074,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2089,17 +2089,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2109,8 +2109,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2177,7 +2177,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 

--- a/docs/resources/stateful_set.md
+++ b/docs/resources/stateful_set.md
@@ -151,40 +151,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -193,8 +193,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -208,23 +208,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -233,8 +233,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -249,24 +249,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -274,19 +274,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -298,8 +298,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -307,19 +307,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -331,24 +331,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -356,19 +356,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -380,8 +380,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -389,19 +389,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -415,7 +415,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -425,27 +425,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -454,20 +454,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -476,8 +476,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -485,8 +485,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -498,8 +498,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -510,17 +510,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -531,8 +531,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -544,44 +544,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -590,8 +590,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -599,36 +599,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -637,8 +637,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -647,31 +647,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -682,19 +682,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -703,8 +703,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -712,8 +712,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -727,31 +727,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -762,19 +762,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -783,8 +783,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -792,8 +792,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -801,23 +801,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -825,8 +825,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -836,8 +836,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -846,31 +846,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -881,19 +881,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -902,8 +902,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -911,8 +911,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -928,16 +928,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -950,7 +950,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -959,7 +959,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -967,7 +967,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -977,27 +977,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -1006,20 +1006,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1028,8 +1028,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1037,8 +1037,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1050,8 +1050,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1062,17 +1062,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1083,8 +1083,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1096,44 +1096,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1142,8 +1142,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1151,36 +1151,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1189,8 +1189,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1199,31 +1199,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1234,19 +1234,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1255,8 +1255,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1264,8 +1264,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1279,31 +1279,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1314,19 +1314,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1335,8 +1335,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1344,8 +1344,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1353,23 +1353,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1377,8 +1377,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1388,8 +1388,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1398,31 +1398,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1433,19 +1433,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1454,8 +1454,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1463,8 +1463,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1480,7 +1480,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1488,7 +1488,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1496,7 +1496,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1505,14 +1505,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1522,8 +1522,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1531,8 +1531,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1540,8 +1540,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1553,7 +1553,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1565,11 +1565,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1578,16 +1578,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1692,7 +1692,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1725,7 +1725,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1750,7 +1750,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1780,7 +1780,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1831,22 +1831,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1854,16 +1854,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2048,26 +2048,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2077,15 +2077,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2093,12 +2093,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2106,8 +2106,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2121,17 +2121,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2141,8 +2141,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2209,7 +2209,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 
@@ -2302,7 +2302,7 @@ Optional:
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
 <a id="nestedblock--spec--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.volume_claim_template.spec.resources`
+### Nested Schema for `spec.volume_claim_template.spec.volume_name`
 
 Optional:
 
@@ -2311,15 +2311,15 @@ Optional:
 
 
 <a id="nestedblock--spec--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.volume_claim_template.spec.selector`
+### Nested Schema for `spec.volume_claim_template.spec.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.volume_claim_template.spec.volume_name.match_expressions`
 
 Optional:
 

--- a/docs/resources/stateful_set_v1.md
+++ b/docs/resources/stateful_set_v1.md
@@ -147,40 +147,40 @@ Optional:
 - `volume` (Block List) List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes (see [below for nested schema](#nestedblock--spec--template--spec--volume))
 
 <a id="nestedblock--spec--template--spec--affinity"></a>
-### Nested Schema for `spec.template.spec.affinity`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity))
-- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity))
-- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity))
+- `node_affinity` (Block List, Max: 1) Node affinity scheduling rules for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity))
+- `pod_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity))
+- `pod_anti_affinity` (Block List, Max: 1) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity`
+<a id="nestedblock--spec--template--spec--volume--node_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List, Max: 1) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference))
+- `preference` (Block List, Min: 1, Max: 1) A node selector term, associated with the corresponding weight. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference))
 - `weight` (Number) weight is in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--preference"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Optional:
 
@@ -189,8 +189,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--preferred_during_scheduling_ignored_during_execution--preference--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.preference.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--weight--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.weight.match_fields`
 
 Required:
 
@@ -204,23 +204,23 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution`
 
 Optional:
 
-- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
+- `node_selector_term` (Block List) List of node selector terms. The terms are ORed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term`
 
 Optional:
 
-- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
-- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
+- `match_expressions` (Block List) List of node selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions))
+- `match_fields` (Block List) A list of node selector requirements by node's fields. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields))
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Optional:
 
@@ -229,8 +229,8 @@ Optional:
 - `values` (Set of String) Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 
-<a id="nestedblock--spec--template--spec--affinity--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
-### Nested Schema for `spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
+<a id="nestedblock--spec--template--spec--volume--node_affinity--required_during_scheduling_ignored_during_execution--node_selector_term--match_fields"></a>
+### Nested Schema for `spec.template.spec.volume.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_fields`
 
 Required:
 
@@ -245,24 +245,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -270,19 +270,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -294,8 +294,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -303,19 +303,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -327,24 +327,24 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity`
 
 Optional:
 
-- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
-- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
+- `preferred_during_scheduling_ignored_during_execution` (Block List) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution))
+- `required_during_scheduling_ignored_during_execution` (Block List) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution))
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
-- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term))
+- `pod_affinity_term` (Block List, Min: 1, Max: 1) A pod affinity term, associated with the corresponding weight (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term))
 - `weight` (Number) weight associated with matching the corresponding podAffinityTerm, in the range 1-100
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--pod_affinity_term"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight`
 
 Required:
 
@@ -352,19 +352,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--preferred_during_scheduling_ignored_during_execution--pod_affinity_term--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--weight--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.weight.namespaces.match_expressions`
 
 Optional:
 
@@ -376,8 +376,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution`
 
 Required:
 
@@ -385,19 +385,19 @@ Required:
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector))
 - `namespaces` (Set of String) namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--affinity--pod_anti_affinity--required_during_scheduling_ignored_during_execution--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--pod_anti_affinity--required_during_scheduling_ignored_during_execution--namespaces--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.pod_anti_affinity.required_during_scheduling_ignored_during_execution.namespaces.match_labels`
 
 Optional:
 
@@ -411,7 +411,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--container"></a>
-### Nested Schema for `spec.template.spec.container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -421,27 +421,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--container--env"></a>
-### Nested Schema for `spec.template.spec.container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -450,20 +450,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -472,8 +472,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -481,8 +481,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -494,8 +494,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -506,17 +506,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--env_from"></a>
-### Nested Schema for `spec.template.spec.container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -527,8 +527,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -540,44 +540,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -586,8 +586,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -595,36 +595,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -633,8 +633,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -643,31 +643,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -678,19 +678,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -699,8 +699,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -708,8 +708,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--port"></a>
-### Nested Schema for `spec.template.spec.container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -723,31 +723,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -758,19 +758,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -779,8 +779,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -788,8 +788,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--resources"></a>
-### Nested Schema for `spec.template.spec.container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -797,23 +797,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--container--security_context"></a>
-### Nested Schema for `spec.template.spec.container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -821,8 +821,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -832,8 +832,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -842,31 +842,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -877,19 +877,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -898,8 +898,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -907,8 +907,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -924,16 +924,16 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
-### Nested Schema for `spec.template.spec.dns_config`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
 - `nameservers` (List of String) A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--dns_config--option))
+- `option` (Block List) A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy. (see [below for nested schema](#nestedblock--spec--template--spec--volume--option))
 - `searches` (List of String) A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
 
-<a id="nestedblock--spec--template--spec--dns_config--option"></a>
-### Nested Schema for `spec.template.spec.dns_config.option`
+<a id="nestedblock--spec--template--spec--volume--option"></a>
+### Nested Schema for `spec.template.spec.volume.option`
 
 Required:
 
@@ -946,7 +946,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--host_aliases"></a>
-### Nested Schema for `spec.template.spec.host_aliases`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -955,7 +955,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--image_pull_secrets"></a>
-### Nested Schema for `spec.template.spec.image_pull_secrets`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -963,7 +963,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--init_container"></a>
-### Nested Schema for `spec.template.spec.init_container`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -973,27 +973,27 @@ Optional:
 
 - `args` (List of String) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 - `command` (List of String) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
-- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env))
-- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from))
+- `env` (Block List) List of environment variables to set in the container. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env))
+- `env_from` (Block List) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from))
 - `image` (String) Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images/
 - `image_pull_policy` (String) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle))
-- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe))
-- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--port))
-- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe))
-- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--init_container--resources))
-- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context))
-- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe))
+- `lifecycle` (Block List, Max: 1) Actions that the management system should take in response to container lifecycle events (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle))
+- `liveness_probe` (Block List, Max: 1) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe))
+- `port` (Block List) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--port))
+- `readiness_probe` (Block List, Max: 1) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe))
+- `resources` (Block List, Max: 1) Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--resources))
+- `security_context` (Block List, Max: 1) Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context))
+- `startup_probe` (Block List, Max: 1) StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe))
 - `stdin` (Boolean) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
 - `stdin_once` (Boolean) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
 - `termination_message_path` (String) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
-- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--volume--volume_mount))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
-<a id="nestedblock--spec--template--spec--init_container--env"></a>
-### Nested Schema for `spec.template.spec.init_container.env`
+<a id="nestedblock--spec--template--spec--volume--env"></a>
+### Nested Schema for `spec.template.spec.volume.env`
 
 Required:
 
@@ -1002,20 +1002,20 @@ Required:
 Optional:
 
 - `value` (String) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from))
+- `value_from` (Block List, Max: 1) Source for the environment variable's value (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from`
+<a id="nestedblock--spec--template--spec--volume--env--value_from"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from`
 
 Optional:
 
-- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref))
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--field_ref))
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref))
-- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref))
+- `config_map_key_ref` (Block List, Max: 1) Selects a key of a ConfigMap. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref))
+- `secret_key_ref` (Block List, Max: 1) Selects a key of a secret in the pod's namespace. (see [below for nested schema](#nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--config_map_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.config_map_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--config_map_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1024,8 +1024,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap or its key must be defined.
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1033,8 +1033,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Required:
 
@@ -1046,8 +1046,8 @@ Optional:
 - `divisor` (String)
 
 
-<a id="nestedblock--spec--template--spec--init_container--env--value_from--secret_key_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env.value_from.secret_key_ref`
+<a id="nestedblock--spec--template--spec--volume--env--value_from--secret_key_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env.value_from.secret_key_ref`
 
 Optional:
 
@@ -1058,17 +1058,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from`
+<a id="nestedblock--spec--template--spec--volume--env_from"></a>
+### Nested Schema for `spec.template.spec.volume.env_from`
 
 Optional:
 
-- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--config_map_ref))
+- `config_map_ref` (Block List, Max: 1) The ConfigMap to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--config_map_ref))
 - `prefix` (String) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
-- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--init_container--env_from--secret_ref))
+- `secret_ref` (Block List, Max: 1) The Secret to select from (see [below for nested schema](#nestedblock--spec--template--spec--volume--env_from--secret_ref))
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--config_map_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.config_map_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--config_map_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1079,8 +1079,8 @@ Optional:
 - `optional` (Boolean) Specify whether the ConfigMap must be defined
 
 
-<a id="nestedblock--spec--template--spec--init_container--env_from--secret_ref"></a>
-### Nested Schema for `spec.template.spec.init_container.env_from.secret_ref`
+<a id="nestedblock--spec--template--spec--volume--env_from--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.env_from.secret_ref`
 
 Required:
 
@@ -1092,44 +1092,44 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle`
+<a id="nestedblock--spec--template--spec--volume--lifecycle"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle`
 
 Optional:
 
-- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start))
-- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop))
+- `post_start` (Block List) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--post_start))
+- `pre_stop` (Block List) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--post_start"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1138,8 +1138,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--post_start--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.post_start.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1147,36 +1147,36 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get))
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket))
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.exec`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--exec"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket.scheme`
 
 Optional:
 
@@ -1185,8 +1185,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--lifecycle--pre_stop--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.lifecycle.pre_stop.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--lifecycle--pre_stop--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.lifecycle.pre_stop.tcp_socket`
 
 Required:
 
@@ -1195,31 +1195,31 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1230,19 +1230,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1251,8 +1251,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--liveness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.liveness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--liveness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.liveness_probe.timeout_seconds`
 
 Required:
 
@@ -1260,8 +1260,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--port"></a>
-### Nested Schema for `spec.template.spec.init_container.port`
+<a id="nestedblock--spec--template--spec--volume--port"></a>
+### Nested Schema for `spec.template.spec.volume.port`
 
 Required:
 
@@ -1275,31 +1275,31 @@ Optional:
 - `protocol` (String) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1310,19 +1310,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1331,8 +1331,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--readiness_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.readiness_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--readiness_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.readiness_probe.timeout_seconds`
 
 Required:
 
@@ -1340,8 +1340,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--resources"></a>
-### Nested Schema for `spec.template.spec.init_container.resources`
+<a id="nestedblock--spec--template--spec--volume--resources"></a>
+### Nested Schema for `spec.template.spec.volume.resources`
 
 Optional:
 
@@ -1349,23 +1349,23 @@ Optional:
 - `requests` (Map of String) Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context`
+<a id="nestedblock--spec--template--spec--volume--security_context"></a>
+### Nested Schema for `spec.template.spec.volume.security_context`
 
 Optional:
 
 - `allow_privilege_escalation` (Boolean) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--capabilities))
+- `capabilities` (Block List, Max: 1) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--capabilities))
 - `privileged` (Boolean) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
 - `read_only_root_filesystem` (Boolean) Whether this container has a read-only root filesystem. Default is false.
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--security_context--seccomp_profile))
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--capabilities"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.capabilities`
+<a id="nestedblock--spec--template--spec--volume--security_context--capabilities"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1373,8 +1373,8 @@ Optional:
 - `drop` (List of String) Removed capabilities
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--security_context--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1384,8 +1384,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--init_container--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.init_container.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--security_context--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.security_context.seccomp_profile`
 
 Optional:
 
@@ -1394,31 +1394,31 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe`
+<a id="nestedblock--spec--template--spec--volume--startup_probe"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe`
 
 Optional:
 
-- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--exec))
+- `exec` (Block List, Max: 1) exec specifies the action to take. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--exec))
 - `failure_threshold` (Number) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--grpc))
-- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get))
+- `grpc` (Block List) GRPC specifies an action involving a GRPC port. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--grpc))
+- `http_get` (Block List, Max: 1) Specifies the http request to perform. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--http_get))
 - `initial_delay_seconds` (Number) Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - `period_seconds` (Number) How often (in seconds) to perform the probe
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
-- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket))
+- `tcp_socket` (Block List) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--tcp_socket))
 - `timeout_seconds` (Number) Number of seconds after which the probe times out. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--exec"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.exec`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--exec"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `command` (List of String) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--grpc"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.grpc`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--grpc"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1429,19 +1429,19 @@ Optional:
 - `service` (String) Name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). If this is not specified, the default behavior is defined by gRPC.
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--http_get"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Optional:
 
 - `host` (String) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header))
+- `http_header` (Block List) Scheme to use for connecting to the host. (see [below for nested schema](#nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header))
 - `path` (String) Path to access on the HTTP server.
 - `port` (String) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 - `scheme` (String) Scheme to use for connecting to the host.
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--http_get--http_header"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.http_get.http_header`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--timeout_seconds--http_header"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds.scheme`
 
 Optional:
 
@@ -1450,8 +1450,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--startup_probe--tcp_socket"></a>
-### Nested Schema for `spec.template.spec.init_container.startup_probe.tcp_socket`
+<a id="nestedblock--spec--template--spec--volume--startup_probe--tcp_socket"></a>
+### Nested Schema for `spec.template.spec.volume.startup_probe.timeout_seconds`
 
 Required:
 
@@ -1459,8 +1459,8 @@ Required:
 
 
 
-<a id="nestedblock--spec--template--spec--init_container--volume_mount"></a>
-### Nested Schema for `spec.template.spec.init_container.volume_mount`
+<a id="nestedblock--spec--template--spec--volume--volume_mount"></a>
+### Nested Schema for `spec.template.spec.volume.volume_mount`
 
 Required:
 
@@ -1476,7 +1476,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
-### Nested Schema for `spec.template.spec.os`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1484,7 +1484,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--readiness_gate"></a>
-### Nested Schema for `spec.template.spec.readiness_gate`
+### Nested Schema for `spec.template.spec.volume`
 
 Required:
 
@@ -1492,7 +1492,7 @@ Required:
 
 
 <a id="nestedblock--spec--template--spec--security_context"></a>
-### Nested Schema for `spec.template.spec.security_context`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1501,14 +1501,14 @@ Optional:
 - `run_as_group` (String) The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 - `run_as_non_root` (Boolean) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 - `run_as_user` (String) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--se_linux_options))
-- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--seccomp_profile))
+- `se_linux_options` (Block List, Max: 1) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. (see [below for nested schema](#nestedblock--spec--template--spec--volume--se_linux_options))
+- `seccomp_profile` (Block List, Max: 1) The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows. (see [below for nested schema](#nestedblock--spec--template--spec--volume--seccomp_profile))
 - `supplemental_groups` (Set of Number) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--sysctl))
-- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--security_context--windows_options))
+- `sysctl` (Block List) holds a list of namespaced sysctls used for the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--sysctl))
+- `windows_options` (Block List, Max: 1) The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux. (see [below for nested schema](#nestedblock--spec--template--spec--volume--windows_options))
 
-<a id="nestedblock--spec--template--spec--security_context--se_linux_options"></a>
-### Nested Schema for `spec.template.spec.security_context.se_linux_options`
+<a id="nestedblock--spec--template--spec--volume--se_linux_options"></a>
+### Nested Schema for `spec.template.spec.volume.se_linux_options`
 
 Optional:
 
@@ -1518,8 +1518,8 @@ Optional:
 - `user` (String) User is a SELinux user label that applies to the container.
 
 
-<a id="nestedblock--spec--template--spec--security_context--seccomp_profile"></a>
-### Nested Schema for `spec.template.spec.security_context.seccomp_profile`
+<a id="nestedblock--spec--template--spec--volume--seccomp_profile"></a>
+### Nested Schema for `spec.template.spec.volume.seccomp_profile`
 
 Optional:
 
@@ -1527,8 +1527,8 @@ Optional:
 - `type` (String) Type indicates which kind of seccomp profile will be applied. Valid options are: Localhost, RuntimeDefault, Unconfined.
 
 
-<a id="nestedblock--spec--template--spec--security_context--sysctl"></a>
-### Nested Schema for `spec.template.spec.security_context.sysctl`
+<a id="nestedblock--spec--template--spec--volume--sysctl"></a>
+### Nested Schema for `spec.template.spec.volume.sysctl`
 
 Required:
 
@@ -1536,8 +1536,8 @@ Required:
 - `value` (String) Value of a property to set.
 
 
-<a id="nestedblock--spec--template--spec--security_context--windows_options"></a>
-### Nested Schema for `spec.template.spec.security_context.windows_options`
+<a id="nestedblock--spec--template--spec--volume--windows_options"></a>
+### Nested Schema for `spec.template.spec.volume.windows_options`
 
 Optional:
 
@@ -1549,7 +1549,7 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--toleration"></a>
-### Nested Schema for `spec.template.spec.toleration`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
@@ -1561,11 +1561,11 @@ Optional:
 
 
 <a id="nestedblock--spec--template--spec--topology_spread_constraint"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint`
+### Nested Schema for `spec.template.spec.volume`
 
 Optional:
 
-- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector))
+- `label_selector` (Block List) A label query over a set of resources, in this case pods. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector))
 - `match_label_keys` (Set of String) is a set of pod label keys to select the pods over which spreading will be calculated.
 - `max_skew` (Number) describes the degree to which pods may be unevenly distributed.
 - `min_domains` (Number) indicates a minimum number of eligible domains.
@@ -1574,16 +1574,16 @@ Optional:
 - `topology_key` (String) the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.
 - `when_unsatisfiable` (String) indicates how to deal with a pod if it doesn't satisfy the spread constraint.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector`
+<a id="nestedblock--spec--template--spec--volume--label_selector"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--label_selector--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--topology_spread_constraint--label_selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.topology_spread_constraint.label_selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--label_selector--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.label_selector.match_labels`
 
 Optional:
 
@@ -1688,7 +1688,7 @@ Optional:
 - `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+### Nested Schema for `spec.template.spec.volume.ceph_fs.user`
 
 Optional:
 
@@ -1721,7 +1721,7 @@ Optional:
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or its keys must be defined.
 
 <a id="nestedblock--spec--template--spec--volume--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.config_map.items`
+### Nested Schema for `spec.template.spec.volume.config_map.optional`
 
 Optional:
 
@@ -1746,7 +1746,7 @@ Optional:
 - `volume_attributes` (Map of String) Attributes of the volume to publish.
 
 <a id="nestedblock--spec--template--spec--volume--csi--node_publish_secret_ref"></a>
-### Nested Schema for `spec.template.spec.volume.csi.node_publish_secret_ref`
+### Nested Schema for `spec.template.spec.volume.csi.volume_attributes`
 
 Optional:
 
@@ -1776,7 +1776,7 @@ Optional:
 - `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--downward_api--items--resource_field_ref))
 
 <a id="nestedblock--spec--template--spec--volume--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.downward_api.items.field_ref`
+### Nested Schema for `spec.template.spec.volume.downward_api.items.resource_field_ref`
 
 Optional:
 
@@ -1827,22 +1827,22 @@ Optional:
 - `metadata` (Block List, Max: 1) May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata))
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec`
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata`
 
 Required:
 
 - `access_modes` (Set of String) A set of the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
-- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources))
+- `resources` (Block List, Min: 1, Max: 1) A list of the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources))
 
 Optional:
 
-- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
+- `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--resources"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
@@ -1850,16 +1850,16 @@ Optional:
 - `requests` (Map of String) Map describing the minimum amount of compute resources required. If this is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--selector"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--metadata--volume_name--match_expressions"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.metadata.volume_name.match_expressions`
 
 Optional:
 
@@ -2044,26 +2044,26 @@ Optional:
 - `default_mode` (String) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 
 <a id="nestedblock--spec--template--spec--volume--projected--sources"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources`
+### Nested Schema for `spec.template.spec.volume.projected.default_mode`
 
 Optional:
 
-- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map))
-- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api))
-- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret))
-- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--service_account_token))
+- `config_map` (Block List) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--config_map))
+- `downward_api` (Block List, Max: 1) DownwardAPI represents downward API about the pod that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--downward_api))
+- `secret` (Block List) Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--secret))
+- `service_account_token` (Block List, Max: 1) A projected service account token volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--config_map"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--config_map--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 - `optional` (Boolean) Optional: Specify whether the ConfigMap or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--config_map--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.config_map.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2073,15 +2073,15 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--downward_api"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items))
+- `items` (Block List) Represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items`
 
 Required:
 
@@ -2089,12 +2089,12 @@ Required:
 
 Optional:
 
-- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref))
+- `field_ref` (Block List, Max: 1) Selects a field of the pod: only annotations, labels, name and namespace are supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref))
 - `mode` (String) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref))
+- `resource_field_ref` (Block List, Max: 1) Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref))
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.field_ref`
 
 Optional:
 
@@ -2102,8 +2102,8 @@ Optional:
 - `field_path` (String) Path of the field to select in the specified API version
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--downward_api--items--resource_field_ref"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.downward_api.items.resource_field_ref`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items--resource_field_ref"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.items.resource_field_ref`
 
 Required:
 
@@ -2117,17 +2117,17 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--secret"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Optional:
 
-- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--sources--secret--items))
+- `items` (Block List) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'. (see [below for nested schema](#nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items))
 - `name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 - `optional` (Boolean) Optional: Specify whether the Secret or it's keys must be defined.
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.secret.items`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token--items"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token.optional`
 
 Optional:
 
@@ -2137,8 +2137,8 @@ Optional:
 
 
 
-<a id="nestedblock--spec--template--spec--volume--projected--sources--service_account_token"></a>
-### Nested Schema for `spec.template.spec.volume.projected.sources.service_account_token`
+<a id="nestedblock--spec--template--spec--volume--projected--default_mode--service_account_token"></a>
+### Nested Schema for `spec.template.spec.volume.projected.default_mode.service_account_token`
 
 Required:
 
@@ -2205,7 +2205,7 @@ Optional:
 - `secret_name` (String) Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secrets
 
 <a id="nestedblock--spec--template--spec--volume--secret--items"></a>
-### Nested Schema for `spec.template.spec.volume.secret.items`
+### Nested Schema for `spec.template.spec.volume.secret.secret_name`
 
 Optional:
 
@@ -2298,7 +2298,7 @@ Optional:
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
 
 <a id="nestedblock--spec--volume_claim_template--spec--resources"></a>
-### Nested Schema for `spec.volume_claim_template.spec.resources`
+### Nested Schema for `spec.volume_claim_template.spec.volume_name`
 
 Optional:
 
@@ -2307,15 +2307,15 @@ Optional:
 
 
 <a id="nestedblock--spec--volume_claim_template--spec--selector"></a>
-### Nested Schema for `spec.volume_claim_template.spec.selector`
+### Nested Schema for `spec.volume_claim_template.spec.volume_name`
 
 Optional:
 
-- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--selector--match_expressions))
+- `match_expressions` (Block List) A list of label selector requirements. The requirements are ANDed. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--volume_name--match_expressions))
 - `match_labels` (Map of String) A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 
-<a id="nestedblock--spec--volume_claim_template--spec--selector--match_expressions"></a>
-### Nested Schema for `spec.volume_claim_template.spec.selector.match_expressions`
+<a id="nestedblock--spec--volume_claim_template--spec--volume_name--match_expressions"></a>
+### Nested Schema for `spec.volume_claim_template.spec.volume_name.match_expressions`
 
 Optional:
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

@sheneska  It seems like we just need to run `tfplugindocs generate` one more time off of main in order to prevent workflow failures on PRs.

This PR just has the changes that were made when after running `tfplugindocs generate` after the recent commit.

My understanding is the tfplugindocs generate should only find any docs that have yet to be generated (In the case where I used it it should've just found server_version but found some that haven't been generated.)

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
