### PR TITLE
Update terraform versions in github actions

### DIFF
--- a/.github/workflows/acceptance_test_dfa.yaml
+++ b/.github/workflows/acceptance_test_dfa.yaml
@@ -13,7 +13,7 @@ on:
     inputs:
       terraformVersion:
         description: Terraform version
-        default: 1.10.0-alpha20240807
+        default: 1.11.2
 
 jobs:
   acceptance_tests:
@@ -29,6 +29,6 @@ jobs:
       - name: Run Tests
         env:
           TF_ACC: 1
-          TF_ACC_TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.9.0-alpha20240516' }}
+          TF_ACC_TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.11.2' }}
         run: |
           go test -v -run '^TestAccKubernetesDeferredActions' ./kubernetes/test-dfa

--- a/.github/workflows/acceptance_tests_aks.yaml
+++ b/.github/workflows/acceptance_tests_aks.yaml
@@ -17,7 +17,7 @@ on:
         default: "1.27"
       terraformVersion:
         description: Terraform version
-        default: 1.7.5
+        default: 1.11.2
       runTests:
         description: The regex passed to the -run option of `go test`
         default: "^TestAcc"
@@ -29,7 +29,7 @@ on:
 
 env:
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/aks/kubeconfig
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.11.2' }}
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
   TF_VAR_location: ${{ github.event.inputs.location || 'canadaeast' }}
   TF_VAR_node_count: ${{ github.event.inputs.nodeCount || '2' }}

--- a/.github/workflows/acceptance_tests_eks.yaml
+++ b/.github/workflows/acceptance_tests_eks.yaml
@@ -26,7 +26,7 @@ on:
         default: "^TestAcc"
       terraformVersion:
         description: Terraform version
-        default: 1.7.5
+        default: 1.11.2
   schedule:
     - cron: '0 20 * * *'
 
@@ -34,7 +34,7 @@ env:
   AWS_REGION: ${{ github.event.inputs.region || 'ca-central-1' }}
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/eks/kubeconfig
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.11.2' }}
   TF_VAR_az_span: ${{ github.event.inputs.azSpan || '2' }}
   TF_VAR_capacity_type: ${{ 'SPOT' }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || '1.29' }}

--- a/.github/workflows/acceptance_tests_gke.yaml
+++ b/.github/workflows/acceptance_tests_gke.yaml
@@ -26,7 +26,7 @@ on:
         default: "^TestAcc"
       terraformVersion:
         description: Terraform version
-        default: 1.7.5
+        default: 1.11.2
   schedule:
     - cron: '0 23 * * *'
 
@@ -37,7 +37,7 @@ env:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   KUBE_CONFIG_PATH: ${{ github.workspace }}/kubernetes/test-infra/gke/kubeconfig
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.10.1' }}
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.11.2' }}
   TF_VAR_cluster_version: ${{ github.event.inputs.clusterVersion || '1.29' }}
   TF_VAR_node_count: ${{ github.event.inputs.nodeCount || '1' }}
   TF_VAR_instance_type: ${{ github.event.inputs.instanceType || 'e2-standard-2' }}

--- a/.github/workflows/acceptance_tests_kind.yaml
+++ b/.github/workflows/acceptance_tests_kind.yaml
@@ -11,7 +11,7 @@ on:
         default: "^TestAcc"
       terraformVersion:
         description: Terraform version
-        default: 1.11.0-rc1 # FIXME change this v1.11.0 is released
+        default: 1.11.2
       parallelRuns:
         description: The maximum number of tests to run simultaneously
         default: 8
@@ -29,7 +29,7 @@ env:
   KUBECONFIG: ${{ github.workspace }}/.kube/config
   KIND_VERSION: ${{ github.event.inputs.kindVersion || '0.25.0' }}
   PARALLEL_RUNS: ${{ github.event.inputs.parallelRuns || '8' }}
-  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.11.0-rc1' }} # FIXME change when v1.11.0 is released
+  TERRAFORM_VERSION: ${{ github.event.inputs.terraformVersion || '1.11.2' }} 
   
 jobs:
   acceptance_tests_kind:

--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -26,13 +26,11 @@ jobs:
     strategy:
       matrix:
         terraform_version:
-          - "1.2.9"
-          - "1.3.9"
-          - "1.4.0"
           - "1.6.0"
           - "1.7.0"
           - "1.8.0"
           - "1.10.1"
+          - "1.11.2"
     env:
       TF_X_KUBERNETES_MANIFEST_RESOURCE: 1
       TERM: linux

--- a/.github/workflows/manifest_acc.yaml
+++ b/.github/workflows/manifest_acc.yaml
@@ -50,6 +50,8 @@ jobs:
             isBaseMajorRelease: true
             kubernetes_version: v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30  
         terraform_version:
+          - 1.11.2
+          - 1.10.5
           - 1.9.8
           - 1.8.5
           - 1.6.6

--- a/.github/workflows/provider_functions_unit.yaml
+++ b/.github/workflows/provider_functions_unit.yaml
@@ -29,6 +29,6 @@ jobs:
         run: go mod verify
       - name: Run unit tests
         env:
-          TF_ACC_TERRAFORM_VERSION: 1.8.0
+          TF_ACC_TERRAFORM_VERSION: 1.11.2
         run: |
           make testfuncs


### PR DESCRIPTION
### Description

This PR updates terraform to the latest version in github actions workflows.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
