### PR TITLE
Simplify the RBAC subject patch by removing old subjects and then adding new ones

### DIFF
--- a/kubernetes/structures_rbac.go
+++ b/kubernetes/structures_rbac.go
@@ -159,36 +159,19 @@ func flattenClusterRoleAggregationRule(in *api.AggregationRule) []interface{} {
 
 // Patch Ops
 func patchRbacSubject(d *schema.ResourceData) PatchOperations {
-	o, n := d.GetChange("subject")
-	oldsubjects := expandRBACSubjects(o.([]interface{}))
-	newsubjects := expandRBACSubjects(n.([]interface{}))
-	ops := make([]PatchOperation, 0, len(newsubjects)+len(oldsubjects))
+	_, n := d.GetChange("subject")
+	newSubjects := expandRBACSubjects(n.([]interface{}))
 
-	common := len(newsubjects)
-	if common > len(oldsubjects) {
-		common = len(oldsubjects)
+	ops := PatchOperations{
+		&RemoveOperation{
+			Path: "/subjects",
+		},
+		&AddOperation{
+			Path:  "/subjects",
+			Value: newSubjects,
+		},
 	}
-	if len(oldsubjects) > len(newsubjects) {
-		for i := len(newsubjects); i < len(oldsubjects); i++ {
-			ops = append(ops, &RemoveOperation{
-				Path: "/subjects/" + strconv.Itoa(len(oldsubjects)-i),
-			})
-		}
-	}
-	for i, v := range newsubjects[:common] {
-		ops = append(ops, &ReplaceOperation{
-			Path:  "/subjects/" + strconv.Itoa(i),
-			Value: v,
-		})
-	}
-	if len(newsubjects) > len(oldsubjects) {
-		for i, v := range newsubjects[common:] {
-			ops = append(ops, &AddOperation{
-				Path:  "/subjects/" + strconv.Itoa(common+i),
-				Value: v,
-			})
-		}
-	}
+
 	return ops
 }
 


### PR DESCRIPTION
### Description

There is an issue regarding how the provider’s Update function applies JSON patches to the subjects array. In particular, the patching logic does not remove subjects that were removed from the Terraform configuration, and it also doesn’t handle re‐indexing when the set of subjects changes. This results in an out‐of‐sync subjects array in Kubernetes whenever the Terraform configuration removes or reorders subjects.

For example, when updating the subjects mixed of "Group" and "ServiceAccount" kind for a RBAC rule (either `ClusterRoleBinding` or `RoleBinding`), we may get the following error

```
Error: Failed to update RoleBinding: RoleBinding.rbac.authorization.k8s.io "can-manage-sandboxes" is invalid: subjects[1].apiGroup: Unsupported value: "rbac.authorization.k8s.io": supported values: ""
```

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
