### PR TITLE
ResourceIdentity: Fix API group names missing .k8s.io suffix

### DIFF
--- a/kubernetes/resource_kubernetes_ingress_class_v1.go
+++ b/kubernetes/resource_kubernetes_ingress_class_v1.go
@@ -113,7 +113,7 @@ func resourceKubernetesIngressClassV1Create(ctx context.Context, d *schema.Resou
 	log.Printf("[INFO] Submitted new IngressClass: %#v", out)
 	d.SetId(out.ObjectMeta.GetName())
 
-	err = setResourceIdentityNonNamespaced(d, "networking/v1", "IngressClass", out.GetName())
+	err = setResourceIdentityNonNamespaced(d, "networking.k8s.io/v1", "IngressClass", out.GetName())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -156,7 +156,7 @@ func resourceKubernetesIngressClassV1Read(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	err = setResourceIdentityNonNamespaced(d, "networking/v1", "IngressClass", ing.GetName())
+	err = setResourceIdentityNonNamespaced(d, "networking.k8s.io/v1", "IngressClass", ing.GetName())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_ingress_class_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_class_v1_test.go
@@ -75,7 +75,7 @@ func TestAccKubernetesIngressClassV1_identity(t *testing.T) {
 					statecheck.ExpectIdentity(
 						resourceName, map[string]knownvalue.Check{
 							"name":        knownvalue.StringExact(name),
-							"api_version": knownvalue.StringExact("networking/v1"),
+							"api_version": knownvalue.StringExact("networking.k8s.io/v1"),
 							"kind":        knownvalue.StringExact("IngressClass"),
 						},
 					),

--- a/kubernetes/resource_kubernetes_ingress_v1.go
+++ b/kubernetes/resource_kubernetes_ingress_v1.go
@@ -275,7 +275,7 @@ func resourceKubernetesIngressV1Read(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	err = setResourceIdentityNamespaced(d, "networking/v1", "Ingress", namespace, name)
+	err = setResourceIdentityNamespaced(d, "networking.k8s.io/v1", "Ingress", namespace, name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_ingress_v1_test.go
+++ b/kubernetes/resource_kubernetes_ingress_v1_test.go
@@ -398,7 +398,7 @@ func TestAccKubernetesIngressV1_identity(t *testing.T) {
 						resourceName, map[string]knownvalue.Check{
 							"namespace":   knownvalue.StringExact("default"),
 							"name":        knownvalue.StringExact(name),
-							"api_version": knownvalue.StringExact("networking/v1"),
+							"api_version": knownvalue.StringExact("networking.k8s.io/v1"),
 							"kind":        knownvalue.StringExact("Ingress"),
 						},
 					),

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
@@ -198,7 +198,7 @@ func resourceKubernetesMutatingWebhookConfigurationV1Read(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 
-	err = setResourceIdentityNonNamespaced(d, "admissionregistration/v1", "MutatingWebhookConfiguration", name)
+	err = setResourceIdentityNonNamespaced(d, "admissionregistration.k8s.io/v1", "MutatingWebhookConfiguration", name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1_test.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1_test.go
@@ -170,7 +170,7 @@ func TestAccKubernetesMutatingWebhookConfigurationV1_identity(t *testing.T) {
 					statecheck.ExpectIdentity(
 						resourceName, map[string]knownvalue.Check{
 							"name":        knownvalue.StringExact(name),
-							"api_version": knownvalue.StringExact("admissionregistration/v1"),
+							"api_version": knownvalue.StringExact("admissionregistration.k8s.io/v1"),
 							"kind":        knownvalue.StringExact("MutatingWebhookConfiguration"),
 						},
 					),

--- a/kubernetes/resource_kubernetes_network_policy_v1.go
+++ b/kubernetes/resource_kubernetes_network_policy_v1.go
@@ -313,7 +313,7 @@ func resourceKubernetesNetworkPolicyV1Read(ctx context.Context, d *schema.Resour
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = setResourceIdentityNamespaced(d, "networking/v1", "NetworkPolicy", namespace, name)
+	err = setResourceIdentityNamespaced(d, "networking.k8s.io/v1", "NetworkPolicy", namespace, name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_network_policy_v1_test.go
+++ b/kubernetes/resource_kubernetes_network_policy_v1_test.go
@@ -386,7 +386,7 @@ func TestAccKubernetesNetworkPolicyV1_identity(t *testing.T) {
 						resourceName, map[string]knownvalue.Check{
 							"namespace":   knownvalue.StringExact("default"),
 							"name":        knownvalue.StringExact(name),
-							"api_version": knownvalue.StringExact("networking/v1"),
+							"api_version": knownvalue.StringExact("networking.k8s.io/v1"),
 							"kind":        knownvalue.StringExact("NetworkPolicy"),
 						},
 					),

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1.go
@@ -219,7 +219,7 @@ func resourceKubernetesValidatingWebhookConfigurationV1Read(ctx context.Context,
 		return diag.FromErr(err)
 	}
 
-	err = setResourceIdentityNonNamespaced(d, "admissionregistration/v1", "ValidatingWebhookConfiguration", name)
+	err = setResourceIdentityNonNamespaced(d, "admissionregistration.k8s.io/v1", "ValidatingWebhookConfiguration", name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1_test.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1_test.go
@@ -171,7 +171,7 @@ func TestAccKubernetesValidatingWebhookConfigurationV1_identity(t *testing.T) {
 					statecheck.ExpectIdentity(
 						resourceName, map[string]knownvalue.Check{
 							"name":        knownvalue.StringExact(name),
-							"api_version": knownvalue.StringExact("admissionregistration/v1"),
+							"api_version": knownvalue.StringExact("admissionregistration.k8s.io/v1"),
 							"kind":        knownvalue.StringExact("ValidatingWebhookConfiguration"),
 						},
 					),


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

This PR fixes resource identities to use the full API group names with `.k8s.io` suffixes. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
