### PR TITLE
Handle Jobs with ttl_seconds_after_finished = 0 correctly

### DIFF
--- a/.changelog/2596.txt
+++ b/.changelog/2596.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Properly handle Kubernetes Jobs with ttl_seconds_after_finished = 0 to prevent unnecessary recreation.
+```

--- a/kubernetes/resource_kubernetes_job_v1.go
+++ b/kubernetes/resource_kubernetes_job_v1.go
@@ -69,10 +69,10 @@ func resourceKubernetesJobV1CustomizeDiff(ctx context.Context, d *schema.Resourc
 	// Only check TTL if present
 	var oldTTLStr, newTTLStr string
 	if oldTTLRaw != nil {
-		oldTTLStr, _ = oldTTLRaw.(string)
+		oldTTLStr = oldTTLRaw.(string)
 	}
 	if newTTLRaw != nil {
-		newTTLStr, _ = newTTLRaw.(string)
+		newTTLStr = newTTLRaw.(string)
 	}
 
 	oldTTLInt, err := strconv.Atoi(oldTTLStr)

--- a/kubernetes/resource_kubernetes_job_v1.go
+++ b/kubernetes/resource_kubernetes_job_v1.go
@@ -57,25 +57,19 @@ func resourceKubernetesJobV1CustomizeDiff(ctx context.Context, d *schema.Resourc
 		return nil
 	}
 
-	// Retrieve old and new TTL values as strings
+	// Retrieve old and new TTL schema values as
 	oldTTLRaw, newTTLRaw := d.GetChange("spec.0.ttl_seconds_after_finished")
-
-	var oldTTLStr, newTTLStr string
-
-	if oldTTLRaw != nil {
-		oldTTLStr, _ = oldTTLRaw.(string)
-	}
-	if newTTLRaw != nil {
-		newTTLStr, _ = newTTLRaw.(string)
-	}
+	oldTTLStr, _ := oldTTLRaw.(string)
+	newTTLStr, _ := newTTLRaw.(string)
 
 	oldTTLInt, err := strconv.Atoi(oldTTLStr)
 	if err != nil {
-		oldTTLInt = 0
+		return fmt.Errorf("invalid old TTL value: %v", err)
 	}
+
 	newTTLInt, err := strconv.Atoi(newTTLStr)
 	if err != nil {
-		newTTLInt = 0
+		return fmt.Errorf("invalid new TTL value: %v", err)
 	}
 
 	conn, err := meta.(KubeClientsets).MainClientset()
@@ -92,31 +86,14 @@ func resourceKubernetesJobV1CustomizeDiff(ctx context.Context, d *schema.Resourc
 	_, err = conn.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// Job is missing
-			if oldTTLInt >= 0 {
-				if oldTTLInt != newTTLInt {
-					// TTL value changed; force recreation
-					log.Printf("[DEBUG] Job %s not found and ttl_seconds_after_finished changed from %d to %d; forcing recreation", d.Id(), oldTTLInt, newTTLInt)
-					d.ForceNew("spec.0.ttl_seconds_after_finished")
-					return nil
-				} else {
-					// TTL remains the same; suppress diff
-					log.Printf("[DEBUG] Job %s not found and ttl_seconds_after_finished remains %d; suppressing diff", d.Id(), oldTTLInt)
-					d.Clear("spec")
-					d.Clear("metadata")
-					return nil
-				}
+			// Job is missing, suppress diff if the TTL is the same
+			if oldTTLInt == newTTLInt {
+				log.Printf("[DEBUG] Job %s not found and ttl_seconds_after_finished remains unchanged; suppressing diff", d.Id())
+				d.Clear("spec")
+				d.Clear("metadata")
 			}
 		} else {
 			return err
-		}
-	} else {
-		// Job exists, check if TTL changed
-		if oldTTLInt != newTTLInt {
-			// TTL changed; force recreation
-			log.Printf("[DEBUG] Job %s exists and ttl_seconds_after_finished changed from %d to %d; forcing recreation", d.Id(), oldTTLInt, newTTLInt)
-			d.ForceNew("spec.0.ttl_seconds_after_finished")
-			return nil
 		}
 	}
 

--- a/kubernetes/resource_kubernetes_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_job_v1_test.go
@@ -295,7 +295,7 @@ func TestAccKubernetesJobV1_updateTTLFromZero(t *testing.T) {
 			// Step 2: Wait for the Job to complete and be deleted
 			{
 				PreConfig: func() {
-					time.Sleep(70 * time.Second)
+					time.Sleep(120 * time.Second)
 				},
 				Config:             testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
 				PlanOnly:           true,

--- a/kubernetes/resource_kubernetes_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_job_v1_test.go
@@ -252,7 +252,7 @@ func TestAccKubernetesJobV1_customizeDiff_ttlZero(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create the Job
 			{
-				Config: testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				Config: testAccKubernetesJobV1Config_Diff(name, imageName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.ttl_seconds_after_finished", "0"),
@@ -263,7 +263,7 @@ func TestAccKubernetesJobV1_customizeDiff_ttlZero(t *testing.T) {
 				PreConfig: func() {
 					time.Sleep(70 * time.Second)
 				},
-				Config:             testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				Config:             testAccKubernetesJobV1Config_Diff(name, imageName, 0),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -286,7 +286,7 @@ func TestAccKubernetesJobV1_updateTTLFromZero(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create the Job with ttl_seconds_after_finished = 0
 			{
-				Config: testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				Config: testAccKubernetesJobV1Config_Diff(name, imageName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.ttl_seconds_after_finished", "0"),
@@ -297,13 +297,13 @@ func TestAccKubernetesJobV1_updateTTLFromZero(t *testing.T) {
 				PreConfig: func() {
 					time.Sleep(120 * time.Second)
 				},
-				Config:             testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				Config:             testAccKubernetesJobV1Config_Diff(name, imageName, 0),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			// Step 3: Update the Job to ttl_seconds_after_finished = 5
 			{
-				Config: testAccKubernetesJobV1Config_customizeDiff_ttlFive(name, imageName),
+				Config: testAccKubernetesJobV1Config_Diff(name, imageName, 5),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesJobV1Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.ttl_seconds_after_finished", "5"),
@@ -593,14 +593,14 @@ func testAccKubernetesJobV1Config_modified(name, imageName string) string {
 }`, name, imageName)
 }
 
