### PR TITLE
Clean up manifest acceptence test workflow matrix.

### DIFF
--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -29,22 +29,20 @@ jobs:
         kubernetes_version:
           # kind images: https://github.com/kubernetes-sigs/kind/releases
           - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
-          - v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0
-          - v1.26.6@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
-          - v1.25.11@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
-          - v1.23.15@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
+          - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
+          - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
+          - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
+          - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
         terraform_version:
-          - 1.8.0
+          - 1.8.5
+          - 1.6.6
           - 1.5.7
           - 1.4.7
           - 1.3.10
           - 1.2.9
           - 1.1.9
           - 1.0.11
-        # BONUS: Run tests on the latest available Kubernetes(1.X) and Terraform(1.X) versions.
-        include:
-          - kubernetes_version: v1.27.3@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
-            terraform_version: 1.6.1
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Set up Go


### PR DESCRIPTION
### Description

- Update node images to use versions built for the correct version of kind where possible (as mentioned in the linked issue there is no 1.30 image available for the currently used version of kind)
- Update terraform versions to latest patch versions
- Move the `include` for TF 1.6 and k8s 1.6 into the general matrix

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

[Workflow run with proposed changes](https://github.com/coryflucas/terraform-provider-kubernetes/actions/runs/10358878020)

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

fixes #2564

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
