### PR TITLE
fix: Resolve panic with `ElementKeyInt(0): can't use tftypes`

### DIFF
--- a/.changelog/2800.txt
+++ b/.changelog/2800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_manifest`: fix an issue with the provider panic'ing when working with complex manifests
+```

--- a/manifest/morph/scaffold.go
+++ b/manifest/morph/scaffold.go
@@ -75,6 +75,7 @@ func DeepUnknown(t tftypes.Type, v tftypes.Value, p *tftypes.AttributePath) (tft
 		if err != nil {
 			return tftypes.Value{}, p.NewError(err)
 		}
+		ntypes := make([]tftypes.Type, len(atts))
 		for i, et := range atts {
 			np := p.WithElementKeyInt(i)
 			nv, err := DeepUnknown(et, vals[i], np)
@@ -82,8 +83,9 @@ func DeepUnknown(t tftypes.Type, v tftypes.Value, p *tftypes.AttributePath) (tft
 				return tftypes.Value{}, np.NewError(err)
 			}
 			vals[i] = nv
+			ntypes[i] = nv.Type()
 		}
-		return tftypes.NewValue(tftypes.Tuple{ElementTypes: atts}, vals), nil
+		return tftypes.NewValue(tftypes.Tuple{ElementTypes: ntypes}, vals), nil
 	case t.Is(tftypes.List{}) || t.Is(tftypes.Set{}):
 		if v.IsNull() {
 			return tftypes.NewValue(t, tftypes.UnknownValue), nil

--- a/manifest/morph/scaffold_test.go
+++ b/manifest/morph/scaffold_test.go
@@ -299,6 +299,61 @@ func TestDeepUnknown(t *testing.T) {
 				},
 			),
 		},
