### PR TITLE
`CI`: require `Ephemeral` Tests to use `1.10` + add `1.10` TF into CI

### DIFF
--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -29,7 +29,7 @@ on:
 
 env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.10.1' }}
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
   TF_VAR_location: ${{ github.event.inputs.location || vars.AZURE_LOCATION }}
   TF_VAR_node_count: ${{ github.event.inputs.nodeCount || vars.AZURE_NODE_COUNT }}

--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -34,7 +34,7 @@ env:
   AWS_REGION: ${{ github.event.inputs.region || vars.AWS_REGION }}
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/eks/kubeconfig
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.10.1' }}
   TF_VAR_az_span: ${{ github.event.inputs.azSpan || vars.AWS_AZ_NUMBER }}
   TF_VAR_capacity_type: ${{ vars.AWS_CAPACITY_TYPE }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION }}

--- a/.github/workflows/acceptance_tests_gke.yaml
+++ b/.github/workflows/acceptance_tests_gke.yaml
@@ -37,7 +37,7 @@ env:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/gke/kubeconfig
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.10.1' }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION }}
   TF_VAR_node_count: ${{ github.event.inputs.nodeCount || vars.GOOGLE_NODE_COUNT }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType || vars.GOOGLE_INSTANCE_TYPE }}

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -11,7 +11,7 @@ on:
         default: "^TestAcc"
       terraformVersion:
         description: Terraform version
-        default: 1.10.0-rc3 # FIXME update this once 1.10 goes out 
+        default: 1.10.1
       parallelRuns:
         description: The maximum number of tests to run simultaneously
         default: 8
@@ -29,7 +29,7 @@ env:
   KUBECONFIG: ${{ github.workspace }}/.kube/config
   KIND_VERSION: ${{ github.event.inputs.kindVersion || vars.KIND_VERSION || '0.25.0' }}
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS || '8' }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.10.0-rc3' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.10.1' }}
 
 jobs:
   acceptance_tests_kind:

--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -32,6 +32,7 @@ jobs:
           - "1.6.0"
           - "1.7.0"
           - "1.8.0"
+          - "1.10.1"
     env:
       TF_X_KUBERNETES_MANIFEST_RESOURCE: 1
       TERM: linux

--- a/internal/framework/provider/authenticationv1/ephemeral_token_request_v1_test.go
+++ b/internal/framework/provider/authenticationv1/ephemeral_token_request_v1_test.go
@@ -18,6 +18,9 @@ func TestAccEpehemeralTokenRequest_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireVersion("1.10.0"),
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testEphemeralTokenRequestV1Config(name, namespace),

--- a/internal/framework/provider/authenticationv1/ephemeral_token_request_v1_test.go
+++ b/internal/framework/provider/authenticationv1/ephemeral_token_request_v1_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestAccEpehemeralTokenRequest_basic(t *testing.T) {
@@ -19,7 +20,7 @@ func TestAccEpehemeralTokenRequest_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.RequireVersion("1.10.0"),
+			tfversion.SkipBelow(tfversion.Version1_10_0),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/internal/framework/provider/certificatesv1/ephemeral_certificate_signing_request_v1_test.go
+++ b/internal/framework/provider/certificatesv1/ephemeral_certificate_signing_request_v1_test.go
@@ -17,6 +17,9 @@ func TestAccEpehemeralCertificateSigningRequest_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireVersion("1.10.0"),
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testEphemeralCertificateSigningRequestRequestV1Config(name),

--- a/internal/framework/provider/certificatesv1/ephemeral_certificate_signing_request_v1_test.go
+++ b/internal/framework/provider/certificatesv1/ephemeral_certificate_signing_request_v1_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestAccEpehemeralCertificateSigningRequest_basic(t *testing.T) {
@@ -18,7 +19,7 @@ func TestAccEpehemeralCertificateSigningRequest_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.RequireVersion("1.10.0"),
+			tfversion.SkipBelow(tfversion.Version1_10_0),
 		},
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
### Description

resolves CI failures due to having 1.9 being used despite Ephemeral Resources being merged. (only works with TF 1.10+)

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
