### PR TITLE
Use RetryContext to eliminate busy-waiting

### DIFF
--- a/manifest/test/acceptance/testdata/Wait/wait_for_fields_pod_invalid.tf
+++ b/manifest/test/acceptance/testdata/Wait/wait_for_fields_pod_invalid.tf
@@ -1,0 +1,51 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "kubernetes_manifest" "test" {
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Pod"
+
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+
+      annotations = {
+        "test.terraform.io" = "test"
+      }
+
+      labels = {
+        app = "nginx"
+      }
+    }
+
+    spec = {
+      containers = [
+        {
+          name  = "nginx"
+          image = "nginx:1.19"
+
+          readinessProbe = {
+            initialDelaySeconds = 10
+
+            httpGet = {
+              path = "/"
+              port = 80
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  wait {
+    fields = {
+      "status.phase" = "Invalid",
+    }
+  }
+
+  timeouts {
+    create = "5s"
+  }
+}

--- a/manifest/test/acceptance/testdata/Wait/wait_for_rollout_invalid.tf
+++ b/manifest/test/acceptance/testdata/Wait/wait_for_rollout_invalid.tf
@@ -1,0 +1,52 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource kubernetes_manifest wait_for_rollout {
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name       = var.name
+      namespace  = var.namespace
+    }
+    spec = {
+      replicas = 2
+      selector = {
+        matchLabels = {
+          app = "tf-acc-test"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            app = "tf-acc-test"
+          }
+        }
+        spec = {
+          containers = [
+            {
+              image           = "nginx:invalid-does-not-exist"
+              imagePullPolicy = "IfNotPresent"
+              name            = "tf-acc-test"
+              readinessProbe  = {
+                httpGet = {
+                  port = 80
+                  path = "/"
+                }
+                initialDelaySeconds = 10
+              }
+            },
+          ]
+        }
+      }
+    }
+  }
+
+  wait {
+    rollout = true
+  }
+
+  timeouts {
+    create = "5s"
+  }
+}


### PR DESCRIPTION
### Description

Fixes #2614

Update `waiter.go` to use `retry.RetryContext`, which brings a couple of benefits:

 - Avoid boilerplate loop/break logic
 - Better consistency with other code within this provider (e.g. [resource_kubernetes_deployment_v1.go](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/kubernetes/resource_kubernetes_deployment_v1.go#L260))
 - We get back-off retries for free, rather than busy-looping every second.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Behaviour isn't much different, but I added a couple of tests anyway as there were existing gaps (timeout cases for two of the wait types).

Output from acceptance testing:

I couldn't get the regex stuff to work on the command line, apologies - I ran the file through my IDE instead (IntelliJ):

```
$ /opt/go/1.21.13/bin/go tool test2json -t /home/alyssa/.cache/JetBrains/IntelliJIdea2024.1/tmp/GoLand/___wait_test_go.test -test.v -test.paniconexit0 -test.run ^\QTestKubernetesManifest_WaitFields_Pod\E|\QTestKubernetesManifest_WaitFields_PodInvalid\E|\QTestKubernetesManifest_WaitRollout_Deployment\E|\QTestKubernetesManifest_WaitRollout_FailingDeployment\E|\QTestKubernetesManifest_WaitCondition_Pod\E|\QTestKubernetesManifest_Wait_InvalidCondition\E|\QTestKubernetesManifest_WaitFields_Annotations\E$

2024/11/04 17:16:49 Testing against Kubernetes API version: v1.29.10
=== RUN   TestKubernetesManifest_WaitFields_Pod
2024/11/04 17:16:50 [DEBUG] Waiting for state to become: [success]
2024/11/04 17:16:50 [TRACE] Waiting 500ms before next try
2024/11/04 17:16:50 [TRACE] Waiting 1s before next try
2024/11/04 17:16:51 [TRACE] Waiting 2s before next try
2024/11/04 17:16:53 [TRACE] Waiting 4s before next try
2024/11/04 17:16:57 [TRACE] Waiting 8s before next try
--- PASS: TestKubernetesManifest_WaitFields_Pod (17.49s)
=== RUN   TestKubernetesManifest_WaitFields_PodInvalid
2024/11/04 17:17:07 [DEBUG] Waiting for state to become: [success]
2024/11/04 17:17:07 [TRACE] Waiting 500ms before next try
2024/11/04 17:17:08 [TRACE] Waiting 1s before next try
2024/11/04 17:17:09 [TRACE] Waiting 2s before next try
2024/11/04 17:17:11 [TRACE] Waiting 4s before next try
2024/11/04 17:17:12 [WARN] WaitForState timeout after 4.920920079s
2024/11/04 17:17:12 [WARN] WaitForState starting 30s refresh grace period
2024/11/04 17:17:12 [ERROR] Context cancelation detected, abandoning grace period
--- PASS: TestKubernetesManifest_WaitFields_PodInvalid (6.87s)
=== RUN   TestKubernetesManifest_WaitRollout_Deployment
2024/11/04 17:17:14 [DEBUG] Waiting for state to become: [success]
2024/11/04 17:17:14 [TRACE] Waiting 500ms before next try
2024/11/04 17:17:15 [TRACE] Waiting 1s before next try
2024/11/04 17:17:16 [TRACE] Waiting 2s before next try
2024/11/04 17:17:18 [TRACE] Waiting 4s before next try
2024/11/04 17:17:22 [TRACE] Waiting 8s before next try
2024/11/04 17:17:30 [TRACE] Waiting 10s before next try
--- PASS: TestKubernetesManifest_WaitRollout_Deployment (26.40s)
=== RUN   TestKubernetesManifest_WaitRollout_FailingDeployment
2024/11/04 17:17:41 [DEBUG] Waiting for state to become: [success]
2024/11/04 17:17:41 [TRACE] Waiting 500ms before next try
2024/11/04 17:17:41 [TRACE] Waiting 1s before next try
2024/11/04 17:17:42 [TRACE] Waiting 2s before next try
2024/11/04 17:17:44 [TRACE] Waiting 4s before next try
2024/11/04 17:17:46 [WARN] WaitForState timeout after 4.936336905s
2024/11/04 17:17:46 [WARN] WaitForState starting 30s refresh grace period
2024/11/04 17:17:46 [ERROR] Context cancelation detected, abandoning grace period
--- PASS: TestKubernetesManifest_WaitRollout_FailingDeployment (5.80s)
=== RUN   TestKubernetesManifest_WaitCondition_Pod
2024/11/04 17:17:46 [DEBUG] Waiting for state to become: [success]
2024/11/04 17:17:46 [TRACE] Waiting 500ms before next try
2024/11/04 17:17:47 [TRACE] Waiting 1s before next try
2024/11/04 17:17:48 [TRACE] Waiting 2s before next try
2024/11/04 17:17:50 [TRACE] Waiting 4s before next try
2024/11/04 17:17:54 [TRACE] Waiting 8s before next try
--- PASS: TestKubernetesManifest_WaitCondition_Pod (17.52s)
=== RUN   TestKubernetesManifest_Wait_InvalidCondition
2024/11/04 17:18:04 [DEBUG] Waiting for state to become: [success]
2024/11/04 17:18:04 [TRACE] Waiting 500ms before next try
2024/11/04 17:18:04 [TRACE] Waiting 1s before next try
2024/11/04 17:18:05 [TRACE] Waiting 2s before next try
--- PASS: TestKubernetesManifest_Wait_InvalidCondition (9.60s)
=== RUN   TestKubernetesManifest_WaitFields_Annotations
2024/11/04 17:18:13 [DEBUG] Waiting for state to become: [success]
--- PASS: TestKubernetesManifest_WaitFields_Annotations (0.70s)
PASS
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`wait` blocks for the `kubernetes_manifest` resource-type will use a back-off pattern, rather than retrying every second
...
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
