### PR TITLE
Add conditions attribute to kubernetes_nodes data source

### DIFF
--- a/.changelog/2612.txt
+++ b/.changelog/2612.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added `conditions` attribute to `kubernetes_nodes` data source, which will provide detailed node health and status information
+```

--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -82,7 +82,7 @@ Read-Only:
 - `allocatable` (Map of String)
 - `capacity` (Map of String)
 - `node_info` (List of Object) (see [below for nested schema](#nestedobjatt--nodes--status--node_info))
-
+- `conditions` (List of Object) (see [below for nested schema](#nestedobjatt--nodes--status--conditions))
 <a id="nestedobjatt--nodes--status--addresses"></a>
 ### Nested Schema for `nodes.status.addresses`
 
@@ -108,7 +108,17 @@ Read-Only:
 - `os_image` (String)
 - `system_uuid` (String)
 
+<a id="nestedobjatt--nodes--status--conditions"></a>
+### Nested Schema for `nodes.status.conditions`
 
+Read-Only:
+
+- `type` (String)
+- `status` (String)
+- `last_heartbeat_time` (String)
+- `last_transition_time` (String)
+- `reason` (String)
+- `message` (String)
 
 
  

--- a/kubernetes/data_source_kubernetes_nodes_test.go
+++ b/kubernetes/data_source_kubernetes_nodes_test.go
@@ -36,6 +36,10 @@ func TestAccKubernetesDataSourceNodes_basic(t *testing.T) {
 		resource.TestMatchResourceAttr(dataSourceName, "nodes.0.status.0.conditions.#", oneOrMore),
 		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.type"),
 		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.status"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.last_heartbeat_time"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.last_transition_time"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.reason"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.message"),
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/kubernetes/data_source_kubernetes_nodes_test.go
+++ b/kubernetes/data_source_kubernetes_nodes_test.go
@@ -33,6 +33,9 @@ func TestAccKubernetesDataSourceNodes_basic(t *testing.T) {
 		resource.TestCheckResourceAttrWith(dataSourceName, "nodes.0.status.0.capacity.memory", checkParsableQuantity),
 		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.node_info.0.architecture"),
 		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.addresses.0.address"),
+		resource.TestMatchResourceAttr(dataSourceName, "nodes.0.status.0.conditions.#", oneOrMore),
+		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.type"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "nodes.0.status.0.conditions.0.status"),
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/kubernetes/schema_node_spec.go
+++ b/kubernetes/schema_node_spec.go
@@ -124,6 +124,39 @@ func nodeStatusFields() map[string]*schema.Schema {
 				},
 			},
 		},
+		"conditions": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "List of conditions describing each node's health and operational status.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"status": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"last_heartbeat_time": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"last_transition_time": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"reason": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"message": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/kubernetes/structures_node.go
+++ b/kubernetes/structures_node.go
@@ -71,12 +71,29 @@ func flattenNodeInfo(in v1.NodeSystemInfo) []interface{} {
 	return []interface{}{att}
 }
 
+func flattenNodeConditions(conditions []v1.NodeCondition) []interface{} {
+	out := make([]interface{}, len(conditions))
+	for i, condition := range conditions {
+		m := make(map[string]interface{})
+		m["type"] = condition.Type
+		m["status"] = condition.Status
+		m["last_heartbeat_time"] = condition.LastHeartbeatTime.String()
+		m["last_transition_time"] = condition.LastTransitionTime.String()
+		m["reason"] = condition.Reason
+		m["message"] = condition.Message
+		out[i] = m
+	}
+	return out
+}
+
 func flattenNodeStatus(in v1.NodeStatus) []interface{} {
 	att := make(map[string]interface{})
 	att["addresses"] = flattenAddresses(in.Addresses...)
 	att["allocatable"] = flattenResourceList(in.Allocatable)
 	att["capacity"] = flattenResourceList(in.Capacity)
 	att["node_info"] = flattenNodeInfo(in.NodeInfo)
+	att["conditions"] = flattenNodeConditions(in.Conditions)
+
 	return []interface{}{att}
 }
 


### PR DESCRIPTION
### Description
Fixes #2430 
This PR introduces a new `conditions` attribute to the `kubernetes_nodes` data source, which will provide detailed insights into each node's health and operational status.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
2024-11-01T10:58:55.241-0500 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccKubernetesDataSourceNodes_basic
--- PASS: TestAccKubernetesDataSourceNodes_basic (1.81s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   2.591s
jaylon.mcshan@jaylon terraform-provider-kubernetes % 
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
