### PR TITLE
`CI`: proper version checking for `v1.31.2` version testing

### DIFF
--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         kubernetes_version:
           # kind images: https://github.com/kubernetes-sigs/kind/releases (note the images are kind release specific)
+          - v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
           - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
           - v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
           - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
@@ -49,10 +50,11 @@ jobs:
           - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
           - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
           - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
-        include:
-          # This version will only run on the 'v3-major-release' branch
-          - kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-            branches: ['v3-major-release']
+        isMain:
+          - ${{ contains(github.ref, 'main') }}
+        exclude:
+          - isMain: true
+            kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
     steps:
       - name: Checkout repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -29,16 +29,20 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes_version:
-          # kind images: https://github.com/kubernetes-sigs/kind/releases
+          # kind images: https://github.com/kubernetes-sigs/kind/releases (note the images are kind release specific)
+          - v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
           - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
-          - v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
-          - v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58
-          - v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843
-          - v1.26.14@sha256:5d648992dda1fdf1f613e927146ba965f4c6e3c3bda1f2f1b99a45b2be7b0195
-        include:
-          # This version will only run on the 'v3-major-release' branch
-          - kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-            branches: ['v3-major-release']
+          - v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
+          - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
+          - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
+          - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
+          - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+        isMain:
+          - ${{ contains(github.ref, 'main') }}
+        exclude:
+          - isMain: true
+            kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
 
         terraform_version:
           - 1.9.8


### PR DESCRIPTION
The branch check was not done correctly. This PR corrects the mistake from https://github.com/hashicorp/terraform-provider-kubernetes/pull/2619

GHA runs can be found here:

Checks for main, runs all k8s versions except for `v1.31.2`: https://github.com/BBBmau/terraform-provider-kubernetes/actions/runs/11844946716

Checks for v3-main-release, all k8s version including `v1.31.2` are ran: https://github.com/BBBmau/terraform-provider-kubernetes/actions/runs/11844947578

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
