### PR TITLE
Resource identity support in SDKv2 Resources

### DIFF
--- a/.changelog/2751.txt
+++ b/.changelog/2751.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add support for ResourceIdentity to SDKv2 resources
+```

--- a/.github/workflows/checkers-and-linters.yml
+++ b/.github/workflows/checkers-and-linters.yml
@@ -21,7 +21,7 @@ jobs:
         go-version-file: 'go.mod'
     # Secrets are not available on pull requests.
     - name: Login to Docker Hub
-      if: github.ref == 'refs/heads/main'
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
       with:
         username: ${{ secrets.RO_DOCKERHUB_USER }}

--- a/kubernetes/resource_kubernetes_cluster_role_v1.go
+++ b/kubernetes/resource_kubernetes_cluster_role_v1.go
@@ -23,9 +23,9 @@ func resourceKubernetesClusterRoleV1() *schema.Resource {
 		UpdateContext: resourceKubernetesClusterRoleV1Update,
 		DeleteContext: resourceKubernetesClusterRoleV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNonNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNonNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchemaRBAC("clusterRole", true, false),
 			"rule": {
@@ -158,6 +158,10 @@ func resourceKubernetesClusterRoleV1Read(ctx context.Context, d *schema.Resource
 		if err != nil {
 			return diag.FromErr(err)
 		}
+	}
+	err = setResourceIdentityNonNamespaced(d, "rbac.authorization.k8s.io/v1", "ClusterRole", name)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/kubernetes/resource_kubernetes_cron_job_v1.go
+++ b/kubernetes/resource_kubernetes_cron_job_v1.go
@@ -27,8 +27,9 @@ func resourceKubernetesCronJobV1() *schema.Resource {
 		UpdateContext: resourceKubernetesCronJobV1Update,
 		DeleteContext: resourceKubernetesCronJobV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		Timeouts: &schema.ResourceTimeout{
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
@@ -160,6 +161,10 @@ func resourceKubernetesCronJobV1Read(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
+	err = setResourceIdentityNamespaced(d, "batch/v1", "CronJob", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_daemon_set_v1.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1.go
@@ -30,8 +30,9 @@ func resourceKubernetesDaemonSetV1() *schema.Resource {
 		UpdateContext: resourceKubernetesDaemonSetV1Update,
 		DeleteContext: resourceKubernetesDaemonSetV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
@@ -277,6 +278,10 @@ func resourceKubernetesDaemonSetV1Read(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	err = setResourceIdentityNamespaced(d, "apps/v1", "DaemonSet", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_deployment_v1.go
+++ b/kubernetes/resource_kubernetes_deployment_v1.go
@@ -36,8 +36,9 @@ func resourceKubernetesDeploymentV1() *schema.Resource {
 		UpdateContext: resourceKubernetesDeploymentV1Update,
 		DeleteContext: resourceKubernetesDeploymentV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
@@ -365,6 +366,11 @@ func resourceKubernetesDeploymentV1Read(ctx context.Context, d *schema.ResourceD
 	}
 
 	err = d.Set("spec", spec)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNamespaced(d, "apps/v1", "Deployment", namespace, name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_v2.go
@@ -24,10 +24,11 @@ func resourceKubernetesHorizontalPodAutoscalerV2() *schema.Resource {
 		ReadContext:   resourceKubernetesHorizontalPodAutoscalerV2Read,
 		UpdateContext: resourceKubernetesHorizontalPodAutoscalerV2Update,
 		DeleteContext: resourceKubernetesHorizontalPodAutoscalerV2Delete,
+		Schema:        horizontalPodAutoscalerSchemaV2(),
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-		Schema: horizontalPodAutoscalerSchemaV2(),
+		Identity: resourceIdentitySchemaNamespaced(),
 	}
 }
 
@@ -95,7 +96,10 @@ func resourceKubernetesHorizontalPodAutoscalerV2Read(ctx context.Context, d *sch
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+	err = setResourceIdentityNamespaced(d, "autoscaling/v2", "HorizontalPodAutoscaler", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_ingress_class_v1.go
+++ b/kubernetes/resource_kubernetes_ingress_class_v1.go
@@ -25,10 +25,11 @@ func resourceKubernetesIngressClassV1() *schema.Resource {
 		ReadContext:   resourceKubernetesIngressClassV1Read,
 		UpdateContext: resourceKubernetesIngressClassV1Update,
 		DeleteContext: resourceKubernetesIngressClassV1Delete,
+		Schema:        resourceKubernetesIngressClassV1Schema(),
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNonNamespaced,
 		},
-		Schema: resourceKubernetesIngressClassV1Schema(),
+		Identity: resourceIdentitySchemaNonNamespaced(),
 	}
 }
 
@@ -112,6 +113,11 @@ func resourceKubernetesIngressClassV1Create(ctx context.Context, d *schema.Resou
 	log.Printf("[INFO] Submitted new IngressClass: %#v", out)
 	d.SetId(out.ObjectMeta.GetName())
 
+	err = setResourceIdentityNonNamespaced(d, "networking/v1", "IngressClass", out.GetName())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return diag.Diagnostics{}
 }
 
@@ -146,6 +152,11 @@ func resourceKubernetesIngressClassV1Read(ctx context.Context, d *schema.Resourc
 	flattened := flattenIngressClassV1Spec(ing.Spec)
 	log.Printf("[DEBUG] Flattened Ingress Class spec: %#v", flattened)
 	err = d.Set("spec", flattened)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNonNamespaced(d, "networking/v1", "IngressClass", ing.GetName())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_ingress_v1.go
+++ b/kubernetes/resource_kubernetes_ingress_v1.go
@@ -26,10 +26,11 @@ func resourceKubernetesIngressV1() *schema.Resource {
 		ReadContext:   resourceKubernetesIngressV1Read,
 		UpdateContext: resourceKubernetesIngressV1Update,
 		DeleteContext: resourceKubernetesIngressV1Delete,
+		Schema:        resourceKubernetesIngressV1Schema(),
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-		Schema: resourceKubernetesIngressV1Schema(),
+		Identity: resourceIdentitySchemaNamespaced(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
@@ -274,6 +275,10 @@ func resourceKubernetesIngressV1Read(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
+	err = setResourceIdentityNamespaced(d, "networking/v1", "Ingress", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -377,7 +377,7 @@ func TestAccKubernetesIngressV1_defaultIngressClass(t *testing.T) {
 
 func TestAccKubernetesIngressV1_identity(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	ingressClass := "default-ingress-class"
+	ingressClass := "identity-ingress-class"
 	resourceName := "kubernetes_ingress_v1.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/kubernetes/resource_kubernetes_job_v1.go
+++ b/kubernetes/resource_kubernetes_job_v1.go
@@ -29,8 +29,9 @@ func resourceKubernetesJobV1() *schema.Resource {
 		UpdateContext: resourceKubernetesJobV1Update,
 		DeleteContext: resourceKubernetesJobV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
@@ -156,6 +157,11 @@ func resourceKubernetesJobV1Read(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	err = d.Set("spec", jobSpec)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNamespaced(d, "batch/v1", "Job", namespace, name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_job_v1.go
+++ b/kubernetes/resource_kubernetes_job_v1.go
@@ -96,6 +96,10 @@ func resourceKubernetesJobV1Create(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[INFO] Submitted new job: %#v", out)
 
 	d.SetId(buildId(out.ObjectMeta))
+	err = setResourceIdentityNamespaced(d, "batch/v1", "Job", out.GetNamespace(), out.GetName())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
@@ -28,9 +28,9 @@ func resourceKubernetesMutatingWebhookConfigurationV1() *schema.Resource {
 		UpdateContext: resourceKubernetesMutatingWebhookConfigurationV1Update,
 		DeleteContext: resourceKubernetesMutatingWebhookConfigurationV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNonNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNonNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchema("mutating webhook configuration", true),
 			"webhook": {
@@ -194,6 +194,11 @@ func resourceKubernetesMutatingWebhookConfigurationV1Read(ctx context.Context, d
 	log.Printf("[DEBUG] Setting webhook to: %#v", cfg.Webhooks)
 
 	err = d.Set("webhook", flattenMutatingWebhooks(cfg.Webhooks))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNonNamespaced(d, "admissionregistration/v1", "MutatingWebhookConfiguration", name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_namespace_v1.go
+++ b/kubernetes/resource_kubernetes_namespace_v1.go
@@ -27,9 +27,9 @@ func resourceKubernetesNamespaceV1() *schema.Resource {
 		UpdateContext: resourceKubernetesNamespaceV1Update,
 		DeleteContext: resourceKubernetesNamespaceV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNonNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNonNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchema("namespace", true),
 			"wait_for_default_service_account": {
@@ -109,6 +109,11 @@ func resourceKubernetesNamespaceV1Read(ctx context.Context, d *schema.ResourceDa
 	}
 	log.Printf("[INFO] Received namespace: %#v", namespace)
 	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d, meta))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNonNamespaced(d, "v1", "Namespace", name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_network_policy_v1.go
+++ b/kubernetes/resource_kubernetes_network_policy_v1.go
@@ -44,9 +44,9 @@ func resourceKubernetesNetworkPolicyV1() *schema.Resource {
 		UpdateContext: resourceKubernetesNetworkPolicyV1Update,
 		DeleteContext: resourceKubernetesNetworkPolicyV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("network policy", true),
 			"spec": {
@@ -313,7 +313,10 @@ func resourceKubernetesNetworkPolicyV1Read(ctx context.Context, d *schema.Resour
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+	err = setResourceIdentityNamespaced(d, "networking/v1", "NetworkPolicy", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_pod_v1.go
+++ b/kubernetes/resource_kubernetes_pod_v1.go
@@ -28,8 +28,9 @@ func resourceKubernetesPodV1() *schema.Resource {
 		UpdateContext: resourceKubernetesPodV1Update,
 		DeleteContext: resourceKubernetesPodV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
@@ -96,7 +97,6 @@ func resourceKubernetesPodV1Create(ctx context.Context, d *schema.ResourceData, 
 
 	log.Printf("[INFO] Creating new pod: %#v", pod)
 	out, err := conn.CoreV1().Pods(metadata.Namespace).Create(ctx, &pod, metav1.CreateOptions{})
-
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -210,8 +210,12 @@ func resourceKubernetesPodV1Read(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return nil
 
+	err = setResourceIdentityNamespaced(d, "v1", "Pod", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
 }
 
 func resourceKubernetesPodV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/kubernetes/resource_kubernetes_role_binding_v1.go
+++ b/kubernetes/resource_kubernetes_role_binding_v1.go
@@ -23,9 +23,9 @@ func resourceKubernetesRoleBindingV1() *schema.Resource {
 		UpdateContext: resourceKubernetesRoleBindingV1Update,
 		DeleteContext: resourceKubernetesRoleBindingV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchemaRBAC("roleBinding", true, true),
 			"role_ref": {
@@ -65,7 +65,6 @@ func resourceKubernetesRoleBindingV1Create(ctx context.Context, d *schema.Resour
 	}
 	log.Printf("[INFO] Creating new RoleBinding: %#v", binding)
 	out, err := conn.RbacV1().RoleBindings(metadata.Namespace).Create(ctx, binding, metav1.CreateOptions{})
-
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -120,7 +119,10 @@ func resourceKubernetesRoleBindingV1Read(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+	err = setResourceIdentityNamespaced(d, "rbac.authorization.k8s.io/v1", "RoleBinding", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_role_v1.go
+++ b/kubernetes/resource_kubernetes_role_v1.go
@@ -24,9 +24,9 @@ func resourceKubernetesRoleV1() *schema.Resource {
 		UpdateContext: resourceKubernetesRoleV1Update,
 		DeleteContext: resourceKubernetesRoleV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchemaRBAC("role", true, true),
 			"rule": {
@@ -131,7 +131,10 @@ func resourceKubernetesRoleV1Read(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+	err = setResourceIdentityNamespaced(d, "rbac.authorization.k8s.io/v1", "Role", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_secret_v1.go
+++ b/kubernetes/resource_kubernetes_secret_v1.go
@@ -33,10 +33,7 @@ func resourceKubernetesSecretV1() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIdentityImportNamespaced,
 		},
-		Identity: &schema.ResourceIdentity{
-			Version:    1,
-			SchemaFunc: resourceIdentitySchema,
-		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 			if diff.Id() == "" {
 				return nil

--- a/kubernetes/resource_kubernetes_secret_v1.go
+++ b/kubernetes/resource_kubernetes_secret_v1.go
@@ -31,7 +31,11 @@ func resourceKubernetesSecretV1() *schema.Resource {
 		UpdateContext: resourceKubernetesSecretV1Update,
 		DeleteContext: resourceKubernetesSecretV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
+		},
+		Identity: &schema.ResourceIdentity{
+			Version:    1,
+			SchemaFunc: resourceIdentitySchema,
 		},
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 			if diff.Id() == "" {
@@ -283,6 +287,10 @@ func resourceKubernetesSecretV1Read(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Set("data", flattenByteMapToStringMap(secret.Data))
 
+	err = setResourceIdentityNamespaced(d, "v1", "Secret", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_secret_v1_test.go
+++ b/kubernetes/resource_kubernetes_secret_v1_test.go
@@ -587,7 +587,7 @@ func testAccKubernetesSecretV1Config_identity(name string) string {
   metadata {
     name = "%s"
   }
-  data = {}
+  data                           = {}
   wait_for_service_account_token = false
 }
 `, name)

