### PR TITLE
fix wait-for-rollout

### DIFF
--- a/kubernetes/resource_kubernetes_daemon_set_v1.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1.go
@@ -172,7 +172,7 @@ func resourceKubernetesDaemonSetV1Create(ctx context.Context, d *schema.Resource
 
 	if d.Get("wait_for_rollout").(bool) {
 		err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate),
-			waitForDaemonSetReplicasFunc(ctx, conn, metadata.Namespace, metadata.Name))
+			waitForDaemonSetPodsFunc(ctx, conn, metadata.Namespace, metadata.Name))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -223,7 +223,7 @@ func resourceKubernetesDaemonSetV1Update(ctx context.Context, d *schema.Resource
 
 	if d.Get("wait_for_rollout").(bool) {
 		err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
-			waitForDaemonSetReplicasFunc(ctx, conn, namespace, name))
+			waitForDaemonSetPodsFunc(ctx, conn, namespace, name))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -333,22 +333,26 @@ func resourceKubernetesDaemonSetV1Exists(ctx context.Context, d *schema.Resource
 	return true, err
 }
 
-func waitForDaemonSetReplicasFunc(ctx context.Context, conn *kubernetes.Clientset, ns, name string) retry.RetryFunc {
+func waitForDaemonSetPodsFunc(ctx context.Context, conn *kubernetes.Clientset, ns, name string) retry.RetryFunc {
 	return func() *retry.RetryError {
 		daemonSet, err := conn.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
 
-		desiredReplicas := daemonSet.Status.DesiredNumberScheduled
-		log.Printf("[DEBUG] Current number of labelled replicas of %q: %d (of %d)\n",
-			daemonSet.GetName(), daemonSet.Status.CurrentNumberScheduled, desiredReplicas)
+		desiredPods := daemonSet.Status.DesiredNumberScheduled
 
-		if daemonSet.Status.CurrentNumberScheduled == desiredReplicas {
-			return nil
+		if daemonSet.Generation > daemonSet.Status.ObservedGeneration {
+			return retry.RetryableError(fmt.Errorf("waiting for rollout to start."))
 		}
 
-		return retry.RetryableError(fmt.Errorf("Waiting for %d replicas of %q to be scheduled (%d)",
-			desiredReplicas, daemonSet.GetName(), daemonSet.Status.CurrentNumberScheduled))
+		if daemonSet.Generation == daemonSet.Status.ObservedGeneration {
+			if daemonSet.Status.NumberReady == desiredPods {
+				return nil
+			}
+			return retry.RetryableError(fmt.Errorf("waiting for rollout to finish: %d pods desired; %d pods ready",
+				desiredPods, daemonSet.Status.NumberReady))
+		}
+		return retry.NonRetryableError(fmt.Errorf("observed generation %d is not expected to be greater than generation %d", daemonSet.Status.ObservedGeneration, daemonSet.Generation))
 	}
 }

--- a/kubernetes/resource_kubernetes_daemon_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1_test.go
@@ -892,6 +892,7 @@ func testAccKubernetesDaemonSetV1ConfigWithTemplateMetadata(depName, imageName s
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
         }
         termination_grace_period_seconds = 1
       }
@@ -979,6 +980,7 @@ func testAccKubernetesDaemonSetV1WithInitContainer(depName, imageName string) st
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
         }
         termination_grace_period_seconds = 1
       }
@@ -1012,6 +1014,7 @@ func testAccKubernetesDaemonSetV1WithNoTopLevelLabels(depName, imageName string)
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
         }
         termination_grace_period_seconds = 1
       }
@@ -1066,6 +1069,7 @@ func testAccKubernetesDaemonSetV1ConfigWithTolerations(rcName, imageName string,
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
         }
         termination_grace_period_seconds = 1
       }
@@ -1119,6 +1123,7 @@ func testAccKubernetesDaemonSetV1ConfigWithContainerSecurityContextSeccompProfil
       }
     }
   }
+  wait_for_rollout = false
 }
 `, deploymentName, seccompProfileType, imageName, seccompProfileType)
 }
@@ -1169,6 +1174,7 @@ func testAccKubernetesDaemonSetV1ConfigWithContainerSecurityContextSeccompProfil
       }
     }
   }
+  wait_for_rollout = false
 }
 `, deploymentName, imageName)
 }
@@ -1201,18 +1207,17 @@ func testAccKubernetesDaemonSetV1ConfigWithResourceRequirements(deploymentName, 
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
 
           resources {
             limits = {
               cpu          = "0.5"
               memory       = "512Mi"
-              "nvidia/gpu" = "1"
             }
 
             requests = {
               cpu          = "250m"
               memory       = "50Mi"
-              "nvidia/gpu" = "1"
             }
           }
         }
@@ -1252,6 +1257,7 @@ func testAccKubernetesDaemonSetV1ConfigWithEmptyResourceRequirements(deploymentN
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
 
           resources {
             limits   = {}
@@ -1294,6 +1300,7 @@ func testAccKubernetesDaemonSetV1ConfigWithResourceRequirementsLimitsOnly(deploy
         container {
           image = "%s"
           name  = "containername"
+          command = ["sleep", "infinity"]
 
           resources {
             limits = {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

Fixes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2092. Current check for the rollout when wait_for_rollout = true is ineffective and is not waiting for rollout at all as it checks a wrong status field of a DaemonSet.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
