### PR TITLE
deprecate unversioned Kubernetes resources and data source

### DIFF
--- a/kubernetes/data_source_kubernetes_ingress.go
+++ b/kubernetes/data_source_kubernetes_ingress.go
@@ -23,8 +23,9 @@ func dataSourceKubernetesIngress() *schema.Resource {
 	docIngressSpec := networking.IngressSpec{}.SwaggerDoc()
 
 	return &schema.Resource{
-		Description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. This data source allows you to pull data about such ingress.",
-		ReadContext: dataSourceKubernetesIngressRead,
+		DeprecationMessage: "Deprecated: this data source will be removed in the next major version of the provider. Use kubernetes_ingress_v1 instead.",
+		Description:        "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. This data source allows you to pull data about such ingress.",
+		ReadContext:        dataSourceKubernetesIngressRead,
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("ingress", false),
 			"spec": {

--- a/kubernetes/resource_kubernetes_certificate_signing_request.go
+++ b/kubernetes/resource_kubernetes_certificate_signing_request.go
@@ -24,10 +24,11 @@ func resourceKubernetesCertificateSigningRequest() *schema.Resource {
 	apiDocStatus := v1beta1.CertificateSigningRequestStatus{}.SwaggerDoc()
 
 	return &schema.Resource{
-		Description:   "Use this resource to generate TLS certificates using Kubernetes. This is a *logical resource*, so it contributes only to the current Terraform state and does not persist any external managed resources. This resource enables automation of [X.509](https://www.itu.int/rec/T-REC-X.509) credential provisioning (including TLS/SSL certificates). It does this by creating a CertificateSigningRequest using the Kubernetes API, which generates a certificate from the Certificate Authority (CA) configured in the Kubernetes cluster. The CSR can be approved automatically by Terraform, or it can be approved by a custom controller running in Kubernetes. See [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for all available options pertaining to CertificateSigningRequests.",
-		CreateContext: resourceKubernetesCertificateSigningRequestCreate,
-		ReadContext:   resourceKubernetesCertificateSigningRequestRead,
-		DeleteContext: resourceKubernetesCertificateSigningRequestDelete,
+		DeprecationMessage: "Deprecated: this resource will be removed in the next major version of the provider. Use kubernetes_certificate_signing_request_v1 instead.",
+		Description:        "Use this resource to generate TLS certificates using Kubernetes. This is a *logical resource*, so it contributes only to the current Terraform state and does not persist any external managed resources. This resource enables automation of [X.509](https://www.itu.int/rec/T-REC-X.509) credential provisioning (including TLS/SSL certificates). It does this by creating a CertificateSigningRequest using the Kubernetes API, which generates a certificate from the Certificate Authority (CA) configured in the Kubernetes cluster. The CSR can be approved automatically by Terraform, or it can be approved by a custom controller running in Kubernetes. See [Kubernetes reference](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for all available options pertaining to CertificateSigningRequests.",
+		CreateContext:      resourceKubernetesCertificateSigningRequestCreate,
+		ReadContext:        resourceKubernetesCertificateSigningRequestRead,
+		DeleteContext:      resourceKubernetesCertificateSigningRequestDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -18,11 +18,12 @@ import (
 
 func resourceKubernetesHorizontalPodAutoscaler() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Horizontal Pod Autoscaler automatically scales the number of pods in a replication controller, deployment or replica set based on observed CPU utilization.",
-		CreateContext: resourceKubernetesHorizontalPodAutoscalerCreate,
-		ReadContext:   resourceKubernetesHorizontalPodAutoscalerRead,
-		UpdateContext: resourceKubernetesHorizontalPodAutoscalerUpdate,
-		DeleteContext: resourceKubernetesHorizontalPodAutoscalerDelete,
+		DeprecationMessage: "Deprecated: this resource will be removed in the next major version of the provider. Use kubernetes_horizontal_pod_autoscaler_v2 (or _v1) instead.",
+		Description:        "Horizontal Pod Autoscaler automatically scales the number of pods in a replication controller, deployment or replica set based on observed CPU utilization.",
+		CreateContext:      resourceKubernetesHorizontalPodAutoscalerCreate,
+		ReadContext:        resourceKubernetesHorizontalPodAutoscalerRead,
+		UpdateContext:      resourceKubernetesHorizontalPodAutoscalerUpdate,
+		DeleteContext:      resourceKubernetesHorizontalPodAutoscalerDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
@@ -24,11 +24,12 @@ func resourceKubernetesMutatingWebhookConfiguration() *schema.Resource {
 	apiDoc := admissionregistrationv1.MutatingWebhookConfiguration{}.SwaggerDoc()
 	webhookDoc := admissionregistrationv1.MutatingWebhook{}.SwaggerDoc()
 	return &schema.Resource{
-		Description:   "Mutating Webhook Configuration configures a [mutating admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks).",
-		CreateContext: resourceKubernetesMutatingWebhookConfigurationCreate,
-		ReadContext:   resourceKubernetesMutatingWebhookConfigurationRead,
-		UpdateContext: resourceKubernetesMutatingWebhookConfigurationUpdate,
-		DeleteContext: resourceKubernetesMutatingWebhookConfigurationDelete,
+		DeprecationMessage: "Deprecated: this resource will be removed in the next major version of the provider. Use kubernetes_mutating_webhook_configuration_v1 instead.",
+		Description:        "Mutating Webhook Configuration configures a [mutating admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks).",
+		CreateContext:      resourceKubernetesMutatingWebhookConfigurationCreate,
+		ReadContext:        resourceKubernetesMutatingWebhookConfigurationRead,
+		UpdateContext:      resourceKubernetesMutatingWebhookConfigurationUpdate,
+		DeleteContext:      resourceKubernetesMutatingWebhookConfigurationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/kubernetes/resource_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget.go
@@ -26,11 +26,12 @@ var (
 
 func resourceKubernetesPodDisruptionBudget() *schema.Resource {
 	return &schema.Resource{
-		Description:   "A Pod Disruption Budget limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, a quorum-based application would like to ensure that the number of replicas running is never brought below the number needed for a quorum. A web front end might want to ensure that the number of replicas serving load never falls below a certain percentage of the total.",
-		CreateContext: resourceKubernetesPodDisruptionBudgetCreate,
-		ReadContext:   resourceKubernetesPodDisruptionBudgetRead,
-		UpdateContext: resourceKubernetesPodDisruptionBudgetUpdate,
-		DeleteContext: resourceKubernetesPodDisruptionBudgetDelete,
+		DeprecationMessage: "Deprecated: this resource will be removed in the next major version of the provider. Use kubernetes_pod_disruption_budget_v1 instead.",
+		Description:        "A Pod Disruption Budget limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, a quorum-based application would like to ensure that the number of replicas running is never brought below the number needed for a quorum. A web front end might want to ensure that the number of replicas serving load never falls below a certain percentage of the total.",
+		CreateContext:      resourceKubernetesPodDisruptionBudgetCreate,
+		ReadContext:        resourceKubernetesPodDisruptionBudgetRead,
+		UpdateContext:      resourceKubernetesPodDisruptionBudgetUpdate,
+		DeleteContext:      resourceKubernetesPodDisruptionBudgetDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

This PR adds deprecation notices to unversioned resources and data sources that already have versioned counterparts. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
