### PR TITLE
CI: use include to prevent PRs on main to use `v1.31.2`

### DIFF
--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -50,10 +50,10 @@ jobs:
           - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
           - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
           - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
-        isMain:
-          - ${{ contains(github.ref, 'main') }}
+        isBaseMain:
+          - ${{ contains(github.base_ref, 'main') }}
         exclude:
-          - isMain: true
+          - isBaseMain: true
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
     steps:
       - name: Checkout repository

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -42,25 +42,23 @@ jobs:
       matrix:
         kubernetes_version:
           # kind images: https://github.com/kubernetes-sigs/kind/releases (note the images are kind release specific)
-          - v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-          - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
-          - v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
-          - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
-          - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          - v1.30.6@sha256:b6d08db72079ba5ae1f4a88a09025c0a904af3b52387643c285442afb05ab994
+          - v1.29.10@sha256:3b2d8c31753e6c8069d4fc4517264cd20e86fd36220671fb7d0a5855103aa84b
+          - v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251
+          - v1.27.16@sha256:2d21a61643eafc439905e18705b8186f3296384750a835ad7a005dceb9546d20
           - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
-          - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
-          - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
-        isMain:
-          - ${{ contains(github.ref, 'main') }}
+          - v1.26.15@sha256:c79602a44b4056d7e48dc20f7504350f1e87530fe953428b792def00bc1076dd
+        isMajorReleaseBranch:
+          - ${{ contains(github.ref, 'v3-major-release') }}
         isBaseMajorRelease:
           - ${{ contains(github.base_ref, 'v3-major-release') }}
-        exclude:
-          # Exclude if reference is main and base reference is not v3-major-release
-          - isMain: true
+        include:
+          # include if reference is v3-major-release and base reference is not v3-major-release
+          - isMajorReleaseBranch: true
             isBaseMajorRelease: false
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-          # Exclude if reference is not main and base reference is v3-major-release
-          - isMain: false
+          # include if reference is not v3-major-release and base reference is v3-major-release
+          - isMajorReleaseBranch: false
             isBaseMajorRelease: true
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
     steps:

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -27,7 +27,7 @@ on:
 
 env:
   KUBECONFIG: ${{ github.workspace }}/.kube/config
-  KIND_VERSION: ${{ github.event.inputs.kindVersion || vars.KIND_VERSION || '0.23.0' }}
+  KIND_VERSION: ${{ github.event.inputs.kindVersion || vars.KIND_VERSION || '0.25.0' }}
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS || '8' }}
   TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.9.2' }}
 
@@ -50,10 +50,18 @@ jobs:
           - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
           - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
           - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
-        isBaseMain:
-          - ${{ contains(github.base_ref, 'main') }}
+        isMain:
+          - ${{ contains(github.ref, 'main') }}
+        isBaseMajorRelease:
+          - ${{ contains(github.base_ref, 'v3-major-release') }}
         exclude:
-          - isBaseMain: true
+          # Exclude if reference is main and base reference is not v3-major-release
+          - isMain: true
+            isBaseMajorRelease: false
+            kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
+          # Exclude if reference is not main and base reference is v3-major-release
+          - isMain: false
+            isBaseMajorRelease: true
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
     steps:
       - name: Checkout repository

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -43,9 +43,11 @@ jobs:
         isBaseMajorRelease:
           - ${{ contains(github.base_ref, 'v3-major-release') }}
         exclude:
+          # Exclude if reference is main and base reference is not v3-major-release
           - isMain: true
             isBaseMajorRelease: false
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
+          # Exclude if reference is not main and base reference is v3-major-release
           - isMain: false
             isBaseMajorRelease: true
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -40,10 +40,15 @@ jobs:
           - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
         isMain:
           - ${{ contains(github.ref, 'main') }}
+        isBaseMajorRelease:
+          - ${{ contains(github.base_ref, 'v3-major-release') }}
         exclude:
           - isMain: true
+            isBaseMajorRelease: false
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-
+          - isMain: false
+            isBaseMajorRelease: true
+            kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
         terraform_version:
           - 1.9.8
           - 1.8.5

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -30,25 +30,23 @@ jobs:
       matrix:
         kubernetes_version:
           # kind images: https://github.com/kubernetes-sigs/kind/releases (note the images are kind release specific)
-          - v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-          - v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
-          - v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
-          - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
-          - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          - v1.30.6@sha256:b6d08db72079ba5ae1f4a88a09025c0a904af3b52387643c285442afb05ab994
+          - v1.29.10@sha256:3b2d8c31753e6c8069d4fc4517264cd20e86fd36220671fb7d0a5855103aa84b
+          - v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251
+          - v1.27.16@sha256:2d21a61643eafc439905e18705b8186f3296384750a835ad7a005dceb9546d20
           - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
-          - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
-          - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
-        isMain:
-          - ${{ contains(github.ref, 'main') }}
+          - v1.26.15@sha256:c79602a44b4056d7e48dc20f7504350f1e87530fe953428b792def00bc1076dd
+        isMajorReleaseBranch:
+          - ${{ contains(github.ref, 'v3-major-release') }}
         isBaseMajorRelease:
           - ${{ contains(github.base_ref, 'v3-major-release') }}
-        exclude:
-          # Exclude if reference is main and base reference is not v3-major-release
-          - isMain: true
+        include:
+          # include if reference is v3-major-release and base reference is not v3-major-release
+          - isMajorReleaseBranch: true
             isBaseMajorRelease: false
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
-          # Exclude if reference is not main and base reference is v3-major-release
-          - isMain: false
+          # include if reference is not v3-major-release and base reference is v3-major-release
+          - isMajorReleaseBranch: false
             isBaseMajorRelease: true
             kubernetes_version: v1.31.2@sha256:33034c0a75dd82b2f2f22bdf0a30ea2a42b2c3547a6d56c52c7ea9c1b5fb89b9
         terraform_version:
@@ -71,7 +69,7 @@ jobs:
       - name: Setup kind
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          version: v0.21.0
+          version: v0.25.0
           node_image: kindest/node:${{ matrix.kubernetes_version }}
           # By default, this action creates a cluster with the name 'chart-testing'
           cluster_name: manifest


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

replace exclude with include to make it easier to understand what's happening with the matrix strategy. `v1.31.2` should only be ran on PRs opened on `v3-major-release` as well as when `v3-major-release` receives new commits.

Also updates kind and the kind images to use the latest `v0.25` version as this version contains the latest `v1.31.2` k8s version.

Tested in manifest acceptance tests here: https://github.com/BBBmau/terraform-provider-kubernetes/actions/workflows/manifest_acc.yaml


<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
