### PR TITLE
`CI`: add `v3-major-release` into CI testing

### DIFF
--- a/.github/workflows/acceptance_test_dfa.yaml
+++ b/.github/workflows/acceptance_test_dfa.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - "manifest/**/*.go"
       - 'kubernetes/**/*.go'

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -18,6 +18,7 @@ on:
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - 'kubernetes/*.go'
       - 'go.mod'
@@ -41,12 +42,17 @@ jobs:
       matrix:
         kubernetes_version:
           # kind images: https://github.com/kubernetes-sigs/kind/releases (note the images are kind release specific)
+          - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
           - v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
           - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
           - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
           - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
           - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
           - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+        include:
+          # This version will only run on the 'v3-major-release' branch
+          - kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
+            branches: ['v3-major-release']
     steps:
       - name: Checkout repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - v3-major-release
     paths:
       - "_examples/kubernetes_manifest/**"
       - "**.go"
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - "_examples/kubernetes_manifest/**"
       - "**.go"

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - '**/*.go'
       - '**/go.mod'

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - v3-major-release
     paths:
       - "manifest/**/*.go"
       - "manifest/**/go.mod"
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - "manifest/**/*.go"
       - "manifest/**/go.mod"
@@ -29,12 +31,17 @@ jobs:
         kubernetes_version:
           # kind images: https://github.com/kubernetes-sigs/kind/releases
           - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
-          - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
-          - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
-          - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
-          - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+          - v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+          - v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58
+          - v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843
+          - v1.26.14@sha256:5d648992dda1fdf1f613e927146ba965f4c6e3c3bda1f2f1b99a45b2be7b0195
+        include:
+          # This version will only run on the 'v3-major-release' branch
+          - kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
+            branches: ['v3-major-release']
+
         terraform_version:
+          - 1.9.8
           - 1.8.5
           - 1.6.6
           - 1.5.7
@@ -43,6 +50,7 @@ jobs:
           - 1.2.9
           - 1.1.9
           - 1.0.11
+
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Set up Go
@@ -52,7 +60,7 @@ jobs:
       - name: Setup kind
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          version: v0.20.0
+          version: v0.21.0
           node_image: kindest/node:${{ matrix.kubernetes_version }}
           # By default, this action creates a cluster with the name 'chart-testing'
           cluster_name: manifest

--- a/.github/workflows/manifest_unit.yaml
+++ b/.github/workflows/manifest_unit.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - v3-major-release
     paths:
       - "manifest/**/*.go"
       - "manifest/**/go.mod"
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - "manifest/**/*.go"
       - "manifest/**/go.mod"

--- a/.github/workflows/provider_functions_unit.yaml
+++ b/.github/workflows/provider_functions_unit.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - v3-major-release
     paths:
       - "internal/framework/provider/functions/**/*.go"
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - "internal/framework/provider/functions/**/*.go"
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v3-major-release
   pull_request:
     branches:
       - main
+      - v3-major-release
     paths:
       - 'kubernetes/*.go'
   workflow_dispatch:


### PR DESCRIPTION
### Description

This sets up GHA to run our tests on `v3-major-release` branch and any PRs opened onto it.

I've ensured that `v1.31.2` ONLY runs on the Major release branch. Not doing this would cause failures on main that would be unrelated since main currently doesn't support `v1.31.2`

I've also added another TF version for manifest testing, with the latest release of `1.9.8`

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
