### PR TITLE
Fix crash when `image_pull_secret.name` set to an empty string

### DIFF
--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -607,6 +607,12 @@ func expandLocalObjectReferenceArray(in []interface{}) []api.LocalObjectReferenc
 	}
 	att = make([]api.LocalObjectReference, len(in))
 	for i, c := range in {
+		// If an item is an empty string, we treat it as nil.
+		// Kubernetes accepts an empty string as a name but issues a warning: `invalid empty name ""`.
+		// Therefore, we should handle this case appropriately.
+		if c == nil {
+			continue
+		}
 		p := c.(map[string]interface{})
 		if name, ok := p["name"]; ok {
 			att[i].Name = name.(string)


### PR DESCRIPTION
### Description

WIP.

### References

Fix: https://github.com/hashicorp/terraform-provider-kubernetes/issues/2654

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
