### PR TITLE
Tolerate 404 errors on delete

### DIFF
--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -493,15 +493,6 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			})
 			return resp, nil
 		}
-		ignoreDestroy := false
-		if ignoreDestroyVal, ok := priorStateVal["ignore_destroy"]; ok && !ignoreDestroyVal.IsNull() {
-			ignoreDestroyVal.As(&ignoreDestroy)
-		}
-		if ignoreDestroy {
-			s.logger.Trace("[ApplyResourceChange][Delete] Skipping deletion because ignore_destroy is true")
-			resp.NewState = req.PlannedState
-			return resp, nil
-		}
 		pco, ok := priorStateVal["object"]
 		if !ok {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
@@ -548,14 +539,25 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 
 		err = rs.Delete(ctxDeadline, rname, metav1.DeleteOptions{})
 		if err != nil {
-			rn := types.NamespacedName{Namespace: rnamespace, Name: rname}.String()
-			resp.Diagnostics = append(resp.Diagnostics,
-				&tfprotov5.Diagnostic{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  fmt.Sprintf("Error deleting resource %s: %s", rn, err),
-					Detail:   err.Error(),
-				})
-			return resp, nil
+			if apierrors.IsNotFound(err) {
+				s.logger.Trace("[ApplyResourceChange][Delete]", "Resource is already deleted")
+
+				resp.Diagnostics = append(resp.Diagnostics,
+					&tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityWarning,
+						Summary:  fmt.Sprintf("Resource %q was already deleted", rname),
+						Detail:   fmt.Sprintf("The resource %q was not found in the Kubernetes API. This may be due to the resource being already deleted.", rname),
+					})
+				return resp, nil
+			} else {
+				resp.Diagnostics = append(resp.Diagnostics,
+					&tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  fmt.Sprintf("Error deleting resource %s: %s", rname, err),
+						Detail:   err.Error(),
+					})
+				return resp, nil
+			}
 		}
 
 		// wait for delete
@@ -572,16 +574,24 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			_, err := rs.Get(ctxDeadline, rname, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					s.logger.Trace("[ApplyResourceChange][Delete]", "Resource is deleted")
+					s.logger.Trace("[ApplyResourceChange][Delete]", "Resource is already deleted")
+
+					resp.Diagnostics = append(resp.Diagnostics,
+						&tfprotov5.Diagnostic{
+							Severity: tfprotov5.DiagnosticSeverityWarning,
+							Summary:  fmt.Sprintf("Resource %q was already deleted", rname),
+							Detail:   fmt.Sprintf("The resource %q was not found in the Kubernetes API. This may be due to the resource being already deleted.", rname),
+						})
 					break
+				} else {
+					resp.Diagnostics = append(resp.Diagnostics,
+						&tfprotov5.Diagnostic{
+							Severity: tfprotov5.DiagnosticSeverityError,
+							Summary:  "Error waiting for deletion.",
+							Detail:   fmt.Sprintf("Error when waiting for resource %q to be deleted: %v", rname, err),
+						})
+					return resp, nil
 				}
-				resp.Diagnostics = append(resp.Diagnostics,
-					&tfprotov5.Diagnostic{
-						Severity: tfprotov5.DiagnosticSeverityError,
-						Summary:  "Error waiting for deletion.",
-						Detail:   fmt.Sprintf("Error when waiting for resource %q to be deleted: %v", rname, err),
-					})
-				return resp, nil
 			}
 			time.Sleep(1 * time.Second) // lintignore:R018
 		}

--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -498,7 +498,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			ignoreDestroyVal.As(&ignoreDestroy)
 		}
 		if ignoreDestroy {
-			s.logger.Trace("[ApplyResourceChange][Delete] Skipping deletion because apply_only is true")
+			s.logger.Trace("[ApplyResourceChange][Delete] Skipping deletion because ignore_destroy is true")
 			resp.NewState = req.PlannedState
 			return resp, nil
 		}

--- a/manifest/provider/provider.go
+++ b/manifest/provider/provider.go
@@ -192,6 +192,12 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 						Description: "The resulting resource state, as returned by the API server after applying the desired state from `manifest`.",
 					},
 					{
+						Name:        "ignore_destroy",
+						Type:        tftypes.Bool,
+						Optional:    true,
+						Description: "When set to true, Terraform will only apply the resource and skip deletion during destroy.",
+					},
+					{
 						Name: "wait_for",
 						Type: tftypes.Object{
 							AttributeTypes: map[string]tftypes.Type{


### PR DESCRIPTION
### Description
Fixes #2188 
This PR introduces changes to handle "404 Not Found" errors during the deletion of Kubernetes resources, particularly in cases where the resource may already have been deleted by a CRD or another process before Terraform attempts to delete it.

Changes Introduced:

- Added logic to check for IsNotFound(err) when calling Delete on resources.

    -     If a "404 Not Found" error is encountered, it is now treated as a successful deletion and logged as "Resource 
          already  deleted, ignoring 404 error".

    -    Other errors during deletion will continue to be handled as before.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
