### PR TITLE
`CI`: remove the use of Github vars in workflows

### DIFF
--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -29,12 +29,12 @@ on:
 
 env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
-  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
-  TF_VAR_location: ${{ github.event.inputs.location || vars.AZURE_LOCATION }}
-  TF_VAR_node_count: ${{ github.event.inputs.nodeCount || vars.AZURE_NODE_COUNT }}
-  TF_VAR_vm_size: ${{ github.event.inputs.vmSize || vars.AZURE_VM_SIZE }}  
-  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION}}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
+  TF_VAR_location: ${{ github.event.inputs.location || 'canadaeast' }}
+  TF_VAR_node_count: ${{ github.event.inputs.nodeCount || '2' }}
+  TF_VAR_vm_size: ${{ github.event.inputs.vmSize || 'Standard_A2_v2' }}  
+  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || '1.29' }}
   
 jobs:
   acceptance_tests_aks:

--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -31,15 +31,15 @@ on:
     - cron: '0 20 * * *'
 
 env:
-  AWS_REGION: ${{ github.event.inputs.region || vars.AWS_REGION }}
+  AWS_REGION: ${{ github.event.inputs.region || 'ca-central-1' }}
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/eks/kubeconfig
-  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
-  TF_VAR_az_span: ${{ github.event.inputs.azSpan || vars.AWS_AZ_NUMBER }}
-  TF_VAR_capacity_type: ${{ vars.AWS_CAPACITY_TYPE }}
-  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION }}
-  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz || vars.AWS_NODES_PER_AZ }}
-  TF_VAR_instance_type: ${{ github.event.inputs.instanceType || vars.AWS_INSTANCE_TYPE }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
+  TF_VAR_az_span: ${{ github.event.inputs.azSpan || '2' }}
+  TF_VAR_capacity_type: ${{ 'SPOT' }}
+  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || '1.29' }}
+  TF_VAR_nodes_per_az: ${{ github.event.inputs.nodesPerAz || '1' }}
+  TF_VAR_instance_type: ${{ github.event.inputs.instanceType || 'm7g.large' }}
 
 jobs:
   acceptance_tests_eks:

--- a/.github/workflows/acceptance_tests_gke.yaml
+++ b/.github/workflows/acceptance_tests_gke.yaml
@@ -32,15 +32,15 @@ on:
 
 env:
   GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-  GOOGLE_REGION: ${{ github.event.inputs.region || vars.GOOGLE_REGION }}
-  GOOGLE_ZONE: ${{github.event.inputs.zone || vars.GOOGLE_ZONE }}
+  GOOGLE_REGION: ${{ github.event.inputs.region || 'northamerica-northeast1' }}
+  GOOGLE_ZONE: ${{github.event.inputs.zone || 'northamerica-northeast1-a' }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/gke/kubeconfig
-  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION }}
-  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || vars.CLUSTER_VERSION }}
-  TF_VAR_node_count: ${{ github.event.inputs.nodeCount || vars.GOOGLE_NODE_COUNT }}
-  TF_VAR_instance_type: ${{ github.event.inputs.instanceType || vars.GOOGLE_INSTANCE_TYPE }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
+  TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || '1.29' }}
+  TF_VAR_node_count: ${{ github.event.inputs.nodeCount || '1' }}
+  TF_VAR_instance_type: ${{ github.event.inputs.instanceType || 'e2-standard-2' }}
 
 jobs:
   acceptance_tests_gke:

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -27,9 +27,9 @@ on:
 
 env:
   KUBECONFIG: ${{ github.workspace }}/.kube/config
-  KIND_VERSION: ${{ github.event.inputs.kindVersion || vars.KIND_VERSION || '0.25.0' }}
-  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || vars.PARALLEL_RUNS || '8' }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || vars.TERRAFORM_VERSION || '1.10.0-rc3' }}
+  KIND_VERSION: ${{ github.event.inputs.kindVersion || '0.25.0' }}
+  PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
 
 jobs:
   acceptance_tests_kind:


### PR DESCRIPTION
### Description

removes the use of variables to use the values that are explicitly set in GHA, just copies the values found in settings (using canada over US):

![image](https://github.com/user-attachments/assets/25c60c47-0197-4c13-bec6-65ffbc645a4b)

should be merged once https://github.com/hashicorp/terraform-provider-kubernetes/pull/2642 is merged

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
