### PR TITLE
Add VolumeDevices to PodSpec (#2572)

### DIFF
--- a/.changelog/2573.txt
+++ b/.changelog/2573.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add VolumeDevices to PodSpec
+```

--- a/.changelog/2573.txt
+++ b/.changelog/2573.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-Add VolumeDevices to PodSpec
+`schema_container.go`: Add VolumeDevices
 ```

--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -466,6 +466,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--job_template--spec--template--spec--container--env"></a>
@@ -949,6 +950,14 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--job_template--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
+
 
 
 <a id="nestedblock--spec--job_template--spec--template--spec--dns_config"></a>
@@ -1018,6 +1027,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--job_template--spec--template--spec--init_container--env"></a>
@@ -1500,6 +1510,14 @@ Optional:
 - `mount_propagation` (String) Mount propagation mode. mount_propagation determines how mounts are propagated from the host to container and the other way around. Valid values are None (default), HostToContainer and Bidirectional.
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+<a id="nestedblock--spec--job_template--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 

--- a/docs/resources/cron_job_v1.md
+++ b/docs/resources/cron_job_v1.md
@@ -461,6 +461,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--job_template--spec--template--spec--container--env"></a>
@@ -944,6 +945,14 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--job_template--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
+
 
 
 <a id="nestedblock--spec--job_template--spec--template--spec--dns_config"></a>
@@ -1013,6 +1022,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--job_template--spec--template--spec--init_container--env"></a>
@@ -1495,6 +1505,14 @@ Optional:
 - `mount_propagation` (String) Mount propagation mode. mount_propagation determines how mounts are propagated from the host to container and the other way around. Valid values are None (default), HostToContainer and Bidirectional.
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+<a id="nestedblock--spec--job_template--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 

--- a/docs/resources/daemon_set_v1.md
+++ b/docs/resources/daemon_set_v1.md
@@ -415,6 +415,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -898,6 +899,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -967,6 +975,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1450,6 +1459,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/daemonset.md
+++ b/docs/resources/daemonset.md
@@ -415,6 +415,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -898,6 +899,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -967,6 +975,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1450,6 +1459,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -415,6 +415,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -898,6 +899,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -967,6 +975,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1450,6 +1459,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/deployment_v1.md
+++ b/docs/resources/deployment_v1.md
@@ -423,6 +423,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -906,6 +907,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -975,6 +983,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1458,6 +1467,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -423,6 +423,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -906,6 +907,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -975,6 +983,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1458,6 +1467,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/job_v1.md
+++ b/docs/resources/job_v1.md
@@ -419,6 +419,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -902,6 +903,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -971,6 +979,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1454,6 +1463,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/pod.md
+++ b/docs/resources/pod.md
@@ -374,6 +374,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--container--env"></a>
@@ -857,6 +858,14 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--container--volume_device"></a>
+### Nested Schema for `spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
+
 
 
 <a id="nestedblock--spec--dns_config"></a>
@@ -926,6 +935,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--init_container--env"></a>
@@ -1408,6 +1418,14 @@ Optional:
 - `mount_propagation` (String) Mount propagation mode. mount_propagation determines how mounts are propagated from the host to container and the other way around. Valid values are None (default), HostToContainer and Bidirectional.
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+<a id="nestedblock--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 

--- a/docs/resources/pod_v1.md
+++ b/docs/resources/pod_v1.md
@@ -372,6 +372,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--container--env"></a>
@@ -855,6 +856,14 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--container--volume_device"></a>
+### Nested Schema for `spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
+
 
 
 <a id="nestedblock--spec--dns_config"></a>
@@ -924,6 +933,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--init_container--env"></a>
@@ -1406,6 +1416,14 @@ Optional:
 - `mount_propagation` (String) Mount propagation mode. mount_propagation determines how mounts are propagated from the host to container and the other way around. Valid values are None (default), HostToContainer and Bidirectional.
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+<a id="nestedblock--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 

--- a/docs/resources/replication_controller.md
+++ b/docs/resources/replication_controller.md
@@ -412,6 +412,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -895,6 +896,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -964,6 +972,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1447,6 +1456,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/replication_controller_v1.md
+++ b/docs/resources/replication_controller_v1.md
@@ -410,6 +410,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -893,6 +894,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -962,6 +970,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1445,6 +1454,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>

--- a/docs/resources/stateful_set.md
+++ b/docs/resources/stateful_set.md
@@ -442,6 +442,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--container--env"></a>
@@ -925,6 +926,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--container--volume_device"></a>
+### Nested Schema for `spec.template.spec.container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--dns_config"></a>
@@ -994,6 +1002,7 @@ Optional:
 - `termination_message_policy` (String) Optional: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
 - `tty` (Boolean) Whether this container should allocate a TTY for itself
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
+- `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
@@ -1477,6 +1486,13 @@ Optional:
 - `read_only` (Boolean) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 - `sub_path` (String) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
+<a id="nestedblock--spec--template--spec--init_container--volume_device"></a>
+### Nested Schema for `spec.template.spec.init_container.volume_device`
+
+Required:
+
+- `device_path` (String) Path within the container at which the volume device should be attached. For example '/dev/xvda'.
+- `name` (String) This must match the Name of a PersistentVolumeClaim.
 
 
 <a id="nestedblock--spec--template--spec--os"></a>
@@ -2348,7 +2364,7 @@ Optional:
 ## Example Usage
 
 ```terraform
-resource "kubernetes_stateful_set" "prometheus" {
+resource "kubernetes_stateful_set_v1" "prometheus" {
   metadata {
     annotations = {
       SomeAnnotation = "foobar"
@@ -2365,6 +2381,7 @@ resource "kubernetes_stateful_set" "prometheus" {
   }
 
   spec {
+    min_ready_seconds      = 10
     pod_management_policy  = "Parallel"
     replicas               = 1
     revision_history_limit = 5
@@ -2399,6 +2416,11 @@ resource "kubernetes_stateful_set" "prometheus" {
             name       = "prometheus-data"
             mount_path = "/data"
             sub_path   = ""
+          }
+
+          volume_device {
+            name        = "prometheus-device"
+            device_path = "/dev/xvda"
           }
         }
 
@@ -2471,6 +2493,11 @@ resource "kubernetes_stateful_set" "prometheus" {
             sub_path   = ""
           }
 
+          volume_device {
+            name        = "prometheus-device"
+            device_path = "/dev/xvda"
+          }
+
           readiness_probe {
             http_get {
               path = "/-/ready"
@@ -2521,6 +2548,24 @@ resource "kubernetes_stateful_set" "prometheus" {
       spec {
         access_modes       = ["ReadWriteOnce"]
         storage_class_name = "standard"
+
+        resources {
+          requests = {
+            storage = "16Gi"
+          }
+        }
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "prometheus-device"
+      }
+
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "local-storage"
+        volume_mode        = "Block"
 
         resources {
           requests = {

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -253,6 +253,21 @@ func volumeMountFields() map[string]*schema.Schema {
 	}
 }
 
+func volumeDeviceFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"device_path": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Path within the container at which the volume device should be attached. For example '/dev/xvda'.",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "This must match the Name of a PersistentVolumeClaim.",
+		},
+	}
+}
+
 func containerFields(isUpdatable bool) map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"args": {
@@ -649,6 +664,15 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			Description: "Pod volumes to mount into the container's filesystem. Cannot be updated.",
 			Elem: &schema.Resource{
 				Schema: volumeMountFields(),
+			},
+		},
+		"volume_device": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			ForceNew:    !isUpdatable,
+			Description: "Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated.",
+			Elem: &schema.Resource{
+				Schema: volumeDeviceFields(),
 			},
 		},
 		"working_dir": {


### PR DESCRIPTION
### Description

Resolves #2572 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing follows, filtered only to the new EKS tests, since it's hard to test locally:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
/usr/lib/go-1.21/bin/go tool test2json -t ~/.cache/JetBrains/IntelliJIdea2024.2/tmp/GoLand/___2resource_kubernetes_stateful_set_v1_eks_test_go.test -test.v=test2json -test.paniconexit0 -test.run ^\QTestAccKubernetesStatefulSetV1_EKS_basic\E|\QTestAccKubernetesStatefulSetV1_EKS_basic_idempotency\E|\QTestAccKubernetesStatefulSetV1_EKS_Update\E|\QTestAccKubernetesStatefulSetV1_EKS_waitForRollout\E$
=== RUN   TestAccKubernetesStatefulSetV1_EKS_basic
=== PAUSE TestAccKubernetesStatefulSetV1_EKS_basic
=== CONT  TestAccKubernetesStatefulSetV1_EKS_basic
--- PASS: TestAccKubernetesStatefulSetV1_EKS_basic (25.41s)
=== RUN   TestAccKubernetesStatefulSetV1_EKS_basic_idempotency
=== PAUSE TestAccKubernetesStatefulSetV1_EKS_basic_idempotency
=== CONT  TestAccKubernetesStatefulSetV1_EKS_basic_idempotency
--- PASS: TestAccKubernetesStatefulSetV1_EKS_basic_idempotency (36.40s)
=== RUN   TestAccKubernetesStatefulSetV1_EKS_Update
=== PAUSE TestAccKubernetesStatefulSetV1_EKS_Update
=== CONT  TestAccKubernetesStatefulSetV1_EKS_Update
=== RUN   TestAccKubernetesStatefulSetV1_EKS_waitForRollout
=== PAUSE TestAccKubernetesStatefulSetV1_EKS_waitForRollout
=== CONT  TestAccKubernetesStatefulSetV1_EKS_waitForRollout
--- PASS: TestAccKubernetesStatefulSetV1_EKS_waitForRollout (19.02s)
--- PASS: TestAccKubernetesStatefulSetV1_EKS_Update (145.19s)
PASS
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add VolumeDevices to PodSpec (#2572)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