--- a/kubernetes/resource_kubernetes_secret_v1_test.go
+++ b/kubernetes/resource_kubernetes_secret_v1_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 var idRefreshIgnoreCommon = []string{"metadata.0.resource_version", "metadata.0.labels", "metadata.0.annotations"}
@@ -400,6 +404,40 @@ func TestAccKubernetesSecretV1_service_account_token(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesSecretV1_identity(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_secret_v1.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesSecretV1Destroy,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesSecretV1Config_identity(name),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentity(
+						resourceName, map[string]knownvalue.Check{
+							"namespace":   knownvalue.StringExact("default"),
+							"name":        knownvalue.StringExact(name),
+							"api_version": knownvalue.StringExact("v1"),
+							"kind":        knownvalue.StringExact("Secret"),
+						},
+					),
+				},
+			},
+			{
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
 func testAccCheckSecretV1Data(m *corev1.Secret, expected map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(expected) == 0 && len(m.Data) == 0 {
@@ -540,6 +578,17 @@ func testAccKubernetesSecretV1Config_basic(name string) string {
     one = "first"
     two = "second"
   }
+}
+`, name)
+}
+
+func testAccKubernetesSecretV1Config_identity(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_secret_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  data = {}
+  wait_for_service_account_token = false
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_service_account_v1.go
+++ b/kubernetes/resource_kubernetes_service_account_v1.go
@@ -30,13 +30,12 @@ func resourceKubernetesServiceAccountV1() *schema.Resource {
 		UpdateContext: resourceKubernetesServiceAccountV1Update,
 		DeleteContext: resourceKubernetesServiceAccountV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceKubernetesServiceAccountV1ImportState,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNamespaced(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),
 		},
-
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("service account", true),
 			"image_pull_secret": {
@@ -303,6 +302,11 @@ func resourceKubernetesServiceAccountV1Read(ctx context.Context, d *schema.Resou
 	secrets := flattenServiceAccountSecrets(svcAcc.Secrets, defaultSecretName)
 	log.Printf("[DEBUG] Flattened secrets: %#v", secrets)
 	err = d.Set("secret", secrets)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNamespaced(d, "v1", "ServiceAccount", namespace, name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_service_v1.go
+++ b/kubernetes/resource_kubernetes_service_v1.go
@@ -28,9 +28,9 @@ func resourceKubernetesServiceV1() *schema.Resource {
 		UpdateContext: resourceKubernetesServiceV1Update,
 		DeleteContext: resourceKubernetesServiceV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNamespaced(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
@@ -430,6 +430,10 @@ func resourceKubernetesServiceV1Read(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
+	err = setResourceIdentityNamespaced(d, "v1", "Service", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/kubernetes/resource_kubernetes_stateful_set_v1.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1.go
@@ -31,8 +31,9 @@ func resourceKubernetesStatefulSetV1() *schema.Resource {
 		UpdateContext: resourceKubernetesStatefulSetV1Update,
 		DeleteContext: resourceKubernetesStatefulSetV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNamespaced,
 		},
+		Identity: resourceIdentitySchemaNamespaced(),
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
@@ -91,7 +92,6 @@ func resourceKubernetesStatefulSetV1Create(ctx context.Context, d *schema.Resour
 	log.Printf("[INFO] Creating new StatefulSet: %#v", statefulSet)
 
 	out, err := conn.AppsV1().StatefulSets(metadata.Namespace).Create(ctx, &statefulSet, metav1.CreateOptions{})
-
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -181,6 +181,11 @@ func resourceKubernetesStatefulSetV1Read(ctx context.Context, d *schema.Resource
 	err = d.Set("spec", sss)
 	if err != nil {
 		return diag.Errorf("Error setting `spec`: %+v", err)
+	}
+
+	err = setResourceIdentityNamespaced(d, "apps/v1", "StatefulSet", namespace, name)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1.go
@@ -30,9 +30,9 @@ func resourceKubernetesValidatingWebhookConfigurationV1() *schema.Resource {
 		UpdateContext: resourceKubernetesValidatingWebhookConfigurationV1Update,
 		DeleteContext: resourceKubernetesValidatingWebhookConfigurationV1Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIdentityImportNonNamespaced,
 		},
-
+		Identity: resourceIdentitySchemaNonNamespaced(),
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchema("validating webhook configuration", true),
 			"webhook": {
@@ -215,6 +215,11 @@ func resourceKubernetesValidatingWebhookConfigurationV1Read(ctx context.Context,
 	log.Printf("[DEBUG] Setting webhook to: %#v", cfg.Webhooks)
 
 	err = d.Set("webhook", flattenValidatingWebhooks(cfg.Webhooks))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setResourceIdentityNonNamespaced(d, "admissionregistration/v1", "ValidatingWebhookConfiguration", name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resourceidentity.go
+++ b/kubernetes/resourceidentity.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package kubernetes
 
 import (

--- a/kubernetes/resourceidentity.go
+++ b/kubernetes/resourceidentity.go
@@ -1,0 +1,96 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIdentitySchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"namespace": {
+			Type:              schema.TypeString,
+			OptionalForImport: true,
+		},
+		"name": {
+			Type:              schema.TypeString,
+			RequiredForImport: true,
+		},
+		"api_version": {
+			Type:              schema.TypeString,
+			RequiredForImport: true,
+		},
+		"kind": {
+			Type:              schema.TypeString,
+			RequiredForImport: true,
+		},
+	}
+}
+
+func resourceIdentityImportNamespaced(ctx context.Context, rd *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+	if rd.Id() != "" {
+		return []*schema.ResourceData{rd}, nil
+	}
+
+	rid, err := rd.Identity()
+	if err != nil {
+		return nil, err
+	}
+
+	namespace, ok := rid.Get("namespace").(string)
+	if !ok {
+		return nil, fmt.Errorf("could not get namespace from resource identity")
+	}
+	name, ok := rid.Get("name").(string)
+	if !ok {
+		return nil, fmt.Errorf("could not get name from resource identity")
+	}
+
+	rd.SetId(fmt.Sprintf("%s/%s", namespace, name))
+
+	return []*schema.ResourceData{rd}, nil
+}
+
+func resourceIdentityImportNonNamespaced(ctx context.Context, rd *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+	if rd.Id() != "" {
+		return []*schema.ResourceData{rd}, nil
+	}
+
+	rid, err := rd.Identity()
+	if err != nil {
+		return nil, err
+	}
+
+	name, ok := rid.Get("name").(string)
+	if !ok {
+		return nil, fmt.Errorf("could not get name from resource identity")
+	}
+
+	rd.SetId(name)
+
+	return []*schema.ResourceData{rd}, nil
+}
+
+func setResourceIdentityNamespaced(d *schema.ResourceData, apiVersion, kind, namespace, name string) error {
+	rid, err := d.Identity()
+	if err != nil {
+		return err
+	}
+	rid.Set("api_version", apiVersion)
+	rid.Set("kind", kind)
+	rid.Set("namespace", namespace)
+	rid.Set("name", name)
+	return nil
+}
+
+func setResourceIdentityNonNamespaced(d *schema.ResourceData, apiVersion, kind, name string) error {
+	rid, err := d.Identity()
+	if err != nil {
+		return err
+	}
+	rid.Set("api_version", apiVersion)
+	rid.Set("kind", kind)
+	rid.Set("name", name)
+	return nil
+}

--- a/kubernetes/resourceidentity.go
+++ b/kubernetes/resourceidentity.go
@@ -7,23 +7,50 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceIdentitySchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"namespace": {
-			Type:              schema.TypeString,
-			OptionalForImport: true,
+func resourceIdentitySchemaNamespaced() *schema.ResourceIdentity {
+	return &schema.ResourceIdentity{
+		Version: 1,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"namespace": {
+					Type:              schema.TypeString,
+					OptionalForImport: true,
+				},
+				"name": {
+					Type:              schema.TypeString,
+					RequiredForImport: true,
+				},
+				"api_version": {
+					Type:              schema.TypeString,
+					RequiredForImport: true,
+				},
+				"kind": {
+					Type:              schema.TypeString,
+					RequiredForImport: true,
+				},
+			}
 		},
-		"name": {
-			Type:              schema.TypeString,
-			RequiredForImport: true,
-		},
-		"api_version": {
-			Type:              schema.TypeString,
-			RequiredForImport: true,
-		},
-		"kind": {
-			Type:              schema.TypeString,
-			RequiredForImport: true,
+	}
+}
+
+func resourceIdentitySchemaNonNamespaced() *schema.ResourceIdentity {
+	return &schema.ResourceIdentity{
+		Version: 1,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"name": {
+					Type:              schema.TypeString,
+					RequiredForImport: true,
+				},
+				"api_version": {
+					Type:              schema.TypeString,
+					RequiredForImport: true,
+				},
+				"kind": {
+					Type:              schema.TypeString,
+					RequiredForImport: true,
+				},
+			}
 		},
 	}
 }


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

This PR adds Resource Identity support to the following SDKv2 resources:

- Secret
- Namespace
- ServiceAccount
- Service
- Pod
- Deployment
- StatefulSet
- DaemonSet
- Job
- CronJob
- HPA
- Ingress
- IngressClass
- NetworkPolicy
- MutatingWebhookConfiguration
- ValidatingWebhookConfiguration
- ClusterRole
- ClusterRoleBinding
- Role
- RoleBinding

All SDKv2 resources will share the same schema containing kind, apiGroup, name, namespace and this PR adds some shared functions to be reused across all resources. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
