### PR TITLE
Do less Kubernetes API requests

### DIFF
--- a/.changelog/2699.txt
+++ b/.changelog/2699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed goroutine-safety in the CRD and metadata cache, resulting in far fewer provider metadata requests.
+```

--- a/manifest/provider/cache.go
+++ b/manifest/provider/cache.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import "sync"

--- a/manifest/provider/cache.go
+++ b/manifest/provider/cache.go
@@ -1,0 +1,16 @@
+package provider
+
+import "sync"
+
+type cache[T any] struct {
+	once  sync.Once
+	value T
+	err   error
+}
+
+func (c *cache[T]) Get(f func() (T, error)) (T, error) {
+	c.once.Do(func() {
+		c.value, c.err = f()
+	})
+	return c.value, c.err
+}

--- a/manifest/provider/clients.go
+++ b/manifest/provider/clients.go
@@ -31,98 +31,71 @@ const (
 
 // getDynamicClient returns a configured unstructured (dynamic) client instance
 func (ps *RawProviderServer) getDynamicClient() (dynamic.Interface, error) {
-	if ps.dynamicClient != nil {
-		return ps.dynamicClient, nil
-	}
 	if ps.clientConfig == nil {
 		return nil, fmt.Errorf("cannot create dynamic client: no client config")
 	}
-	dynClient, err := dynamic.NewForConfig(ps.clientConfig)
-	if err != nil {
-		return nil, err
-	}
-	ps.dynamicClient = dynClient
-	return dynClient, nil
+
+	return ps.dynamicClient.Get(func() (dynamic.Interface, error) {
+		return dynamic.NewForConfig(ps.clientConfig)
+	})
 }
 
 // getDiscoveryClient returns a configured discovery client instance.
 func (ps *RawProviderServer) getDiscoveryClient() (discovery.DiscoveryInterface, error) {
-	if ps.discoveryClient != nil {
-		return ps.discoveryClient, nil
-	}
 	if ps.clientConfig == nil {
 		return nil, fmt.Errorf("cannot create discovery client: no client config")
 	}
-	discoClient, err := discovery.NewDiscoveryClientForConfig(ps.clientConfig)
-	if err != nil {
-		return nil, err
-	}
-	ps.discoveryClient = discoClient
-	return discoClient, nil
+
+	return ps.discoveryClient.Get(func() (discovery.DiscoveryInterface, error) {
+		return discovery.NewDiscoveryClientForConfig(ps.clientConfig)
+	})
 }
 
 // getRestMapper returns a RESTMapper client instance
 func (ps *RawProviderServer) getRestMapper() (meta.RESTMapper, error) {
-	if ps.restMapper != nil {
-		return ps.restMapper, nil
-	}
-	dc, err := ps.getDiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
+	return ps.restMapper.Get(func() (meta.RESTMapper, error) {
+		dc, err := ps.getDiscoveryClient()
+		if err != nil {
+			return nil, err
+		}
 
-	// agr, err := restmapper.GetAPIGroupResources(dc)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// mapper := restmapper.NewDeferredDiscoveryRESTMapper(agr)
-
-	cache := memory.NewMemCacheClient(dc)
-	ps.restMapper = restmapper.NewDeferredDiscoveryRESTMapper(cache)
-	return ps.restMapper, nil
+		cacheClient := memory.NewMemCacheClient(dc)
+		return restmapper.NewDeferredDiscoveryRESTMapper(cacheClient), nil
+	})
 }
 
 // getRestClient returns a raw REST client instance
 func (ps *RawProviderServer) getRestClient() (rest.Interface, error) {
-	if ps.restClient != nil {
-		return ps.restClient, nil
-	}
 	if ps.clientConfig == nil {
 		return nil, fmt.Errorf("cannot create REST client: no client config")
 	}
-	restClient, err := rest.UnversionedRESTClientFor(ps.clientConfig)
-	if err != nil {
-		return nil, err
-	}
-	ps.restClient = restClient
-	return restClient, nil
+
+	return ps.restClient.Get(func() (rest.Interface, error) {
+		return rest.UnversionedRESTClientFor(ps.clientConfig)
+	})
 }
 
 // getOAPIv2Foundry returns an interface to request tftype types from an OpenAPIv2 spec
 func (ps *RawProviderServer) getOAPIv2Foundry() (openapi.Foundry, error) {
-	if ps.OAPIFoundry != nil {
-		return ps.OAPIFoundry, nil
-	}
+	return ps.OAPIFoundry.Get(func() (openapi.Foundry, error) {
+		rc, err := ps.getRestClient()
+		if err != nil {
+			return nil, fmt.Errorf("failed get OpenAPI spec: %s", err)
+		}
 
-	rc, err := ps.getRestClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed get OpenAPI spec: %s", err)
-	}
+		rq := rc.Verb("GET").Timeout(30*time.Second).AbsPath("openapi", "v2")
+		rs, err := rq.DoRaw(context.TODO())
+		if err != nil {
+			return nil, fmt.Errorf("failed get OpenAPI spec: %s", err)
+		}
 
-	rq := rc.Verb("GET").Timeout(30*time.Second).AbsPath("openapi", "v2")
-	rs, err := rq.DoRaw(context.TODO())
-	if err != nil {
-		return nil, fmt.Errorf("failed get OpenAPI spec: %s", err)
-	}
+		oapif, err := openapi.NewFoundryFromSpecV2(rs)
+		if err != nil {
+			return nil, fmt.Errorf("failed construct OpenAPI foundry: %s", err)
+		}
 
-	oapif, err := openapi.NewFoundryFromSpecV2(rs)
-	if err != nil {
-		return nil, fmt.Errorf("failed construct OpenAPI foundry: %s", err)
-	}
-
-	ps.OAPIFoundry = oapif
-
-	return oapif, nil
+		return oapif, nil
+	})
 }
 
 func loggingTransport(rt http.RoundTripper) http.RoundTripper {
@@ -145,34 +118,38 @@ func (t *loggingRountTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return t.lt.RoundTrip(req)
 }
 
-func (ps *RawProviderServer) checkValidCredentials(ctx context.Context) (diags []*tfprotov5.Diagnostic) {
-	rc, err := ps.getRestClient()
-	if err != nil {
-		diags = append(diags, &tfprotov5.Diagnostic{
-			Severity: tfprotov5.DiagnosticSeverityError,
-			Summary:  "Failed to construct REST client",
-			Detail:   err.Error(),
-		})
-		return
-	}
-	vpath := []string{"/apis"}
-	rs := rc.Get().AbsPath(vpath...).Do(ctx)
-	if rs.Error() != nil {
-		switch {
-		case apierrors.IsUnauthorized(rs.Error()):
+func (ps *RawProviderServer) checkValidCredentials(ctx context.Context) []*tfprotov5.Diagnostic {
+	diagnostics, _ := ps.checkValidCredentialsResult.Get(func() (diags []*tfprotov5.Diagnostic, err error) {
+		rc, err := ps.getRestClient()
+		if err != nil {
 			diags = append(diags, &tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,
-				Summary:  "Invalid credentials",
-				Detail:   fmt.Sprintf("The credentials configured in the provider block are not accepted by the API server. Error: %s\n\nSet TF_LOG=debug and look for '[InvalidClientConfiguration]' in the log to see actual configuration.", rs.Error().Error()),
+				Summary:  "Failed to construct REST client",
+				Detail:   err.Error(),
 			})
-		default:
-			diags = append(diags, &tfprotov5.Diagnostic{
-				Severity: tfprotov5.DiagnosticSeverityError,
-				Summary:  "Invalid configuration for API client",
-				Detail:   rs.Error().Error(),
-			})
+			return
 		}
-		ps.logger.Debug("[InvalidClientConfiguration]", "Config", dump(ps.clientConfig))
-	}
-	return
+		vpath := []string{"/apis"}
+		rs := rc.Get().AbsPath(vpath...).Do(ctx)
+		if rs.Error() != nil {
+			switch {
+			case apierrors.IsUnauthorized(rs.Error()):
+				diags = append(diags, &tfprotov5.Diagnostic{
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Invalid credentials",
+					Detail:   fmt.Sprintf("The credentials configured in the provider block are not accepted by the API server. Error: %s\n\nSet TF_LOG=debug and look for '[InvalidClientConfiguration]' in the log to see actual configuration.", rs.Error().Error()),
+				})
+			default:
+				diags = append(diags, &tfprotov5.Diagnostic{
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Invalid configuration for API client",
+					Detail:   rs.Error().Error(),
+				})
+			}
+			ps.logger.Debug("[InvalidClientConfiguration]", "Config", dump(ps.clientConfig))
+		}
+		return
+	})
+
+	return diagnostics
 }

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -34,14 +35,16 @@ type RawProviderServer struct {
 	// Since the provider is essentially a gRPC server, the execution flow is dictated by the order of the client (Terraform) request calls.
 	// Thus it needs a way to persist state between the gRPC calls. These attributes store values that need to be persisted between gRPC calls,
 	// such as instances of the Kubernetes clients, configuration options needed at runtime.
-	logger              hclog.Logger
-	clientConfig        *rest.Config
-	clientConfigUnknown bool
-	dynamicClient       dynamic.Interface
-	discoveryClient     discovery.DiscoveryInterface
-	restMapper          meta.RESTMapper
-	restClient          rest.Interface
-	OAPIFoundry         openapi.Foundry
+	logger                      hclog.Logger
+	clientConfig                *rest.Config
+	clientConfigUnknown         bool
+	dynamicClient               cache[dynamic.Interface]
+	discoveryClient             cache[discovery.DiscoveryInterface]
+	restMapper                  cache[meta.RESTMapper]
+	restClient                  cache[rest.Interface]
+	OAPIFoundry                 cache[openapi.Foundry]
+	crds                        cache[[]unstructured.Unstructured]
+	checkValidCredentialsResult cache[[]*tfprotov5.Diagnostic]
 
 	hostTFVersion string
 }


### PR DESCRIPTION
### Description

The first reason why provider does so many requests is because its caches aren't goroutine-safe. For example, Terraform invokes provider concurrently and every individual goroutine starts its own getOAPIv2Foundry() invocation. Every getOAPIv2Foundry() starts its own Kubernetes API request and these requests consume Kubernetes client Burst leading eventually to a stall.

The second reason is that CRDs should also be cached because production Kubernetes clusters may have lots and lots of CRDs and getting them all is not cheap. Furthermore, getting them over and over consumes Kubernetes client Burst leading to a major stall.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Do less Kubernetes API invocations
Make `RawProviderServer` caches goroutine-safe
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
