### PR TITLE
Add resource identity to kubernetes_manifest

### DIFF
--- a/.changelog/2737.txt
+++ b/.changelog/2737.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add ResourceIdentity support to kubernetes_manifest
+```

--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -20,9 +20,11 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-var defaultCreateTimeout = "10m"
-var defaultUpdateTimeout = "10m"
-var defaultDeleteTimeout = "10m"
+var (
+	defaultCreateTimeout = "10m"
+	defaultUpdateTimeout = "10m"
+	defaultDeleteTimeout = "10m"
+)
 
 // ApplyResourceChange function
 func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest) (*tfprotov5.ApplyResourceChangeResponse, error) {
@@ -482,6 +484,15 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			return resp, err
 		}
 		resp.NewState = &newResState
+
+		// set resource identity data
+		idData, err := createIdentityData(result)
+		if err != nil {
+			return resp, err
+		}
+		resp.NewIdentity = &tfprotov5.ResourceIdentityData{
+			IdentityData: &idData,
+		}
 	case applyPlannedState.IsNull():
 		// Delete the resource
 		priorStateVal := make(map[string]tftypes.Value)

--- a/manifest/provider/read.go
+++ b/manifest/provider/read.go
@@ -194,5 +194,15 @@ func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Rea
 		return resp, err
 	}
 	resp.NewState = &newState
+
+	// set resource identity data
+	idData, err := createIdentityData(ro)
+	if err != nil {
+		return resp, err
+	}
+	resp.NewIdentity = &tfprotov5.ResourceIdentityData{
+		IdentityData: &idData,
+	}
+
 	return resp, nil
 }

--- a/manifest/provider/resourceidentity.go
+++ b/manifest/provider/resourceidentity.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/manifest/provider/resourceidentity.go
+++ b/manifest/provider/resourceidentity.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func (s *RawProviderServer) GetResourceIdentitySchemas(ctx context.Context, req *tfprotov5.GetResourceIdentitySchemasRequest) (*tfprotov5.GetResourceIdentitySchemasResponse, error) {
+	s.logger.Trace("[GetResourceIdentitySchemas][Request]\n%s\n", dump(*req))
+	resp := &tfprotov5.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: map[string]*tfprotov5.ResourceIdentitySchema{
+			"kubernetes_manifest": {
+				Version: 1,
+				IdentityAttributes: []*tfprotov5.ResourceIdentitySchemaAttribute{
+					{Name: "api_version", RequiredForImport: true, Type: tftypes.String},
+					{Name: "kind", RequiredForImport: true, Type: tftypes.String},
+					{Name: "name", RequiredForImport: true, Type: tftypes.String},
+					{Name: "namespace", RequiredForImport: true, Type: tftypes.String},
+				},
+			},
+		},
+	}
+	return resp, nil
+}
+
+func (s *RawProviderServer) UpgradeResourceIdentity(ctx context.Context, req *tfprotov5.UpgradeResourceIdentityRequest) (*tfprotov5.UpgradeResourceIdentityResponse, error) {
+	s.logger.Trace("[UpgradeResourceIdentity][Request]\n%s\n", dump(*req))
+	resp := &tfprotov5.UpgradeResourceIdentityResponse{}
+	return resp, nil
+}
+
+func getIdentityType() tftypes.Type {
+	return tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"namespace":   tftypes.String,
+			"name":        tftypes.String,
+			"api_version": tftypes.String,
+			"kind":        tftypes.String,
+		},
+	}
+}
+
+func createIdentityData(obj *unstructured.Unstructured) (tfprotov5.DynamicValue, error) {
+	idVal := tftypes.NewValue(getIdentityType(), map[string]tftypes.Value{
+		"namespace":   tftypes.NewValue(tftypes.String, obj.GetNamespace()),
+		"name":        tftypes.NewValue(tftypes.String, obj.GetName()),
+		"api_version": tftypes.NewValue(tftypes.String, obj.GetAPIVersion()),
+		"kind":        tftypes.NewValue(tftypes.String, obj.GetKind()),
+	})
+	return tfprotov5.NewDynamicValue(idVal.Type(), idVal)
+}

--- a/manifest/provider/server.go
+++ b/manifest/provider/server.go
@@ -23,9 +23,11 @@ func init() {
 	install.Install(scheme.Scheme)
 }
 
-var _ tfprotov5.ProviderServer = &RawProviderServer{}
-var _ tfprotov5.ResourceServer = &RawProviderServer{}
-var _ tfprotov5.DataSourceServer = &RawProviderServer{}
+var (
+	_ tfprotov5.ProviderServer   = &RawProviderServer{}
+	_ tfprotov5.ResourceServer   = &RawProviderServer{}
+	_ tfprotov5.DataSourceServer = &RawProviderServer{}
+)
 
 // RawProviderServer implements the ProviderServer interface as exported from ProtoBuf.
 type RawProviderServer struct {
@@ -134,17 +136,5 @@ func (s *RawProviderServer) RenewEphemeralResource(ctx context.Context, req *tfp
 func (s *RawProviderServer) ValidateEphemeralResourceConfig(ctx context.Context, req *tfprotov5.ValidateEphemeralResourceConfigRequest) (*tfprotov5.ValidateEphemeralResourceConfigResponse, error) {
 	s.logger.Trace("[ValidateEphemeralResourceConfig][Request]\n%s\n", dump(*req))
 	resp := &tfprotov5.ValidateEphemeralResourceConfigResponse{}
-	return resp, nil
-}
-
-func (s *RawProviderServer) GetResourceIdentitySchemas(ctx context.Context, req *tfprotov5.GetResourceIdentitySchemasRequest) (*tfprotov5.GetResourceIdentitySchemasResponse, error) {
-	s.logger.Trace("[GetResourceIdentitySchemas][Request]\n%s\n", dump(*req))
-	resp := &tfprotov5.GetResourceIdentitySchemasResponse{}
-	return resp, nil
-}
-
-func (s *RawProviderServer) UpgradeResourceIdentity(ctx context.Context, req *tfprotov5.UpgradeResourceIdentityRequest) (*tfprotov5.UpgradeResourceIdentityResponse, error) {
-	s.logger.Trace("[UpgradeResourceIdentity][Request]\n%s\n", dump(*req))
-	resp := &tfprotov5.UpgradeResourceIdentityResponse{}
 	return resp, nil
 }

--- a/manifest/test/acceptance/configmap_test.go
+++ b/manifest/test/acceptance/configmap_test.go
@@ -87,4 +87,9 @@ func TestKubernetesManifest_ConfigMap(t *testing.T) {
 	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
 
 	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+
+	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "api_version", "v1")
+	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "kind", "ConfigMap")
+	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "name", name)
+	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "namespace", namespace)
 }

--- a/manifest/test/acceptance/configmap_test.go
+++ b/manifest/test/acceptance/configmap_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/kubernetes"
 	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes/manifest/test/helper/state"
@@ -88,8 +89,17 @@ func TestKubernetesManifest_ConfigMap(t *testing.T) {
 
 	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
 
-	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "api_version", "v1")
-	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "kind", "ConfigMap")
-	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "name", name)
-	tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "namespace", namespace)
+	tfversion, err := tf.Version(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve terraform version: %v", err)
+	}
+	constraint, _ := version.NewConstraint(">= 1.12.0")
+	if constraint.Check(tfversion) {
+		tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "api_version", "v1")
+		tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "kind", "ConfigMap")
+		tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "name", name)
+		tfstate.AssertIdentityValueEqual(t, "kubernetes_manifest.test", "namespace", namespace)
+	} else {
+		t.Logf("Skipping identity assertions because terraform version %s is less than 1.12.0", tfversion)
+	}
 }

--- a/manifest/test/helper/state/state_helper.go
+++ b/manifest/test/helper/state/state_helper.go
@@ -145,7 +145,7 @@ func (s *Helper) GetIdentityValue(t *testing.T, address string, identitykey stri
 
 	val, ok := identityvals[identitykey]
 	if !ok {
-		t.Fatalf("resource identity value %q does note exist for %q", identitykey, address)
+		t.Fatalf("resource identity value %q does not exist for %q", identitykey, address)
 	}
 	return val
 }

--- a/manifest/test/helper/state/state_helper.go
+++ b/manifest/test/helper/state/state_helper.go
@@ -26,6 +26,7 @@ type Helper struct {
 func NewHelper(tfstate *tfjson.State) *Helper {
 	return &Helper{tfstate}
 }
+
 func (s *Helper) ResourceExists(t *testing.T, resourceAddress string) bool {
 	t.Helper()
 	_, err := getAttributesValuesFromResource(s, resourceAddress)
@@ -37,6 +38,16 @@ func getAttributesValuesFromResource(state *Helper, address string) (interface{}
 	for _, r := range state.Values.RootModule.Resources {
 		if r.Address == address {
 			return r.AttributeValues, nil
+		}
+	}
+	return nil, fmt.Errorf("Could not find resource %q in state", address)
+}
+
+// getIdentityValues pulls out the getIdentityValues field from the resource at the given address
+func getIdentityValuesFromResource(state *Helper, address string) (map[string]any, error) {
+	for _, r := range state.Values.RootModule.Resources {
+		if r.Address == address {
+			return r.IdentityValues, nil
 		}
 	}
 	return nil, fmt.Errorf("Could not find resource %q in state", address)
@@ -95,10 +106,10 @@ func parseStateAddress(address string) (string, string) {
 	switch parts[0] {
 	case "data":
 		resourceAddress = strings.Join(parts[0:3], ".")
-		attributeAddress = strings.Join(parts[3:len(parts)], ".")
+		attributeAddress = strings.Join(parts[3:], ".")
 	default:
 		resourceAddress = strings.Join(parts[0:2], ".")
-		attributeAddress = strings.Join(parts[2:len(parts)], ".")
+		attributeAddress = strings.Join(parts[2:], ".")
 	}
 
 	return resourceAddress, attributeAddress
@@ -121,6 +132,22 @@ func (s *Helper) GetAttributeValue(t *testing.T, address string) interface{} {
 	}
 
 	return value
+}
+
+// GetIdentityValue will get the identity value at the given resource address from the state
+func (s *Helper) GetIdentityValue(t *testing.T, address string, identitykey string) interface{} {
+	t.Helper()
+
+	identityvals, err := getIdentityValuesFromResource(s, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, ok := identityvals[identitykey]
+	if !ok {
+		t.Fatalf("resource identity value %q does note exist for %q", identitykey, address)
+	}
+	return val
 }
 
 // GetOutputValue gets the given output name value from the state
@@ -155,6 +182,14 @@ func (s *Helper) AssertAttributeEqual(t *testing.T, address string, expectedValu
 
 	assert.EqualValues(t, expectedValue, s.GetAttributeValue(t, address),
 		fmt.Sprintf("Address: %q", address))
+}
+
+// AssertIdentityValueEqual will fail the test if the identity value does not equal expectedValue
+func (s *Helper) AssertIdentityValueEqual(t *testing.T, address string, identitykey string, expectedValue interface{}) {
+	t.Helper()
+
+	assert.EqualValues(t, expectedValue, s.GetIdentityValue(t, address, identitykey),
+		fmt.Sprintf("Resource: %q, Identity key: %q", address, identitykey))
 }
 
 // AssertAttributeNotEqual will fail the test if the attribute is equal to expectedValue

--- a/manifest/test/plugintest/working_dir.go
+++ b/manifest/test/plugintest/working_dir.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/test/logging"
@@ -84,7 +86,7 @@ func (wd *WorkingDir) SetConfig(ctx context.Context, cfg string) error {
 	if err := os.Remove(rmFilename); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("unable to remove %q: %w", rmFilename, err)
 	}
-	err := os.WriteFile(outFilename, bCfg, 0700)
+	err := os.WriteFile(outFilename, bCfg, 0o700)
 	if err != nil {
 		return err
 	}
@@ -325,4 +327,17 @@ func (wd *WorkingDir) Schemas(ctx context.Context) (*tfjson.ProviderSchemas, err
 	logging.HelperResourceTrace(ctx, "Called Terraform CLI providers schema command")
 
 	return providerSchemas, err
+}
+
+// Version returns the current version of Terraform
+//
+// If the version cannot be read, Version returns an error.
+func (wd *WorkingDir) Version(ctx context.Context) (*version.Version, error) {
+	logging.HelperResourceTrace(ctx, "Calling Terraform CLI providers version command")
+
+	version, _, err := wd.tf.Version(context.Background(), false)
+
+	logging.HelperResourceTrace(ctx, "Called Terraform CLI providers version command")
+
+	return version, err
 }


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
