### PR TITLE
Revert "Remove CephFS volume support from the Kubernetes provider #2613"

### DIFF
--- a/.changelog/2613.txt
+++ b/.changelog/2613.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-Removed deprecated support for CephFS volumes in the Kubernetes provider to align with updated Kubernetes storage options.
-```

--- a/docs/data-sources/persistent_volume_v1.md
+++ b/docs/data-sources/persistent_volume_v1.md
@@ -66,6 +66,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--persistent_volume_source--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--persistent_volume_source--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--persistent_volume_source--cinder))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--persistent_volume_source--csi))
 - `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--fc))
@@ -124,6 +125,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--persistent_volume_source--ceph_fs"></a>
+### Nested Schema for `spec.persistent_volume_source.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.persistent_volume_source.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--persistent_volume_source--cinder"></a>

--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -1650,6 +1650,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--csi))
@@ -1717,6 +1718,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--job_template--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.job_template.spec.template.spec.volume.cinder`

--- a/docs/resources/cron_job_v1.md
+++ b/docs/resources/cron_job_v1.md
@@ -1645,6 +1645,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--csi))
@@ -1712,6 +1713,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--job_template--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--job_template--spec--template--spec--volume--cinder"></a>

--- a/docs/resources/daemon_set_v1.md
+++ b/docs/resources/daemon_set_v1.md
@@ -1595,6 +1595,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1662,6 +1663,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>

--- a/docs/resources/daemonset.md
+++ b/docs/resources/daemonset.md
@@ -1595,6 +1595,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1662,6 +1663,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -1595,6 +1595,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1662,6 +1663,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/docs/resources/deployment_v1.md
+++ b/docs/resources/deployment_v1.md
@@ -1603,6 +1603,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1670,6 +1671,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -1603,6 +1603,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1670,6 +1671,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>

--- a/docs/resources/job_v1.md
+++ b/docs/resources/job_v1.md
@@ -1601,6 +1601,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1668,6 +1669,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/docs/resources/persistent_volume.md
+++ b/docs/resources/persistent_volume.md
@@ -67,6 +67,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--persistent_volume_source--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--persistent_volume_source--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--persistent_volume_source--cinder))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--persistent_volume_source--csi))
 - `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--fc))
@@ -125,6 +126,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--persistent_volume_source--ceph_fs"></a>
+### Nested Schema for `spec.persistent_volume_source.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.persistent_volume_source.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--persistent_volume_source--cinder"></a>

--- a/docs/resources/persistent_volume_v1.md
+++ b/docs/resources/persistent_volume_v1.md
@@ -67,6 +67,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--persistent_volume_source--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--persistent_volume_source--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--persistent_volume_source--cinder))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--persistent_volume_source--csi))
 - `fc` (Block List, Max: 1) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. (see [below for nested schema](#nestedblock--spec--persistent_volume_source--fc))
@@ -125,6 +126,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--persistent_volume_source--ceph_fs"></a>
+### Nested Schema for `spec.persistent_volume_source.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--persistent_volume_source--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.persistent_volume_source.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--persistent_volume_source--cinder"></a>

--- a/docs/resources/pod.md
+++ b/docs/resources/pod.md
@@ -1556,6 +1556,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--volume--csi))
@@ -1623,6 +1624,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--volume--cinder"></a>
 ### Nested Schema for `spec.volume.cinder`

--- a/docs/resources/pod_v1.md
+++ b/docs/resources/pod_v1.md
@@ -1554,6 +1554,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--volume--csi))
@@ -1621,6 +1622,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--volume--cinder"></a>

--- a/docs/resources/replication_controller.md
+++ b/docs/resources/replication_controller.md
@@ -1592,6 +1592,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1659,6 +1660,31 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
 
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>

