### PR TITLE
docs(kubernetes_manifest): Resource naming

### DIFF
--- a/docs/resources/manifest.md
+++ b/docs/resources/manifest.md
@@ -86,7 +86,7 @@ Optional:
 ### Example: Create a Kubernetes ConfigMap
 
 ```terraform
-resource "kubernetes_manifest" "test-configmap" {
+resource "kubernetes_manifest" "test_configmap" {
   manifest = {
     "apiVersion" = "v1"
     "kind"       = "ConfigMap"
@@ -104,7 +104,7 @@ resource "kubernetes_manifest" "test-configmap" {
 ### Example: Create a Kubernetes Custom Resource Definition
 
 ```terraform
-resource "kubernetes_manifest" "test-crd" {
+resource "kubernetes_manifest" "test_crd" {
   manifest = {
     apiVersion = "apiextensions.k8s.io/v1"
     kind       = "CustomResourceDefinition"


### PR DESCRIPTION
### Description
The documentation regarding the kubernetes manifest resource contains examples naming resources with hyphen (-) this PR replaces them with underscore (_) to follow terraform codestyle standards


Let me know if there is anything else I should  do. 
Thank you

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
