### PR TITLE
Fix deletion not found handling in the delete operation and adding related tests

### DIFF
--- a/.changelog/2592.txt
+++ b/.changelog/2592.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-handling "404 Not Found" errors during the deletion of Kubernetes resources, particularly in cases where the resource may have already been deleted by an operator managing the CRD before Terraform attempts to delete it.
+`kubernetes_manifest` - handling "404 Not Found" errors during the deletion of Kubernetes resources, particularly in cases where the resource may have already been deleted by an operator managing the CRD before Terraform attempts to delete it.
 ```

--- a/.changelog/2592.txt
+++ b/.changelog/2592.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+handling "404 Not Found" errors during the deletion of Kubernetes resources, particularly in cases where the resource may have already been deleted by an operator managing the CRD before Terraform attempts to delete it.
+```

--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -556,8 +556,8 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 						Summary:  fmt.Sprintf("Error deleting resource %s: %s", rname, err),
 						Detail:   err.Error(),
 					})
-				return resp, nil
 			}
+			return resp, nil
 		}
 		// wait for delete
 		for {

--- a/manifest/test/acceptance/delete_not_found_test.go
+++ b/manifest/test/acceptance/delete_not_found_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
+)
+
+func TestKubernetesManifest_DeletionNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Fatalf("Failed to create provider instance: %v", err)
+	}
+
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(ctx, t)
+	tf.SetReattachInfo(ctx, reattachInfo)
+
+	k8shelper.CreateNamespace(t, namespace)
+	t.Logf("Verifying if namespace %s exists", namespace)
+	k8shelper.AssertResourceExists(t, "v1", "namespaces", namespace)
+
+	defer func() {
+		tf.Destroy(ctx)
+		tf.Close()
+		k8shelper.DeleteResource(t, namespace, kubernetes.NewGroupVersionResource("v1", "namespaces"))
+		k8shelper.AssertResourceDoesNotExist(t, "v1", "namespaces", namespace)
+	}()
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+
+	// Load the Terraform config that will create the ConfigMap
+	tfconfig := loadTerraformConfig(t, "DeleteNotFoundTest/resource.tf", tfvars)
+	tf.SetConfig(ctx, tfconfig)
+
+	t.Log("Applying Terraform configuration to create ConfigMap")
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Terraform apply failed: %v", err)
+	}
+
+	state, err := tf.State(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve Terraform state: %v", err)
+	}
+	t.Logf("Terraform state: %v", state)
+
+	time.Sleep(2 * time.Second)
+
+	t.Logf("Checking if ConfigMap %s in namespace %s was created", name, namespace)
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "configmaps", namespace, name)
+
+	// Simulating the deletion of the resource outside of Terraform
+	k8shelper.DeleteNamespacedResource(t, name, namespace, kubernetes.NewGroupVersionResource("v1", "configmaps"))
+
+	// Running tf destroy in order to check if we are handling "404 Not Found" gracefully
+	tf.Destroy(ctx)
+
+	// Ensuring that the ConfigMap no longer exists
+	k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "configmaps", namespace, name)
+}

--- a/manifest/test/acceptance/testdata/DeleteNotFoundTest/resource.tf
+++ b/manifest/test/acceptance/testdata/DeleteNotFoundTest/resource.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    "apiVersion" = "v1"
+    "kind"       = "ConfigMap"
+    "metadata" = {
+      "name"      = var.name
+      "namespace" = var.namespace
+    }
+    "data" = {
+      "foo" = "bar"
+    }
+  }
+}
+

--- a/manifest/test/acceptance/testdata/DeleteNotFoundTest/resource.tf
+++ b/manifest/test/acceptance/testdata/DeleteNotFoundTest/resource.tf
@@ -1,3 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
 resource "kubernetes_manifest" "test" {
   manifest = {
     "apiVersion" = "v1"

--- a/manifest/test/acceptance/testdata/DeleteNotFoundTest/variables.tf
+++ b/manifest/test/acceptance/testdata/DeleteNotFoundTest/variables.tf
@@ -1,0 +1,19 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
### Description

Fixes #2188 
This PR introduces changes to handle "404 Not Found" errors during the deletion of Kubernetes resources, particularly in cases where the resource may have already been deleted by an operator managing the CRD before Terraform attempts to delete it.

Changes Introduced:

Added logic to check for IsNotFound(err) when calling Delete on resources.

If a "404 Not Found" error is encountered, it is now treated as a successful deletion and logged as "Resource
already deleted, ignoring 404 error".
Other errors during deletion will continue to be handled as before.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
jaylon.mcshan@jaylon terraform-provider-kubernetes % go test -v -tags=acceptance ./manifest/test/acceptance -run TestKubernetesManifest_DeletionNotFound

2024/09/25 09:53:50 Testing against Kubernetes API version: v1.30.0
=== RUN   TestKubernetesManifest_DeletionNotFound
    delete_not_found_test.go:35: Verifying if namespace tf-acc-test-vkxthtphka exists
    delete_not_found_test.go:54: Applying Terraform configuration to create ConfigMap
    delete_not_found_test.go:64: Terraform state: &{false 1.0 1.8.3 0x14000b787d0 []}
    delete_not_found_test.go:68: Checking if ConfigMap tf-acc-test-bypcuockzy in namespace tf-acc-test-vkxthtphka was created
2024-09-25T09:53:52.894-0500 [WARN]  sdk.proto: Response contains warning diagnostic: tf_rpc=ApplyResourceChange diagnostic_detail="The resource \"tf-acc-test-bypcuockzy\" was not found in the Kubernetes API. This may be due to the resource being already deleted." diagnostic_severity=WARNING diagnostic_summary="Resource \"tf-acc-test-bypcuockzy\" was already deleted" tf_resource_type=kubernetes_manifest tf_proto_version=5.6 tf_provider_addr=registry.terraform.io/hashicorp/kubernetes tf_req_id=1b6b3752-6308-e766-046e-1e392d2e3bcf
--- PASS: TestKubernetesManifest_DeletionNotFound (2.63s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     3.421s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
handling "404 Not Found" errors during the deletion of Kubernetes resources, particularly in cases where the resource may have already been deleted by an operator managing the CRD before Terraform attempts to delete it.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
