### PR TITLE
Adds "moved" support for most of the non-versioned to versioned resources

### DIFF
--- a/internal/move/move.go
+++ b/internal/move/move.go
@@ -1,0 +1,125 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package move
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// moveMap defines supported source -> target resource type moves
+// for identical-schema resource pairs where the deprecated name and
+// the _v1 name share the same constructor function.
+var moveMap = map[string]string{
+	// core
+	"kubernetes_namespace":               "kubernetes_namespace_v1",
+	"kubernetes_service":                 "kubernetes_service_v1",
+	"kubernetes_service_account":         "kubernetes_service_account_v1",
+	"kubernetes_default_service_account": "kubernetes_default_service_account_v1",
+	"kubernetes_config_map":              "kubernetes_config_map_v1",
+	"kubernetes_secret":                  "kubernetes_secret_v1",
+	"kubernetes_pod":                     "kubernetes_pod_v1",
+	"kubernetes_endpoints":               "kubernetes_endpoints_v1",
+	"kubernetes_limit_range":             "kubernetes_limit_range_v1",
+	"kubernetes_persistent_volume":       "kubernetes_persistent_volume_v1",
+	"kubernetes_persistent_volume_claim": "kubernetes_persistent_volume_claim_v1",
+	"kubernetes_replication_controller":  "kubernetes_replication_controller_v1",
+	"kubernetes_resource_quota":          "kubernetes_resource_quota_v1",
+	// api registration
+	"kubernetes_api_service": "kubernetes_api_service_v1",
+	// apps
+	"kubernetes_deployment":   "kubernetes_deployment_v1",
+	"kubernetes_daemonset":    "kubernetes_daemon_set_v1",
+	"kubernetes_stateful_set": "kubernetes_stateful_set_v1",
+	// batch
+	"kubernetes_job": "kubernetes_job_v1",
+	// rbac
+	"kubernetes_role":                 "kubernetes_role_v1",
+	"kubernetes_role_binding":         "kubernetes_role_binding_v1",
+	"kubernetes_cluster_role":         "kubernetes_cluster_role_v1",
+	"kubernetes_cluster_role_binding": "kubernetes_cluster_role_binding_v1",
+	// networking
+	"kubernetes_ingress_class":  "kubernetes_ingress_class_v1",
+	"kubernetes_network_policy": "kubernetes_network_policy_v1",
+	// scheduling
+	"kubernetes_priority_class": "kubernetes_priority_class_v1",
+	// storage
+	"kubernetes_storage_class": "kubernetes_storage_class_v1",
+}
+
+// reverseMoveMap supports moves in the opposite direction (v1 -> deprecated).
+var reverseMoveMap map[string]string
+
+func init() {
+	reverseMoveMap = make(map[string]string, len(moveMap))
+	for source, target := range moveMap {
+		reverseMoveMap[target] = source
+	}
+}
+
+// isSupported returns true if the given source -> target move is supported.
+func isSupported(source, target string) bool {
+	if t, ok := moveMap[source]; ok && t == target {
+		return true
+	}
+	if t, ok := reverseMoveMap[source]; ok && t == target {
+		return true
+	}
+	return false
+}
+
+// ServerWithMoveState wraps a tfprotov6.ProviderServer to add
+// MoveResourceState support for identical-schema resource pairs.
+type ServerWithMoveState struct {
+	tfprotov6.ProviderServer
+}
+
+// NewServerWithMoveState creates a new wrapper around the given upstream server.
+func NewServerWithMoveState(upstream tfprotov6.ProviderServer) *ServerWithMoveState {
+	return &ServerWithMoveState{ProviderServer: upstream}
+}
+
+// MoveResourceState handles moving state between deprecated and versioned
+// resource types that share identical schemas.
+func (s *ServerWithMoveState) MoveResourceState(ctx context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	if !isSupported(req.SourceTypeName, req.TargetTypeName) {
+		return s.ProviderServer.MoveResourceState(ctx, req)
+	}
+
+	if req.SourceState == nil {
+		return &tfprotov6.MoveResourceStateResponse{}, nil
+	}
+
+	return &tfprotov6.MoveResourceStateResponse{
+		TargetState:   &tfprotov6.DynamicValue{JSON: req.SourceState.JSON},
+		TargetPrivate: req.SourcePrivate,
+	}, nil
+}
+
+// GetMetadata overrides the upstream response to advertise MoveResourceState support.
+func (s *ServerWithMoveState) GetMetadata(ctx context.Context, req *tfprotov6.GetMetadataRequest) (*tfprotov6.GetMetadataResponse, error) {
+	resp, err := s.ProviderServer.GetMetadata(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.ServerCapabilities == nil {
+		resp.ServerCapabilities = &tfprotov6.ServerCapabilities{}
+	}
+	resp.ServerCapabilities.MoveResourceState = true
+	return resp, err
+}
+
+// GetProviderSchema overrides the upstream response to advertise MoveResourceState support.
+func (s *ServerWithMoveState) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProviderSchemaRequest) (*tfprotov6.GetProviderSchemaResponse, error) {
+	resp, err := s.ProviderServer.GetProviderSchema(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.ServerCapabilities == nil {
+		resp.ServerCapabilities = &tfprotov6.ServerCapabilities{}
+	}
+	resp.ServerCapabilities.MoveResourceState = true
+	return resp, err
+}

--- a/internal/move/move_acc_test.go
+++ b/internal/move/move_acc_test.go
@@ -1,0 +1,321 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package move_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/mux"
+)
+
+var muxFactory = map[string]func() (tfprotov6.ProviderServer, error){
+	"kubernetes": func() (tfprotov6.ProviderServer, error) {
+		return mux.MuxServer(context.Background(), "test")
+	},
+}
+
+func TestAccMoveResourceState_configMapForward(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-move-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccConfigMapConfig_deprecated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.key1", "value1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccConfigMapConfig_movedToV1(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("kubernetes_config_map_v1.test", plancheck.ResourceActionNoop),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_config_map_v1.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_config_map_v1.test", "data.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMoveResourceState_configMapReverse(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-move-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccConfigMapConfig_v1(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_config_map_v1.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_config_map_v1.test", "data.key1", "value1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccConfigMapConfig_movedToDeprecated(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("kubernetes_config_map.test", plancheck.ResourceActionNoop),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMoveResourceState_secret(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-move-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccSecretConfig_deprecated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_secret.test", "metadata.0.name", name),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccSecretConfig_movedToV1(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("kubernetes_secret_v1.test", plancheck.ResourceActionNoop),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_secret_v1.test", "metadata.0.name", name),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMoveResourceState_daemonset(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-move-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccDaemonsetConfig_deprecated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_daemonset.test", "metadata.0.name", name),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: muxFactory,
+				Config:                   testAccDaemonsetConfig_movedToV1(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("kubernetes_daemon_set_v1.test", plancheck.ResourceActionNoop),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubernetes_daemon_set_v1.test", "metadata.0.name", name),
+				),
+			},
+		},
+	})
+}
+
+// randomSuffix generates a short random string for unique resource names.
+func randomSuffix() string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 10)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// --- Config helpers ---
+
+func testAccConfigMapConfig_deprecated(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_config_map" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  data = {
+    key1 = "value1"
+  }
+}
+`, name)
+}
+
+func testAccConfigMapConfig_v1(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_config_map_v1" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  data = {
+    key1 = "value1"
+  }
+}
+`, name)
+}
+
+func testAccConfigMapConfig_movedToDeprecated(name string) string {
+	return fmt.Sprintf(`
+moved {
+  from = kubernetes_config_map_v1.test
+  to   = kubernetes_config_map.test
+}
+
+resource "kubernetes_config_map" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  data = {
+    key1 = "value1"
+  }
+}
+`, name)
+}
+
+func testAccConfigMapConfig_movedToV1(name string) string {
+	return fmt.Sprintf(`
+moved {
+  from = kubernetes_config_map.test
+  to   = kubernetes_config_map_v1.test
+}
+
+resource "kubernetes_config_map_v1" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  data = {
+    key1 = "value1"
+  }
+}
+`, name)
+}
+
+func testAccSecretConfig_deprecated(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_secret" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  data = {
+    key1 = "value1"
+  }
+}
+`, name)
+}
+
+func testAccSecretConfig_movedToV1(name string) string {
+	return fmt.Sprintf(`
+moved {
+  from = kubernetes_secret.test
+  to   = kubernetes_secret_v1.test
+}
+
+resource "kubernetes_secret_v1" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  data = {
+    key1 = "value1"
+  }
+}
+`, name)
+}
+
+func testAccDaemonsetConfig_deprecated(name string) string {
+	return fmt.Sprintf(`resource "kubernetes_daemonset" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "%s"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "%s"
+        }
+      }
+      spec {
+        container {
+          image = "nginx:1.21"
+          name  = "nginx"
+        }
+      }
+    }
+  }
+}
+`, name, name, name)
+}
+
+func testAccDaemonsetConfig_movedToV1(name string) string {
+	return fmt.Sprintf(`
+moved {
+  from = kubernetes_daemonset.test
+  to   = kubernetes_daemon_set_v1.test
+}
+
+resource "kubernetes_daemon_set_v1" "test" {
+  metadata {
+    namespace = "default"
+    name      = "%s"
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "%s"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "%s"
+        }
+      }
+      spec {
+        container {
+          image = "nginx:1.21"
+          name  = "nginx"
+        }
+      }
+    }
+  }
+}
+`, name, name, name)
+}

--- a/internal/move/move_test.go
+++ b/internal/move/move_test.go
@@ -1,0 +1,185 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package move
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// mockServer is a minimal mock that records whether MoveResourceState was called.
+type mockServer struct {
+	tfprotov6.ProviderServer
+	moveResourceStateCalled bool
+}
+
+func (m *mockServer) MoveResourceState(_ context.Context, _ *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	m.moveResourceStateCalled = true
+	return &tfprotov6.MoveResourceStateResponse{
+		Diagnostics: []*tfprotov6.Diagnostic{
+			{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Move Resource State Not Supported",
+			},
+		},
+	}, nil
+}
+
+func TestMoveResourceState_ForwardMove(t *testing.T) {
+	mock := &mockServer{}
+	server := NewServerWithMoveState(mock)
+
+	sourceJSON := []byte(`{"id":"test-ns","metadata":[{"name":"test-ns"}]}`)
+	sourcePrivate := []byte(`{"private":"data"}`)
+
+	resp, err := server.MoveResourceState(context.Background(), &tfprotov6.MoveResourceStateRequest{
+		SourceTypeName: "kubernetes_namespace",
+		TargetTypeName: "kubernetes_namespace_v1",
+		SourceState:    &tfprotov6.RawState{JSON: sourceJSON},
+		SourcePrivate:  sourcePrivate,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.moveResourceStateCalled {
+		t.Fatal("expected move to be handled by wrapper, not delegated to upstream")
+	}
+	if resp.TargetState == nil {
+		t.Fatal("expected TargetState to be set")
+	}
+	if string(resp.TargetState.JSON) != string(sourceJSON) {
+		t.Errorf("expected TargetState.JSON = %s, got %s", sourceJSON, resp.TargetState.JSON)
+	}
+	if string(resp.TargetPrivate) != string(sourcePrivate) {
+		t.Errorf("expected TargetPrivate = %s, got %s", sourcePrivate, resp.TargetPrivate)
+	}
+	if len(resp.Diagnostics) > 0 {
+		t.Errorf("expected no diagnostics, got %v", resp.Diagnostics)
+	}
+}
+
+func TestMoveResourceState_ReverseMove(t *testing.T) {
+	mock := &mockServer{}
+	server := NewServerWithMoveState(mock)
+
+	sourceJSON := []byte(`{"id":"test-ns","metadata":[{"name":"test-ns"}]}`)
+
+	resp, err := server.MoveResourceState(context.Background(), &tfprotov6.MoveResourceStateRequest{
+		SourceTypeName: "kubernetes_namespace_v1",
+		TargetTypeName: "kubernetes_namespace",
+		SourceState:    &tfprotov6.RawState{JSON: sourceJSON},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.moveResourceStateCalled {
+		t.Fatal("expected move to be handled by wrapper, not delegated to upstream")
+	}
+	if resp.TargetState == nil {
+		t.Fatal("expected TargetState to be set")
+	}
+	if string(resp.TargetState.JSON) != string(sourceJSON) {
+		t.Errorf("expected TargetState.JSON = %s, got %s", sourceJSON, resp.TargetState.JSON)
+	}
+}
+
+func TestMoveResourceState_UnsupportedDelegatesToUpstream(t *testing.T) {
+	mock := &mockServer{}
+	server := NewServerWithMoveState(mock)
+
+	resp, err := server.MoveResourceState(context.Background(), &tfprotov6.MoveResourceStateRequest{
+		SourceTypeName: "kubernetes_cron_job",
+		TargetTypeName: "kubernetes_cron_job_v1",
+		SourceState:    &tfprotov6.RawState{JSON: []byte(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mock.moveResourceStateCalled {
+		t.Fatal("expected unsupported move to be delegated to upstream")
+	}
+	if len(resp.Diagnostics) == 0 {
+		t.Fatal("expected diagnostics from upstream mock")
+	}
+}
+
+func TestMoveResourceState_NilSourceState(t *testing.T) {
+	mock := &mockServer{}
+	server := NewServerWithMoveState(mock)
+
+	resp, err := server.MoveResourceState(context.Background(), &tfprotov6.MoveResourceStateRequest{
+		SourceTypeName: "kubernetes_namespace",
+		TargetTypeName: "kubernetes_namespace_v1",
+		SourceState:    nil,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.TargetState != nil {
+		t.Error("expected nil TargetState for nil SourceState")
+	}
+}
+
+func TestMoveResourceState_InvalidPairDelegates(t *testing.T) {
+	mock := &mockServer{}
+	server := NewServerWithMoveState(mock)
+
+	// Valid source but wrong target
+	_, err := server.MoveResourceState(context.Background(), &tfprotov6.MoveResourceStateRequest{
+		SourceTypeName: "kubernetes_namespace",
+		TargetTypeName: "kubernetes_secret_v1",
+		SourceState:    &tfprotov6.RawState{JSON: []byte(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mock.moveResourceStateCalled {
+		t.Fatal("expected mismatched pair to be delegated to upstream")
+	}
+}
+
+func TestMoveResourceState_DaemonsetNamingDifference(t *testing.T) {
+	// kubernetes_daemonset -> kubernetes_daemon_set_v1 (note the underscore difference)
+	mock := &mockServer{}
+	server := NewServerWithMoveState(mock)
+
+	sourceJSON := []byte(`{"id":"test"}`)
+
+	resp, err := server.MoveResourceState(context.Background(), &tfprotov6.MoveResourceStateRequest{
+		SourceTypeName: "kubernetes_daemonset",
+		TargetTypeName: "kubernetes_daemon_set_v1",
+		SourceState:    &tfprotov6.RawState{JSON: sourceJSON},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.moveResourceStateCalled {
+		t.Fatal("expected daemonset move to be handled by wrapper")
+	}
+	if string(resp.TargetState.JSON) != string(sourceJSON) {
+		t.Errorf("expected TargetState.JSON = %s, got %s", sourceJSON, resp.TargetState.JSON)
+	}
+}
+
+func TestMoveMap_AllPairsAreBidirectional(t *testing.T) {
+	for source, target := range moveMap {
+		if rev, ok := reverseMoveMap[target]; !ok || rev != source {
+			t.Errorf("moveMap entry %s -> %s has no valid reverse mapping", source, target)
+		}
+	}
+}
+
+func TestMoveMap_AllSupportedPairs(t *testing.T) {
+	// Verify all entries in moveMap are recognized by isSupported in both directions
+	for source, target := range moveMap {
+		if !isSupported(source, target) {
+			t.Errorf("isSupported(%s, %s) = false, expected true", source, target)
+		}
+		if !isSupported(target, source) {
+			t.Errorf("isSupported(%s, %s) = false, expected true (reverse)", target, source)
+		}
+	}
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	framework "github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/move"
 	"github.com/hashicorp/terraform-provider-kubernetes/kubernetes"
 	manifest "github.com/hashicorp/terraform-provider-kubernetes/manifest/provider"
 )
@@ -34,8 +35,10 @@ func MuxServer(ctx context.Context, v string) (tfprotov6.ProviderServer, error) 
 		return nil, err
 	}
 
+	wrappedSdkProvider := move.NewServerWithMoveState(upgradedSdkProvider)
+
 	providers := []func() tfprotov6.ProviderServer{
-		func() tfprotov6.ProviderServer { return upgradedSdkProvider },
+		func() tfprotov6.ProviderServer { return wrappedSdkProvider },
 		func() tfprotov6.ProviderServer { return upgradedManifestProvider },
 		providerserver.NewProtocol6(framework.New(v, kubernetesProvider.Meta)),
 	}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Not applicable I think.


### Description

I, like many others, have upgraded to version 3.0.0 of this provider. With it we want to remove the deprecation warnings about resources like `kubernetes_namespace` and use `kubernetes_namespace_v1`. But this provider doesn't support the `moved` block and manually messing with state is not scalable for our deployment. This is detailed in a few issues, this being the main one: https://github.com/hashicorp/terraform-provider-kubernetes/issues/2812

This PR adds `moved` support for ~25 resource types. I have not included the following as they have slightly different schemas,

     - kubernetes_cron_job -> kubernetes_cron_job_v1
     - kubernetes_ingress -> kubernetes_ingress_v1
     - kubernetes_validating_webhook_configuration -> _v1
     - kubernetes_mutating_webhook_configuration -> _v1
     - kubernetes_csi_driver -> kubernetes_csi_driver_v1
     - kubernetes_horizontal_pod_autoscaler -> _v1 / _v2
     - kubernetes_pod_disruption_budget -> _v1
     - kubernetes_certificate_signing_request -> _v1

**Note:** I will add the caveat that I am NOT a Go developer. Claude did all the heavy lifting here. We just really want this functionality present in the provider.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?
  - There are failures in `internal/framework/provider/functions` on my local, but these happened before my changes

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccMoveResourceState'

  === RUN   TestAccMoveResourceState_configMapForward
  --- PASS: TestAccMoveResourceState_configMapForward (4.64s)
  === RUN   TestAccMoveResourceState_configMapReverse
  --- PASS: TestAccMoveResourceState_configMapReverse (4.17s)
  === RUN   TestAccMoveResourceState_secret
  --- PASS: TestAccMoveResourceState_secret (4.12s)
  === RUN   TestAccMoveResourceState_daemonset
  --- PASS: TestAccMoveResourceState_daemonset (6.31s)
  PASS
  ok    github.com/hashicorp/terraform-provider-kubernetes/internal/move        19.254s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`moved` is now supported for the following resources,

| # | Deprecated Resource | Versioned Replacement |
|---|---|---|
| | **Core** | |
| 1 | `kubernetes_namespace` | `kubernetes_namespace_v1` |
| 2 | `kubernetes_service` | `kubernetes_service_v1` |
| 3 | `kubernetes_service_account` | `kubernetes_service_account_v1` |
| 4 | `kubernetes_default_service_account` | `kubernetes_default_service_account_v1` |
| 5 | `kubernetes_config_map` | `kubernetes_config_map_v1` |
| 6 | `kubernetes_secret` | `kubernetes_secret_v1` |
| 7 | `kubernetes_pod` | `kubernetes_pod_v1` |
| 8 | `kubernetes_endpoints` | `kubernetes_endpoints_v1` |
| 9 | `kubernetes_limit_range` | `kubernetes_limit_range_v1` |
| 10 | `kubernetes_persistent_volume` | `kubernetes_persistent_volume_v1` |
| 11 | `kubernetes_persistent_volume_claim` | `kubernetes_persistent_volume_claim_v1` |
| 12 | `kubernetes_replication_controller` | `kubernetes_replication_controller_v1` |
| 13 | `kubernetes_resource_quota` | `kubernetes_resource_quota_v1` |
| | **API Registration** | |
| 14 | `kubernetes_api_service` | `kubernetes_api_service_v1` |
| | **Apps** | |
| 15 | `kubernetes_deployment` | `kubernetes_deployment_v1` |
| 16 | `kubernetes_daemonset` | `kubernetes_daemon_set_v1` |
| 17 | `kubernetes_stateful_set` | `kubernetes_stateful_set_v1` |
| | **Batch** | |
| 18 | `kubernetes_job` | `kubernetes_job_v1` |
| | **RBAC** | |
| 19 | `kubernetes_role` | `kubernetes_role_v1` |
| 20 | `kubernetes_role_binding` | `kubernetes_role_binding_v1` |
| 21 | `kubernetes_cluster_role` | `kubernetes_cluster_role_v1` |
| 22 | `kubernetes_cluster_role_binding` | `kubernetes_cluster_role_binding_v1` |
| | **Networking** | |
| 23 | `kubernetes_ingress_class` | `kubernetes_ingress_class_v1` |
| 24 | `kubernetes_network_policy` | `kubernetes_network_policy_v1` |
| | **Scheduling** | |
| 25 | `kubernetes_priority_class` | `kubernetes_priority_class_v1` |
| | **Storage** | |
| 26 | `kubernetes_storage_class` | `kubernetes_storage_class_v1` |
...
```

### References

https://github.com/hashicorp/terraform-provider-kubernetes/issues/2812
https://github.com/hashicorp/terraform-provider-kubernetes/issues/2829

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