--- a/docs/resources/replication_controller_v1.md
+++ b/docs/resources/replication_controller_v1.md
@@ -1590,6 +1590,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1657,6 +1658,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/docs/resources/stateful_set.md
+++ b/docs/resources/stateful_set.md
@@ -1622,6 +1622,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1689,6 +1690,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/docs/resources/stateful_set_v1.md
+++ b/docs/resources/stateful_set_v1.md
@@ -1627,6 +1627,7 @@ Optional:
 - `aws_elastic_block_store` (Block List, Max: 1) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore (see [below for nested schema](#nestedblock--spec--template--spec--volume--aws_elastic_block_store))
 - `azure_disk` (Block List, Max: 1) Represents an Azure Data Disk mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_disk))
 - `azure_file` (Block List, Max: 1) Represents an Azure File Service mount on the host and bind mount to the pod. (see [below for nested schema](#nestedblock--spec--template--spec--volume--azure_file))
+- `ceph_fs` (Block List, Max: 1) Represents a Ceph FS mount on the host that shares a pod's lifetime (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs))
 - `cinder` (Block List, Max: 1) Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md (see [below for nested schema](#nestedblock--spec--template--spec--volume--cinder))
 - `config_map` (Block List, Max: 1) ConfigMap represents a configMap that should populate this volume (see [below for nested schema](#nestedblock--spec--template--spec--volume--config_map))
 - `csi` (Block List, Max: 1) Represents a CSI Volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#csi (see [below for nested schema](#nestedblock--spec--template--spec--volume--csi))
@@ -1694,6 +1695,32 @@ Optional:
 
 - `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
 - `secret_namespace` (String) The namespace of the secret that contains Azure Storage Account Name and Key. For Kubernetes up to 1.18.x the default is the same as the Pod. For Kubernetes 1.19.x and later the default is "default" namespace.
+
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs`
+
+Required:
+
+- `monitors` (Set of String) Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+Optional:
+
+- `path` (String) Used as the mounted root, rather than the full Ceph tree, default is /
+- `read_only` (Boolean) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_file` (String) The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+- `secret_ref` (Block List, Max: 1) Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it (see [below for nested schema](#nestedblock--spec--template--spec--volume--ceph_fs--secret_ref))
+- `user` (String) User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+<a id="nestedblock--spec--template--spec--volume--ceph_fs--secret_ref"></a>
+### Nested Schema for `spec.template.spec.volume.ceph_fs.secret_ref`
+
+Optional:
+
+- `name` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+- `namespace` (String) Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
 
 <a id="nestedblock--spec--template--spec--volume--cinder"></a>
 ### Nested Schema for `spec.template.spec.volume.cinder`

--- a/kubernetes/schema_volume_source.go
+++ b/kubernetes/schema_volume_source.go
@@ -197,6 +197,44 @@ func commonVolumeSources() map[string]*schema.Schema {
 				},
 			},
 		},
+		"ceph_fs": {
+			Type:        schema.TypeList,
+			Description: "Represents a Ceph FS mount on the host that shares a pod's lifetime",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"monitors": {
+						Type:        schema.TypeSet,
+						Description: "Monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+						Required:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
+					},
+					"path": {
+						Type:        schema.TypeString,
+						Description: "Used as the mounted root, rather than the full Ceph tree, default is /",
+						Optional:    true,
+					},
+					"read_only": {
+						Type:        schema.TypeBool,
+						Description: "Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+						Optional:    true,
+					},
+					"secret_file": {
+						Type:        schema.TypeString,
+						Description: "The path to key ring for User, default is `/etc/ceph/user.secret`. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+						Optional:    true,
+					},
+					"secret_ref": commonVolumeSourcesSecretRef("Reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"),
+					"user": {
+						Type:        schema.TypeString,
+						Description: "User is the rados user name, default is admin. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+						Optional:    true,
+					},
+				},
+			},
+		},
 		"cinder": {
 			Type:        schema.TypeList,
 			Description: "Represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -67,6 +67,27 @@ func flattenAzureFilePersistentVolumeSource(in *v1.AzureFilePersistentVolumeSour
 	return []interface{}{att}
 }
 
+func flattenCephFSPersistentVolumeSource(in *v1.CephFSPersistentVolumeSource) []interface{} {
+	att := make(map[string]interface{})
+	att["monitors"] = newStringSet(schema.HashString, in.Monitors)
+	if in.Path != "" {
+		att["path"] = in.Path
+	}
+	if in.User != "" {
+		att["user"] = in.User
+	}
+	if in.SecretFile != "" {
+		att["secret_file"] = in.SecretFile
+	}
+	if in.SecretRef != nil {
+		att["secret_ref"] = flattenSecretReference(in.SecretRef)
+	}
+	if in.ReadOnly {
+		att["read_only"] = in.ReadOnly
+	}
+	return []interface{}{att}
+}
+
 func flattenCinderPersistentVolumeSource(in *v1.CinderPersistentVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["volume_id"] = in.VolumeID
@@ -300,6 +321,9 @@ func flattenPersistentVolumeSource(in v1.PersistentVolumeSource) []interface{} {
 	}
 	if in.Cinder != nil {
 		att["cinder"] = flattenCinderPersistentVolumeSource(in.Cinder)
+	}
+	if in.CephFS != nil {
+		att["ceph_fs"] = flattenCephFSPersistentVolumeSource(in.CephFS)
 	}
 	if in.FC != nil {
 		att["fc"] = flattenFCVolumeSource(in.FC)
@@ -576,6 +600,32 @@ func expandAzureFilePersistentVolumeSource(l []interface{}) *v1.AzureFilePersist
 	}
 	if v, ok := in["secret_namespace"].(string); ok && v != "" {
 		obj.SecretNamespace = &v
+	}
+	return obj
+}
+
+func expandCephFSPersistentVolumeSource(l []interface{}) *v1.CephFSPersistentVolumeSource {
+	if len(l) == 0 || l[0] == nil {
+		return &v1.CephFSPersistentVolumeSource{}
+	}
+	in := l[0].(map[string]interface{})
+	obj := &v1.CephFSPersistentVolumeSource{
+		Monitors: sliceOfString(in["monitors"].(*schema.Set).List()),
+	}
+	if v, ok := in["path"].(string); ok {
+		obj.Path = v
+	}
+	if v, ok := in["user"].(string); ok {
+		obj.User = v
+	}
+	if v, ok := in["secret_file"].(string); ok {
+		obj.SecretFile = v
+	}
+	if v, ok := in["secret_ref"].([]interface{}); ok && len(v) > 0 {
+		obj.SecretRef = expandSecretReference(v)
+	}
+	if v, ok := in["read_only"].(bool); ok {
+		obj.ReadOnly = v
 	}
 	return obj
 }
@@ -886,6 +936,9 @@ func expandPersistentVolumeSource(l []interface{}) v1.PersistentVolumeSource {
 	}
 	if v, ok := in["cinder"].([]interface{}); ok && len(v) > 0 {
 		obj.Cinder = expandCinderPersistentVolumeSource(v)
+	}
+	if v, ok := in["ceph_fs"].([]interface{}); ok && len(v) > 0 {
+		obj.CephFS = expandCephFSPersistentVolumeSource(v)
 	}
 	if v, ok := in["fc"].([]interface{}); ok && len(v) > 0 {
 		obj.FC = expandFCVolumeSource(v)


### PR DESCRIPTION
This reverts commit 317cfd132ead5f4b80af3adb3ca974387c777374.

This reverts commit b3c02878f7cdaccf3de578b4c89efc9f96798c97.

This is meant for the major release of `v3.0.0`

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