-func testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName string) string {
+func testAccKubernetesJobV1Config_Diff(name, imageName string, ttl int) string {
 	return fmt.Sprintf(`
 resource "kubernetes_job_v1" "test" {
   metadata {
     name = "%s"
   }
   spec {
-    ttl_seconds_after_finished = 0
+    ttl_seconds_after_finished = %d
     template {
       metadata {}
       spec {
@@ -615,30 +615,5 @@ resource "kubernetes_job_v1" "test" {
   }
   wait_for_completion = false
 }
-`, name, imageName)
-}
-
-func testAccKubernetesJobV1Config_customizeDiff_ttlFive(name, imageName string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_job_v1" "test" {
-  metadata {
-    name = "%s"
-  }
-  spec {
-    ttl_seconds_after_finished = 5
-    template {
-      metadata {}
-      spec {
-        container {
-          name    = "wait-test"
-          image   = "%s"
-          command = ["sleep", "60"]
-        }
-        restart_policy = "Never"
-      }
-    }
-  }
-  wait_for_completion = false
-}
-`, name, imageName)
+`, name, ttl, imageName)
 }

--- a/kubernetes/resource_kubernetes_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_job_v1_test.go
@@ -237,6 +237,40 @@ func TestAccKubernetesJobV1_ttl_seconds_after_finished(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesJobV1_customizeDiff_ttlZero(t *testing.T) {
+	var conf batchv1.Job
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	imageName := busyboxImage
+	resourceName := "kubernetes_job_v1.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.21.0")
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the Job
+			{
+				Config: testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesJobV1Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.ttl_seconds_after_finished", "0"),
+				),
+			},
+			// Step 2: Wait for the Job to complete and be deleted
+			{
+				PreConfig: func() {
+					time.Sleep(70 * time.Second)
+				},
+				Config:             testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func testAccCheckJobV1Waited(minDuration time.Duration) func(*terraform.State) error {
 	// NOTE this works because this function is called when setting up the test
 	// and the function it returns is called after the resource has been created
@@ -515,4 +549,29 @@ func testAccKubernetesJobV1Config_modified(name, imageName string) string {
   }
   wait_for_completion = false
 }`, name, imageName)
+}
+
+func testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_job_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    ttl_seconds_after_finished = 0
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "wait-test"
+          image   = "%s"
+          command = ["sleep", "60"]
+        }
+        restart_policy = "Never"
+      }
+    }
+  }
+  wait_for_completion = false
+}
+`, name, imageName)
 }

