### PR TITLE
fix(app): #2645 Fixed data source label selection

### DIFF
--- a/kubernetes/data_source_kubernetes_pod_v1.go
+++ b/kubernetes/data_source_kubernetes_pod_v1.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,6 +42,7 @@ func dataSourceKubernetesPodV1() *schema.Resource {
 }
 
 func dataSourceKubernetesPodV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var pod v1.Pod
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
 		return diag.FromErr(err)
@@ -54,8 +56,32 @@ func dataSourceKubernetesPodV1Read(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.SetId(buildId(om))
 
-	log.Printf("[INFO] Reading pod %s", metadata.Name)
-	pod, err := conn.CoreV1().Pods(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})
+	pods := conn.CoreV1().Pods(metadata.Namespace)
+
+	if metadata.Name != "" {
+		log.Printf("[INFO] Getting pod %s", metadata.Name)
+		podResult, getErr := pods.Get(ctx, metadata.Name, metav1.GetOptions{})
+		if getErr != nil {
+			err = getErr
+		} else {
+			pod = *podResult
+		}
+	} else {
+		log.Printf("[INFO] Listing pods")
+		listOptions := metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{MatchLabels: metadata.Labels}),
+		}
+		podList, listErr := pods.List(ctx, listOptions)
+		if listErr != nil {
+			err = listErr
+		} else {
+			if len(podList.Items) == 0 {
+				return diag.Errorf("No pods found")
+			}
+			pod = podList.Items[0]
+		}
+	}
+
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
Fixed the missing implementation of selection with label in the datasource. Before it was only getting the pods with the name attribute, now it can select with labels

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