+		"tuple-with-dynamic": {
+			In: deepUnknownTestSampleInput{
+				T: tftypes.Tuple{
+					ElementTypes: []tftypes.Type{
+						tftypes.DynamicPseudoType,
+					},
+				},
+				V: tftypes.NewValue(
+					tftypes.Tuple{
+						ElementTypes: []tftypes.Type{
+							tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"name": tftypes.String,
+								},
+							},
+						},
+					},
+					[]tftypes.Value{
+						tftypes.NewValue(
+							tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"name": tftypes.String,
+								},
+							},
+							map[string]tftypes.Value{
+								"name": tftypes.NewValue(tftypes.String, "test"),
+							},
+						),
+					},
+				),
+			},
+			Out: tftypes.NewValue(
+				tftypes.Tuple{
+					ElementTypes: []tftypes.Type{
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"name": tftypes.String,
+							},
+						},
+					},
+				},
+				[]tftypes.Value{
+					tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"name": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"name": tftypes.NewValue(tftypes.String, "test"),
+						},
+					),
+				},
+			),
+		},
 	}
 	for n, s := range samples {
 		t.Run(n, func(t *testing.T) {

--- a/manifest/test/acceptance/strategic_patch_test.go
+++ b/manifest/test/acceptance/strategic_patch_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
+)
+
+func TestKubernetesManifest_StrategicPatch(t *testing.T) {
+	ctx := context.Background()
+
+	reattachInfo, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create provider instance: %q", err)
+	}
+
+	kind := "Strategic"
+	plural := "strategics"
+	group := "terraform.io"
+	version := "v1"
+	groupVersion := group + "/" + version
+	crd := fmt.Sprintf("%s.%s", plural, group)
+
+	name := strings.ToLower(randName())
+	namespace := "default"
+
+	tfvars := TFVARS{
+		"name":          name,
+		"namespace":     namespace,
+		"kind":          kind,
+		"plural":        plural,
+		"group":         group,
+		"group_version": groupVersion,
+		"cr_version":    version,
+	}
+
+	step1 := tfhelper.RequireNewWorkingDir(ctx, t)
+	step1.SetReattachInfo(ctx, reattachInfo)
+	defer func() {
+		step1.Destroy(ctx)
+		step1.Close()
+		k8shelper.AssertResourceDoesNotExist(t, "apiextensions.k8s.io/v1", "customresourcedefinitions", crd)
+	}()
+
+	crdTfConfig := loadTerraformConfig(t, "StrategicPatch/crd.tf", tfvars)
+	step1.SetConfig(ctx, string(crdTfConfig))
+	step1.Init(ctx)
+	step1.Apply(ctx)
+	k8shelper.AssertResourceExists(t, "apiextensions.k8s.io/v1", "customresourcedefinitions", crd)
+
+	// wait for API to finish ingesting the CRD
+	time.Sleep(5 * time.Second) //lintignore:R018
+
+	reattachInfo2, err := provider.ServeTest(ctx, hclog.Default(), t)
+	if err != nil {
+		t.Errorf("Failed to create additional provider instance: %q", err)
+	}
+	step2 := tfhelper.RequireNewWorkingDir(ctx, t)
+	step2.SetReattachInfo(ctx, reattachInfo2)
+	defer func() {
+		step2.Destroy(ctx)
+		step2.Close()
+		k8shelper.AssertResourceDoesNotExist(t, groupVersion, kind, name)
+	}()
+
+	tfconfig := loadTerraformConfig(t, "StrategicPatch/strategic_patch.tf", tfvars)
+	step2.SetConfig(ctx, string(tfconfig))
+	step2.Init(ctx)
+	step2.Apply(ctx)
+}

--- a/manifest/test/acceptance/testdata/StrategicPatch/crd.tf
+++ b/manifest/test/acceptance/testdata/StrategicPatch/crd.tf
@@ -1,0 +1,58 @@
+resource "kubernetes_manifest" "crd" {
+  manifest = {
+    apiVersion = "apiextensions.k8s.io/v1"
+    kind       = "CustomResourceDefinition"
+    metadata = {
+      name = "${var.plural}.${var.group}"
+    }
+    spec = {
+      group = "${var.group}"
+      names = {
+        kind   = "${var.kind}"
+        plural = "${var.plural}"
+      }
+      scope = "Namespaced"
+      versions = [
+        {
+          name    = "${var.cr_version}"
+          served  = true
+          storage = true
+          schema = {
+            openAPIV3Schema = {
+              type = "object"
+              properties = {
+                spec = {
+                  type = "object"
+                  properties = {
+                    patchStrategicMerge = {
+                      type = "object"
+                      properties = {
+                        containers = {
+                          type = "array"
+                          "x-kubernetes-list-type" = "map"
+                          "x-kubernetes-list-map-keys" = ["name"]
+                          items = {
+                            type = "object"
+                            required = ["name"]
+                            properties = {
+                              name = {
+                                type = "string"
+                              }
+                              image = {
+                                type = "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+      ]
+    }
+  }
+}

--- a/manifest/test/acceptance/testdata/StrategicPatch/strategic_patch.tf
+++ b/manifest/test/acceptance/testdata/StrategicPatch/strategic_patch.tf
@@ -1,0 +1,20 @@
+resource "kubernetes_manifest" "test" {
+  manifest = {
+    apiVersion = "${var.group_version}"
+    kind       = "${var.kind}"
+    metadata = {
+      name      = "${var.name}"
+      namespace = "${var.namespace}"
+    }
+    spec = {
+      patchStrategicMerge = {
+        containers = [
+          {
+            name  = "nginx"
+            image = "nginx:latest"
+          },
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

This commit updates the `manifest/morph/scaffold.go` logic in order to
resolve a panic encountered when working with `Tuple` types.

Also adds a new unit test to cover this case.

Disclaimer: This fix and the coresponding test case was generated by
Gemini, and has been reviewed and tested by myself.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ cd manifest
$ make testacc TESTARGS="-run ^TestKubernetesManifest_StrategicPatch"
go test -count=1 -tags acceptance "./test/acceptance" -v -run ^TestKubernetesManifest_StrategicPatch -timeout 120m
2025/10/15 17:06:15 Testing against Kubernetes API version: v1.34.0
=== RUN   TestKubernetesManifest_StrategicPatch
--- PASS: TestKubernetesManifest_StrategicPatch (8.37s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/manifest/test/acceptance     8.815s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix: Resolve issue with provider crashing the `kubernetes_manifest` resource when working with complex manifests
```

### References

Fixes: #2778 #2754 plus probably others...
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