--- a/kubernetes/resource_kubernetes_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_job_v1_test.go
@@ -271,6 +271,48 @@ func TestAccKubernetesJobV1_customizeDiff_ttlZero(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesJobV1_updateTTLFromZero(t *testing.T) {
+	var conf batchv1.Job
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	imageName := busyboxImage
+	resourceName := "kubernetes_job_v1.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.21.0")
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the Job with ttl_seconds_after_finished = 0
+			{
+				Config: testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesJobV1Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.ttl_seconds_after_finished", "0"),
+				),
+			},
+			// Step 2: Wait for the Job to complete and be deleted
+			{
+				PreConfig: func() {
+					time.Sleep(70 * time.Second)
+				},
+				Config:             testAccKubernetesJobV1Config_customizeDiff_ttlZero(name, imageName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Step 3: Update the Job to ttl_seconds_after_finished = 5
+			{
+				Config: testAccKubernetesJobV1Config_customizeDiff_ttlFive(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesJobV1Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.ttl_seconds_after_finished", "5"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckJobV1Waited(minDuration time.Duration) func(*terraform.State) error {
 	// NOTE this works because this function is called when setting up the test
 	// and the function it returns is called after the resource has been created
@@ -559,6 +601,31 @@ resource "kubernetes_job_v1" "test" {
   }
   spec {
     ttl_seconds_after_finished = 0
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "wait-test"
+          image   = "%s"
+          command = ["sleep", "60"]
+        }
+        restart_policy = "Never"
+      }
+    }
+  }
+  wait_for_completion = false
+}
+`, name, imageName)
+}
+
+func testAccKubernetesJobV1Config_customizeDiff_ttlFive(name, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_job_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    ttl_seconds_after_finished = 5
     template {
       metadata {}
       spec {

--- a/kubernetes/resource_kubernetes_job_v1_test.go
+++ b/kubernetes/resource_kubernetes_job_v1_test.go
@@ -261,7 +261,7 @@ func TestAccKubernetesJobV1_customizeDiff_ttlZero(t *testing.T) {
 			// Step 2: Wait for the Job to complete and be deleted
 			{
 				PreConfig: func() {
-					time.Sleep(70 * time.Second)
+					time.Sleep(30 * time.Second)
 				},
 				Config:             testAccKubernetesJobV1Config_Diff(name, imageName, 0),
 				PlanOnly:           true,
@@ -295,7 +295,7 @@ func TestAccKubernetesJobV1_updateTTLFromZero(t *testing.T) {
 			// Step 2: Wait for the Job to complete and be deleted
 			{
 				PreConfig: func() {
-					time.Sleep(120 * time.Second)
+					time.Sleep(30 * time.Second)
 				},
 				Config:             testAccKubernetesJobV1Config_Diff(name, imageName, 0),
 				PlanOnly:           true,
@@ -607,7 +607,7 @@ resource "kubernetes_job_v1" "test" {
         container {
           name    = "wait-test"
           image   = "%s"
-          command = ["sleep", "60"]
+          command = ["sleep", "20"]
         }
         restart_policy = "Never"
       }

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -235,7 +235,7 @@ func jobSpecFields(specUpdatable bool) map[string]*schema.Schema {
 		"ttl_seconds_after_finished": {
 			Type:     schema.TypeString,
 			Optional: true,
-			ForceNew: false,
+			ForceNew: true,
 			ValidateFunc: func(value interface{}, key string) ([]string, []error) {
 				v, err := strconv.Atoi(value.(string))
 				if err != nil {


### PR DESCRIPTION
### Description
Fixes #2531 
When a Kubernetes Job has ttl_seconds_after_finished set to 0, Kubernetes deletes the Job immediately after it completes. This can cause Terraform to plan the recreation of the Job in subsequent runs, which is sort of undesirable behavior. The expected behavior is for Terraform to recognize that the Job was deleted intentionally and not attempt to recreate it or show any diffs.

**Changes made**
    - Read function:
        - When the read crud func encounters a `NotFound` error for a job, it now checks if `ttl `is set to 0, if so it keeps the 
        resource in the state without marking it as destroyed, this helps prevent the recreation of the job. If it is not 0, it 
        behaves as before by removing the resource from the state.

CustomizeDiff function introduced:
        - Supressing diffs when the job has been deleted due to due to ttl = 0


### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
└─(10:13:50 on fix-job-ttl-zero-handling)──> make test TESTARGS="-run TestAccKubernetesJobV1_customizeDiff_ttlZero"
==> Checking that code complies with gofmt requirements...
go vet ./...
go test "/Users/mau/Dev/terraform-provider-kubernetes/kubernetes" -vet=off -run TestAccKubernetesJobV1_customizeDiff_ttlZero -parallel 8 -timeout=30s
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   0.924s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Properly handle Kubernetes Jobs with ttl_seconds_after_finished = 0 to prevent unnecessary recreation.
```

### References
Fixes #2531 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
