### PR TITLE
feat: Add support for User namespaces

### DIFF
--- a/.changelog/2828.txt
+++ b/.changelog/2828.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+Add User Namespaces support to following resources:
+* `kubernetes_pod_v1`
+* `kubernetes_daemonset_v1`
+* `kubernetes_deployment_v1`
+* `kubernetes_stateful_set_v1`
+```

--- a/.changelog/2828.txt
+++ b/.changelog/2828.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
 Add User Namespaces support to following resources:
-* `kubernetes_pod_v1`
-* `kubernetes_daemonset_v1`
+* `kubernetes_daemon_set_v1`
 * `kubernetes_deployment_v1`
+* `kubernetes_pod_v1`
 * `kubernetes_stateful_set_v1`
 ```

--- a/kubernetes/resource_kubernetes_daemon_set_v1.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1.go
@@ -140,7 +140,7 @@ func resourceKubernetesDaemonSetSchemaV1() map[string]*schema.Schema {
 		},
 		"wait_for_rollout": {
 			Type:        schema.TypeBool,
-			Description: "Wait for the rollout of the deployment to complete. Defaults to true.",
+			Description: "Wait for the rollout of the daemon set to complete. Defaults to true.",
 			Default:     true,
 			Optional:    true,
 		},

--- a/kubernetes/resource_kubernetes_daemon_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_daemon_set_v1_test.go
@@ -218,6 +218,35 @@ func TestAccKubernetesDaemonSetV1_initContainer(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesDaemonSetV1_host_users(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kubernetes_daemon_set_v1.test"
+	imageName := busyboxImage
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			skipIfClusterVersionLessThan(t, "1.25.0") // User namespaces is beta in 1.25
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesDaemonSetV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDaemonSetV1ConfigHostUsers(name, imageName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.host_users", "true"),
+				),
+			},
+			{
+				Config: testAccKubernetesDaemonSetV1ConfigHostUsers(name, imageName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.spec.0.host_users", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesDaemonSetV1_noTopLevelLabels(t *testing.T) {
 	var conf appsv1.DaemonSet
 	resourceName := "kubernetes_daemon_set_v1.test"
@@ -1393,4 +1422,35 @@ func testAccKubernetesDaemonSetV1ConfigMinimalWithTemplateNamespace(name, imageN
   }
 }
 `, name, imageName)
+}
+
+func testAccKubernetesDaemonSetV1ConfigHostUsers(name, image string, hostUsers bool) string {
+	return fmt.Sprintf(`
+resource "kubernetes_daemon_set_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "tf-acc-test"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "tf-acc-test"
+        }
+      }
+      spec {
+        host_users = %t
+        container {
+          image = "%s"
+          name  = "test"
+        }
+      }
+    }
+  }
+}
+`, name, hostUsers, image)
 }

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -186,7 +186,6 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 			Default:     conditionalDefault(!isComputed, false),
 			Description: "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.",
 		},
-
 		"host_pid": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -195,7 +194,14 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 			Default:     conditionalDefault(!isComputed, false),
 			Description: "Use the host's pid namespace.",
 		},
-
+		"host_users": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    isComputed,
+			ForceNew:    !isUpdatable,
+			Default:     conditionalDefault(!isComputed, true),
+			Description: "Use the host's user namespace. Optional: Defaults to true.",
+		},
 		"hostname": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -91,6 +91,9 @@ func flattenPodSpec(in v1.PodSpec, isTemplate bool) ([]interface{}, error) {
 	att["host_ipc"] = in.HostIPC
 	att["host_network"] = in.HostNetwork
 	att["host_pid"] = in.HostPID
+	if in.HostUsers != nil {
+		att["host_users"] = *in.HostUsers
+	}
 
 	if in.Hostname != "" {
 		att["hostname"] = in.Hostname
@@ -794,6 +797,9 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 
 	if v, ok := in["host_pid"]; ok {
 		obj.HostPID = v.(bool)
+	}
+	if v, ok := in["host_users"]; ok {
+		obj.HostUsers = ptr.To(v.(bool))
 	}
 
 	if v, ok := in["hostname"]; ok {


### PR DESCRIPTION

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

<!--- Please leave a helpful description of the pull request here. --->
This commit updates the pod related resources in order to add support for
the User Namepaces feature which was enabled by default in `1.33` [1].

As part of this:
* Updated `PodSpec` to add `host_users` field, which is optional and
  defaults to `true`
* Update corresponding functions to get and set `host_users` field.
* Added tests to relevant resources


[1] https://kubernetes.io/blog/2025/04/25/userns-enabled-by-default/

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Fixes: #2818

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
