### PR TITLE
[docs] update API version for Kubernetes exec configuration to v1

### DIFF
--- a/docs/guides/getting-started.html.md
+++ b/docs/guides/getting-started.html.md
@@ -113,7 +113,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ resource "kubernetes_namespace" "example" {
 
 ## Terraform version
 
-This provider requires Terraform version `v1.0.0` or above. 
+This provider requires Terraform version `v1.0.0` or above.
 
 ## Kubernetes versions
 
@@ -116,7 +116,7 @@ provider "kubernetes" {
   host                   = var.cluster_endpoint
   cluster_ca_certificate = base64decode(var.cluster_ca_cert)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }
@@ -195,7 +195,7 @@ The following arguments are supported:
 * `token` - (Optional) Token of your service account. Can be sourced from `KUBE_TOKEN`.
 * `proxy_url` - (Optional) URL to the proxy to be used for all API requests. URLs with "http", "https", and "socks5" schemes are supported. Can be sourced from `KUBE_PROXY_URL`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
-* `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
+* `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1`.
 * `command` - (Required) Command to execute.
 * `args` - (Optional) List of arguments to pass when executing the plugin.
 * `env` - (Optional) Map of environment variables to set when executing the plugin.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -199,7 +199,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -199,7 +199,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/examples/example_5.tf
+++ b/examples/example_5.tf
@@ -2,7 +2,7 @@ provider "kubernetes" {
   host                   = var.cluster_endpoint
   cluster_ca_certificate = base64decode(var.cluster_ca_cert)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/examples/resources/service/example_2.tf
+++ b/examples/resources/service/example_2.tf
@@ -18,7 +18,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/examples/resources/service_v1/example_2.tf
+++ b/examples/resources/service_v1/example_2.tf
@@ -18,7 +18,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -112,7 +112,7 @@ locals {
       name = "terraform"
       user = {
         exec = {
-          apiVersion = "client.authentication.k8s.io/v1beta1"
+          apiVersion = "client.authentication.k8s.io/v1"
           command    = "aws"
           args = [
             "eks", "get-token", "--cluster-name", local.cluster_name

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -92,7 +92,7 @@ locals {
         name = google_service_account.default.email
         user = {
           exec = {
-            apiVersion         = "client.authentication.k8s.io/v1beta1"
+            apiVersion         = "client.authentication.k8s.io/v1"
             command            = "gke-gcloud-auth-plugin"
             interactiveMode    = "Never"
             provideClusterInfo = true

--- a/templates/guides/getting-started.html.markdown
+++ b/templates/guides/getting-started.html.markdown
@@ -113,7 +113,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -137,7 +137,7 @@ The following arguments are supported:
 * `token` - (Optional) Token of your service account. Can be sourced from `KUBE_TOKEN`.
 * `proxy_url` - (Optional) URL to the proxy to be used for all API requests. URLs with "http", "https", and "socks5" schemes are supported. Can be sourced from `KUBE_PROXY_URL`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
-  * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
+  * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1`.
   * `command` - (Required) Command to execute.
   * `args` - (Optional) List of arguments to pass when executing the plugin.
   * `env` - (Optional) Map of environment variables to set when executing the plugin.


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This PR updates the API version reference in documentation and examples to align with Kubernetes stable API version.

### Description

This PR updates the Kubernetes exec-based credential plugin API version from `client.authentication.k8s.io/v1beta1` to `client.authentication.k8s.io/v1` across all documentation, examples, and test infrastructure.

The `v1beta1` API version has been deprecated in favor of the stable `v1` API version. This change ensures that:
- Documentation reflects current best practices
- Examples use the stable, non-deprecated API version
- Test infrastructure is aligned with modern Kubernetes clusters

**Files Updated:**
- Documentation files (guides, resource docs, index)
- Example Terraform configurations
- Test infrastructure for EKS and GKE

This is a documentation and example update only - no provider code logic has been changed.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
  - N/A - This is a documentation/example update only
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

N/A - No provider code changes

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NOTES:

* Documentation and examples have been updated to use `client.authentication.k8s.io/v1` instead of the deprecated `v1beta1` API version for exec-based credential plugins

References

- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
- The v1beta1 API version is deprecated and v1 is now the stable version for ExecCredential

Community Note

- Please vote on this issue by adding a 👍 https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/ to the original issue to help the community and maintainers prioritize this request
- If you are interested in working on this issue or have submitted a pull request, please leave a comment