### PR TITLE
Completely disable `typeCache` in `getTypeFromSchema`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/hashstructure v1.1.0
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/mod v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,6 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
-github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
-github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/manifest/openapi/schema.go
+++ b/manifest/openapi/schema.go
@@ -13,7 +13,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest"
-	"github.com/mitchellh/hashstructure"
 )
 
 func resolveSchemaRef(ref *openapi3.SchemaRef, defs map[string]*openapi3.SchemaRef) (*openapi3.Schema, error) {
@@ -60,7 +59,6 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 		return nil, errors.New("cannot convert OpenAPI type (nil)")
 	}
 
-	h, herr := hashstructure.Hash(elem, nil)
 
 	var t tftypes.Type
 
@@ -80,6 +78,8 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 
 	// check if type is in cache
 	// HACK: this is temporarily disabled to diagnose a cache corruption issue.
+	// At the time of removal hashstructure v1 ("github.com/mitchellh/hashstructure") was in use.
+	// h, herr := hashstructure.Hash(elem, nil)
 	// if herr == nil {
 	// 	if t, ok := typeCache.Load(h); ok {
 	// 		return t.(tftypes.Type), nil
@@ -133,9 +133,10 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 			} else {
 				t = tftypes.List{ElementType: et}
 			}
-			if herr == nil {
-				typeCache.Store(h, t)
-			}
+			// See above HACK
+			// if herr == nil {
+			// 	typeCache.Store(h, t)
+			// }
 			return t, nil
 		case elem.AdditionalProperties != nil && elem.Items == nil: // "overriden" array - translates to a tftypes.Tuple
 			it, err := resolveSchemaRef(elem.AdditionalProperties, defs)
@@ -170,9 +171,10 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 				atts[p] = pType
 			}
 			t = tftypes.Object{AttributeTypes: atts}
-			if herr == nil {
-				typeCache.Store(h, t)
-			}
+			// See above HACK
+			// if herr == nil {
+			// 	typeCache.Store(h, t)
+			// }
 			return t, nil
 
 		case elem.Properties == nil && elem.AdditionalProperties != nil:
@@ -187,17 +189,19 @@ func getTypeFromSchema(elem *openapi3.Schema, stackdepth uint64, typeCache *sync
 				return nil, err
 			}
 			t = tftypes.Map{ElementType: pt}
-			if herr == nil {
-				typeCache.Store(h, t)
-			}
+			// See above HACK
+			// if herr == nil {
+			// 	typeCache.Store(h, t)
+			// }
 			return t, nil
 
 		case elem.Properties == nil && elem.AdditionalProperties == nil:
 			// this is a strange case, encountered with io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1 and also io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus
 			t = tftypes.DynamicPseudoType
-			if herr == nil {
-				typeCache.Store(h, t)
-			}
+			// See above HACK
+			// if herr == nil {
+			// 	typeCache.Store(h, t)
+			// }
 			return t, nil
 
 		}


### PR DESCRIPTION
### Description

In 0f0be856541e7437f4c92b390dc21b0b98eff6e6, the usage `typeCache` was disabled in `getTypeFromSchema` due to schema corruption issues that have yet to be resolved.

Despite being disabled `elem` is still hashed and populated into the `typeCache` resulting in a dramatic waste of memory and compute.

This commit comments out all references of `typeCache` in `getTypeFromSchema`.

Tests on v2.30.0 with a dramatically large CRD (~4.0Mb) show a ~50% decrease in memory consumption:

```
❯ go tool pprof  memprof-no-cache
Showing nodes accounting for 177.72MB, 83.13% of 213.79MB total
Dropped 113 nodes (cum <= 1.07MB)
Showing top 10 nodes out of 133
      flat  flat%   sum%        cum   cum%
   47.75MB 22.34% 22.34%    48.26MB 22.57%  io.ReadAll
   31.37MB 14.67% 37.01%    31.37MB 14.67%  encoding/json.(*RawMessage).UnmarshalJSON
   24.51MB 11.46% 48.47%    37.01MB 17.31%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).objectInterface
      18MB  8.42% 56.89%    90.97MB 42.55%  encoding/json.Unmarshal
   15.51MB  7.25% 64.15%    15.51MB  7.25%  reflect.mapassign_faststr0
   14.50MB  6.78% 70.93%    14.50MB  6.78%  reflect.New
      10MB  4.68% 75.61%       10MB  4.68%  compress/flate.(*huffmanDecoder).init
    6.50MB  3.04% 78.65%    10.50MB  4.91%  sigs.k8s.io/json/internal/golang/encoding/json.unquote (inline)
       5MB  2.34% 80.99%        5MB  2.34%  encoding/json.(*scanner).pushParseState
    4.57MB  2.14% 83.13%     4.57MB  2.14%  net/http.init.func5

❯ go tool pprof  memprof-with-cache
File: acceptance.test
Type: alloc_space
Time: Dec 11, 2024 at 4:18pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 443.30MB, 89.03% of 497.90MB total
Dropped 150 nodes (cum <= 2.49MB)
Showing top 10 nodes out of 114
      flat  flat%   sum%        cum   cum%
  178.51MB 35.85% 35.85%   272.01MB 54.63%  github.com/mitchellh/hashstructure.(*walker).visit
   53.42MB 10.73% 46.58%    53.42MB 10.73%  io.ReadAll
      45MB  9.04% 55.62%       45MB  9.04%  encoding/binary.Write
   37.34MB  7.50% 63.12%    37.34MB  7.50%  encoding/json.(*RawMessage).UnmarshalJSON
   26.51MB  5.32% 68.44%    37.01MB  7.43%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).objectInterface
   25.50MB  5.12% 73.56%    25.50MB  5.12%  reflect.(*structType).Field
      23MB  4.62% 78.18%   108.49MB 21.79%  encoding/json.Unmarshal
   21.01MB  4.22% 82.40%    21.01MB  4.22%  reflect.packEface
   20.01MB  4.02% 86.42%    20.01MB  4.02%  reflect.mapassign_faststr0
      13MB  2.61% 89.03%       13MB  2.61%  reflect.New
```

### Acceptance tests
The cache itself appears to be write only, I'm happy to run the acceptance tests but there should be any functional changes.

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Reduced memory consumption of `kubernetes_manifest` by up to 50%
```

### References

This was discovered by my team while digging into some crashes in our integration tests following an, admittedly massive, [update of our redpanda CRD](https://github.com/redpanda-data/redpanda-operator/commit/dbe048184836d832e5cb05d9ddac4b16e0566e7b)
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
