### PR TITLE
Fix reference link in K8s Deployment documentation

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -67,7 +67,7 @@ Optional:
 Required:
 
 - `metadata` (Block List, Min: 1, Max: 1) Standard pod's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata (see [below for nested schema](#nestedblock--spec--template--metadata))
-- `spec` (Block List, Min: 1, Max: 1) Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps (see [below for nested schema](#nestedblock--spec--template--spec))
+- `spec` (Block List, Min: 1, Max: 1) Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/ (see [below for nested schema](#nestedblock--spec--template--spec))
 
 <a id="nestedblock--spec--template--metadata"></a>
 ### Nested Schema for `spec.template.metadata`

--- a/docs/resources/deployment_v1.md
+++ b/docs/resources/deployment_v1.md
@@ -67,7 +67,7 @@ Optional:
 Required:
 
 - `metadata` (Block List, Min: 1, Max: 1) Standard pod's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata (see [below for nested schema](#nestedblock--spec--template--metadata))
-- `spec` (Block List, Min: 1, Max: 1) Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps (see [below for nested schema](#nestedblock--spec--template--spec))
+- `spec` (Block List, Min: 1, Max: 1) Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/ (see [below for nested schema](#nestedblock--spec--template--spec))
 
 <a id="nestedblock--spec--template--metadata"></a>
 ### Nested Schema for `spec.template.metadata`


### PR DESCRIPTION
### Description

There is a broken link in the spec section of the kubernetes deployment resource documentation that has been updated. 
Fixes Issue #2601. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
