### PR TITLE
add support for binary_data field in config_map_v1_data

### DIFF
--- a/.changelog/2616.txt
+++ b/.changelog/2616.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added support for the `binary_data` field in the `kubernetes_config_map_v1_data` resource.
+```

--- a/docs/resources/config_map_v1_data.md
+++ b/docs/resources/config_map_v1_data.md
@@ -18,7 +18,7 @@ This resource allows Terraform to manage data within a pre-existing ConfigMap. T
 - `metadata` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--metadata))
 
 ### Optional
-
+- `binary_data` (Map of String) BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. This field only accepts base64-encoded payloads that will be decoded/encoded before being sent/received to/from the apiserver.
 - `field_manager` (String) Set the name of the field manager for the specified labels.
 - `force` (Boolean) Force overwriting data that is managed outside of Terraform.
 
@@ -49,6 +49,9 @@ resource "kubernetes_config_map_v1_data" "example" {
   }
   data = {
     "owner" = "myteam"
+  }
+  binary_data = {
+    "logo.png" = "HxShiC0rp..."
   }
 }
 ```

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -49,14 +49,16 @@ func resourceKubernetesConfigMapV1Data() *schema.Resource {
 				},
 			},
 			"data": {
-				Type:        schema.TypeMap,
-				Description: "The data we want to add to the ConfigMap.",
-				Required:    true,
+				Type:         schema.TypeMap,
+				Description:  "The data we want to add to the ConfigMap.",
+				AtLeastOneOf: []string{"data", "binary_data"},
+				Optional:     true,
 			},
 			"binary_data": {
 				Type:         schema.TypeMap,
 				Description:  "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. This field only accepts base64-encoded payloads that will be decoded/encoded before being sent/received to/from the apiserver.",
 				Optional:     true,
+				AtLeastOneOf: []string{"data", "binary_data"},
 				ValidateFunc: validateBase64EncodedMap,
 			},
 			"force": {

--- a/kubernetes/resource_kubernetes_config_map_v1_data.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data.go
@@ -53,6 +53,12 @@ func resourceKubernetesConfigMapV1Data() *schema.Resource {
 				Description: "The data we want to add to the ConfigMap.",
 				Required:    true,
 			},
+			"binary_data": {
+				Type:         schema.TypeMap,
+				Description:  "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. This field only accepts base64-encoded payloads that will be decoded/encoded before being sent/received to/from the apiserver.",
+				Optional:     true,
+				ValidateFunc: validateBase64EncodedMap,
+			},
 			"force": {
 				Type:        schema.TypeBool,
 				Description: "Force overwriting data that is managed outside of Terraform.",
@@ -120,6 +126,7 @@ func resourceKubernetesConfigMapV1DataRead(ctx context.Context, d *schema.Resour
 	}
 
 	d.Set("data", data)
+	d.Set("binary_data", flattenByteMapToBase64Map(res.BinaryData))
 	return nil
 }
 
@@ -169,6 +176,7 @@ func resourceKubernetesConfigMapV1DataUpdate(ctx context.Context, d *schema.Reso
 
 	// craft the patch to update the data
 	data := d.Get("data")
+	binaryData := expandBase64MapToByteMap(d.Get("binary_data").(map[string]interface{}))
 	if d.Id() == "" {
 		// if we're deleting then just we just patch
 		// with an empty data map
@@ -181,7 +189,8 @@ func resourceKubernetesConfigMapV1DataUpdate(ctx context.Context, d *schema.Reso
 			"name":      name,
 			"namespace": namespace,
 		},
-		"data": data,
+		"data":       data,
+		"binaryData": binaryData,
 	}
 	patch := unstructured.Unstructured{}
 	patch.Object = patchobj

--- a/kubernetes/resource_kubernetes_config_map_v1_data_test.go
+++ b/kubernetes/resource_kubernetes_config_map_v1_data_test.go
@@ -202,8 +202,8 @@ func testAccKubernetesConfigMapV1Data_binaryDataUpdated(name string, baseDir str
   }
 
   binary_data = {
-    "binary1" = "${filebase64("%s/test-fixtures/binary.data")}"
-    "binary2" = "${filebase64("%s/test-fixtures/binary2.data")}"
+    "binary1"       = "${filebase64("%s/test-fixtures/binary.data")}"
+    "binary2"       = "${filebase64("%s/test-fixtures/binary2.data")}"
     "inline_binary" = "${base64encode("Raw inline data")}"
   }
 


### PR DESCRIPTION
### Description
Fixes #2467 
This PR enhances the kubernetes_config_map_v1_data resource by introducing the binary_data field

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
test_name=TestAccKubernetesConfigMapV1Data_binaryData
--- PASS: TestAccKubernetesConfigMapV1Data_binaryData (2.89s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   3.695s
jaylon.mcshan@jaylon terraform-provider-kubernetes % 
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
