### PR TITLE
Adding ignore_destroy attribute/logic

### DIFF
--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -498,7 +498,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			ignoreDestroyVal.As(&ignoreDestroy)
 		}
 		if ignoreDestroy {
-			s.logger.Trace("[ApplyResourceChange][Delete] Skipping deletion because apply_only is true")
+			s.logger.Trace("[ApplyResourceChange][Delete] Skipping deletion because ignore_destroy is true")
 			resp.NewState = req.PlannedState
 			return resp, nil
 		}

--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -192,6 +192,12 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 						Description: "The resulting resource state, as returned by the API server after applying the desired state from `manifest`.",
 					},
 					{
+						Name:        "ignore_destroy",
+						Type:        tftypes.Bool,
+						Optional:    true,
+						Description: "When set to true, Terraform will only apply the resource and skip deletion during destroy.",
+					},
+					{
 						Name: "wait_for",
 						Type: tftypes.Object{
 							AttributeTypes: map[string]tftypes.Type{


### PR DESCRIPTION
### Description
Fixes #2188 
This update introduces the `ignore_destroy` attribute to the Kubernetes provider. When set to `true`, it ensures that the resource will only be applied and will not be deleted during a Terraform destroy operation.

Important Note:
The `ignore_destroy` attribute only takes effect if the resource is applied with the attribute set to true prior to running a destroy operation. If the attribute is set immediately before the destroy command, it will not have any impact. This limitation arises because, at destroy time, the provider does not have access to the resource's configuration, as nothing is being created. As such, the attribute must be applied during the resource creation phase for it to take effect during subsequent destroy operations.

I believe this sort of edge case should be considered when using the `ignore_destroy `attribute, and I will need document the process accordingly in the provider documentation.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Tested using a test config on my local machine. When running apply with the attribute set, following `terraform destroy`. the resource is not deleted, but when adding the attribute after the resource is created, the resource is destroyed.
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
