### PR TITLE
add  field for PersistentVolumeClaim resource

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim_v1.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_v1.go
@@ -103,6 +103,15 @@ func resourceKubernetesPersistentVolumeClaimV1Create(ctx context.Context, d *sch
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	if claim.Spec.DataSource != nil {
+		_, err := conn.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Spec.DataSource.Name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return diag.Errorf("data source PersistentVolumeClaim '%s' not found", claim.Spec.DataSource.Name)
+			}
+			return diag.FromErr(err)
+		}
+	}
 	log.Printf("[INFO] Creating new persistent volume claim: %#v", claim)
 	out, err := conn.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(ctx, claim, metav1.CreateOptions{})
 	if err != nil {

--- a/kubernetes/schema_persistent_volume_claim.go
+++ b/kubernetes/schema_persistent_volume_claim.go
@@ -66,6 +66,31 @@ func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
 				},
 			},
 		},
+		"data_source": {
+			Type:        schema.TypeList,
+			Description: "Specifies the data source for the PVC. Allows creating a PVC from another PVC, VolumeSnapshot, or VolumePopulator.",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"persistent_volume_claim": {
+						Type:        schema.TypeList,
+						Description: "Details of the source PersistentVolumeClaim.",
+						Required:    true,
+						MaxItems:    1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"claim_name": {
+									Type:        schema.TypeString,
+									Description: "The name of the source PersistentVolumeClaim.",
+									Required:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"selector": {
 			Type:        schema.TypeList,
 			Description: "A label query over volumes to consider for binding.",


### PR DESCRIPTION
### Description
Addresses #2608 

This pull request introduces the `data_source` field for the PersistentVolumeClaim resource. 

### Changes
1. Added `data_source` field to the PersistentVolumeClaim schema.
2. Implemented validation in the `Create` function to ensure the specified `data_source` PVC exists.
3. Included the new field in flatten and expand method.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
2024-12-09T10:14:13.480-0600 [DEBUG] sdk.helper_resource: Called TestCase CheckDestroy: test_step_number=2 test_terraform_path=/opt/homebrew/bin/terraform test_name=TestAccKubernetesPersistentVolumeClaimV1_dataSource test_working_directory=/var/folders/bp/l16ph9cj7958ml9t254_zcv00000gn/T/plugintest3860028569
2024-12-09T10:14:13.482-0600 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccKubernetesPersistentVolumeClaimV1_dataSource
--- PASS: TestAccKubernetesPersistentVolumeClaimV1_dataSource (3.21s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   3.824s
jaylon.mcshan@jaylon terraform-provider-kubernetes % 


2024-12-09T10:15:00.499-0600 [DEBUG] sdk.helper_resource: Started sdkv2 provider instance server: tf_provider_addr=registry.terraform.io/hashicorp/kubernetes test_name=TestAccKubernetesPersistentVolumeClaimV1_invalidDataSource test_terraform_path=/opt/homebrew/bin/terraform test_working_directory=/var/folders/bp/l16ph9cj7958ml9t254_zcv00000gn/T/plugintest1113338307 test_step_number=1
2024-12-09T10:15:00.558-0600 [DEBUG] sdk.helper_resource: Stopping providers: test_working_directory=/var/folders/bp/l16ph9cj7958ml9t254_zcv00000gn/T/plugintest1113338307 test_step_number=1 test_name=TestAccKubernetesPersistentVolumeClaimV1_invalidDataSource test_terraform_path=/opt/homebrew/bin/terraform
2024-12-09T10:15:00.560-0600 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccKubernetesPersistentVolumeClaimV1_invalidDataSource
--- PASS: TestAccKubernetesPersistentVolumeClaimV1_invalidDataSource (0.51s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   1.248s
jaylon.mcshan@jaylon terraform-provider-kubernetes % 
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
