### PR TITLE
Return current state when requesting deferral.

### DIFF
--- a/.changelog/2570.txt
+++ b/.changelog/2570.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+deferred actions: return unknown value instead of nil when requesting deferral of a planned resource change.
+```

--- a/.github/workflows/acceptance_test_dfa.yaml
+++ b/.github/workflows/acceptance_test_dfa.yaml
@@ -12,7 +12,7 @@ on:
     inputs:
       terraformVersion:
         description: Terraform version
-        default: 1.9.0-alpha20240516
+        default: 1.10.0-alpha20240807
 
 jobs:
   acceptance_tests:

--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -27,7 +27,16 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 
 	cp := req.ClientCapabilities
 	if cp != nil && cp.DeferralAllowed && s.clientConfigUnknown {
+		v := tftypes.NewValue(tftypes.DynamicPseudoType, nil)
+		dv, err := tfprotov5.NewDynamicValue(v.Type(), v)
+		if err != nil {
+			return resp, err
+		}
 		// if client support it, request deferral when client configuration not fully known
+		resp.ImportedResources = append(resp.ImportedResources, &tfprotov5.ImportedResource{
+			TypeName: req.TypeName,
+			State:    &dv,
+		})
 		resp.Deferred = &tfprotov5.Deferred{
 			Reason: tfprotov5.DeferredReasonProviderConfigUnknown,
 		}

--- a/manifest/provider/import.go
+++ b/manifest/provider/import.go
@@ -27,7 +27,7 @@ func (s *RawProviderServer) ImportResourceState(ctx context.Context, req *tfprot
 
 	cp := req.ClientCapabilities
 	if cp != nil && cp.DeferralAllowed && s.clientConfigUnknown {
-		v := tftypes.NewValue(tftypes.DynamicPseudoType, nil)
+		v := tftypes.NewValue(tftypes.DynamicPseudoType, tftypes.UnknownValue)
 		dv, err := tfprotov5.NewDynamicValue(v.Type(), v)
 		if err != nil {
 			return resp, err

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -130,41 +130,6 @@ func isImportedFlagFromPrivate(p []byte) (f bool, d []*tfprotov5.Diagnostic) {
 func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
 	resp := &tfprotov5.PlanResourceChangeResponse{}
 
-	canDeferr := req.ClientCapabilities != nil && req.ClientCapabilities.DeferralAllowed
-
-	if canDeferr && s.clientConfigUnknown {
-		// if client supports it, request deferral when client configuration not fully known
-		resp.PlannedState = req.ProposedNewState
-		resp.Deferred = &tfprotov5.Deferred{
-			Reason: tfprotov5.DeferredReasonProviderConfigUnknown,
-		}
-		return resp, nil
-	}
-
-	isImported, d := isImportedFlagFromPrivate(req.PriorPrivate)
-	resp.Diagnostics = append(resp.Diagnostics, d...)
-	if !isImported {
-		resp.RequiresReplace = append(resp.RequiresReplace,
-			tftypes.NewAttributePath().WithAttributeName("manifest").WithAttributeName("apiVersion"),
-			tftypes.NewAttributePath().WithAttributeName("manifest").WithAttributeName("kind"),
-			tftypes.NewAttributePath().WithAttributeName("manifest").WithAttributeName("metadata").WithAttributeName("name"),
-		)
-	} else {
-		resp.PlannedPrivate = req.PriorPrivate
-	}
-
-	execDiag := s.canExecute()
-	if len(execDiag) > 0 {
-		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
-		return resp, nil
-	}
-
-	// test if credentials are valid - we're going to need them further down
-	resp.Diagnostics = append(resp.Diagnostics, s.checkValidCredentials(ctx)...)
-	if len(resp.Diagnostics) > 0 {
-		return resp, nil
-	}
-
 	rt, err := GetResourceType(req.TypeName)
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
@@ -194,6 +159,47 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 			Summary:  "Failed to extract planned resource state from tftypes.Value",
 			Detail:   err.Error(),
 		})
+		return resp, nil
+	}
+
+	canDeferr := req.ClientCapabilities != nil && req.ClientCapabilities.DeferralAllowed
+
+	if canDeferr && s.clientConfigUnknown {
+		// if client supports it, request deferral when client configuration not fully known
+		proposedVal["object"] = tftypes.NewValue(tftypes.DynamicPseudoType, tftypes.UnknownValue)
+		newPlannedState := tftypes.NewValue(proposedState.Type(), proposedVal)
+		ps, err := tfprotov5.NewDynamicValue(newPlannedState.Type(), newPlannedState)
+		if err != nil {
+			return resp, err
+		}
+		resp.PlannedState = &ps
+		resp.Deferred = &tfprotov5.Deferred{
+			Reason: tfprotov5.DeferredReasonProviderConfigUnknown,
+		}
+		return resp, nil
+	}
+
+	isImported, d := isImportedFlagFromPrivate(req.PriorPrivate)
+	resp.Diagnostics = append(resp.Diagnostics, d...)
+	if !isImported {
+		resp.RequiresReplace = append(resp.RequiresReplace,
+			tftypes.NewAttributePath().WithAttributeName("manifest").WithAttributeName("apiVersion"),
+			tftypes.NewAttributePath().WithAttributeName("manifest").WithAttributeName("kind"),
+			tftypes.NewAttributePath().WithAttributeName("manifest").WithAttributeName("metadata").WithAttributeName("name"),
+		)
+	} else {
+		resp.PlannedPrivate = req.PriorPrivate
+	}
+
+	execDiag := s.canExecute()
+	if len(execDiag) > 0 {
+		resp.Diagnostics = append(resp.Diagnostics, execDiag...)
+		return resp, nil
+	}
+
+	// test if credentials are valid - we're going to need them further down
+	resp.Diagnostics = append(resp.Diagnostics, s.checkValidCredentials(ctx)...)
+	if len(resp.Diagnostics) > 0 {
 		return resp, nil
 	}
 

--- a/manifest/provider/plan.go
+++ b/manifest/provider/plan.go
@@ -134,6 +134,7 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 
 	if canDeferr && s.clientConfigUnknown {
 		// if client supports it, request deferral when client configuration not fully known
+		resp.PlannedState = req.ProposedNewState
 		resp.Deferred = &tfprotov5.Deferred{
 			Reason: tfprotov5.DeferredReasonProviderConfigUnknown,
 		}

--- a/manifest/provider/read.go
+++ b/manifest/provider/read.go
@@ -23,6 +23,7 @@ func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Rea
 	cp := req.ClientCapabilities
 	if cp != nil && cp.DeferralAllowed && s.clientConfigUnknown {
 		// if client support it, request deferral when client configuration not fully known
+		resp.NewState = req.CurrentState
 		resp.Deferred = &tfprotov5.Deferred{
 			Reason: tfprotov5.DeferredReasonProviderConfigUnknown,
 		}


### PR DESCRIPTION
### Description

Returns current state durring planning and reading resources that require deferral.
This is to correlate with new expectations of Terraform core introduced in: https://github.com/hashicorp/terraform/pull/35526

Testing this change requires running with an up-to-date build of Terraform, that includes the above mentioned PR. A build from current main would be ideal.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

Without this change:

```
$ go test -v -run '^TestAccKubernetesDeferredActions' ./kubernetes/test-dfa
=== RUN   TestAccKubernetesDeferredActions_2_step
    deferred_actions_test.go:28: Step 1/3 error: Error running pre-apply plan: exit status 1

        Error: Attempt to get attribute from null value

          on workspace.tf line 13, in resource "kubernetes_manifest" "demo_workspace":
          13:     kind       = kubernetes_manifest.crd_workspaces.object.spec.names.kind
            ├────────────────
            │ kubernetes_manifest.crd_workspaces.object is null

        This value is null, so it does not have any attributes.
--- FAIL: TestAccKubernetesDeferredActions_2_step (4.35s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-kubernetes/kubernetes/test-dfa	5.424s
FAIL
```

With this change:
```
$ go test -v -run '^TestAccKubernetesDeferredActions' ./kubernetes/test-dfa
=== RUN   TestAccKubernetesDeferredActions_2_step
--- PASS: TestAccKubernetesDeferredActions_2_step (41.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes/test-dfa	42.673s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
deferred actions: return unknown value instead of nil when requesting deferral of a planned resource change.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
