### PR TITLE
`CI`: git clone terraform in RUNNER_TEMP dir

### DIFF
--- a/.github/workflows/acceptance_test_kind_daily_mainline.yaml
+++ b/.github/workflows/acceptance_test_kind_daily_mainline.yaml
@@ -32,8 +32,8 @@ jobs:
           go-version-file: 'go.mod'
       - name: Install Terraform From Source
         run: |
-          git clone --depth 1 -b main https://github.com/hashicorp/terraform.git
-          cd terraform
+          git clone --depth 1 -b main https://github.com/hashicorp/terraform.git "${RUNNER_TEMP}/terraform"
+          cd "${RUNNER_TEMP}/terraform"
           go build -o terraform
           mkdir -p "${HOME}/bin"
           mv terraform "${HOME}/bin/terraform"


### PR DESCRIPTION
for `acceptance_daily_mainline` terraform would be cloned into the root of the github_workspace. This causes an error since `go fmt` includes `terraform` directory as part of the check. This moves the cloning of mainline terraform into the runners temporary directory that's meant to act as a directory for artifacts associated with the GHA Job