### PR TITLE
fixed failing function uts after kubernetes_validating_admission_policy_v1 resource was added

### DIFF
--- a/internal/framework/provider/functions/functions_test.go
+++ b/internal/framework/provider/functions/functions_test.go
@@ -5,10 +5,10 @@ package functions_test
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider"
 )
 
-var testAccProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-	"kubernetes": providerserver.NewProtocol5WithError(provider.New("test", nil)),
+var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"kubernetes": providerserver.NewProtocol6WithError(provider.New("test", nil)),
 }

--- a/internal/framework/provider/functions/manifest_decode_multi_test.go
+++ b/internal/framework/provider/functions/manifest_decode_multi_test.go
@@ -22,7 +22,7 @@ func TestManifestDecodeMulti(t *testing.T) {
 	outputName := "test"
 
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testManifestDecodeMultiConfig("testdata/decode_single.yaml"),

--- a/internal/framework/provider/functions/manifest_decode_test.go
+++ b/internal/framework/provider/functions/manifest_decode_test.go
@@ -21,7 +21,7 @@ func TestManifestDecode(t *testing.T) {
 	outputName := "test"
 
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testManifestDecodeConfig("testdata/decode_single.yaml"),
@@ -51,7 +51,7 @@ func TestManifestDecode_ErrorOnMulti(t *testing.T) {
 	t.Parallel()
 
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testManifestDecodeConfig("testdata/decode_multi.yaml"),

--- a/internal/framework/provider/functions/manifest_encode_test.go
+++ b/internal/framework/provider/functions/manifest_encode_test.go
@@ -15,7 +15,7 @@ func TestManifestEncode(t *testing.T) {
 	outputName := "test"
 
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testManifestEncodeConfig(),
@@ -40,7 +40,7 @@ func TestManifestEncodeMulti(t *testing.T) {
 	outputName := "test"
 
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testManifestEncodeMultiConfig(),


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description

<!--- Please leave a helpful description of the pull request here. --->
updated provider factory from v5 to v6 in encode, decode function uts.
as uts were failing after kubernetes_validating_admission_policy_v1 was added. 

```
=== NAME  TestManifestEncodeMulti
    manifest_encode_test.go:42: Step 1/1 error: Error running pre-apply plan: exit status 1

        Error: Failed to load plugin schemas

        Error while loading schemas for plugin components: Failed to obtain provider
        schema: Could not load the schema for provider
        registry.terraform.io/hashicorp/kubernetes: failed to retrieve schema from
        provider "registry.terraform.io/hashicorp/kubernetes": Error converting
        resource schema: The schema for the resource
        "kubernetes_validating_admission_policy_v1" couldn't be converted into a
        usable type. This is always a problem with the provider. Please report the
        following to the provider developer:

        AttributeName("spec"): protocol version 5 cannot have Attributes set..
```        


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

make testfuncs passed.

```
make testfuncs 
==> Checking that code complies with gofmt requirements...
go test "/Users/jitendragangwar/hashicorp/code/terraform-provider-kubernetes/internal/framework/provider/functions" -v -vet=off  -parallel 8
=== RUN   TestManifestDecodeMulti
=== PAUSE TestManifestDecodeMulti
=== RUN   TestManifestDecode
=== PAUSE TestManifestDecode
=== RUN   TestManifestDecode_ErrorOnMulti
=== PAUSE TestManifestDecode_ErrorOnMulti
=== RUN   TestManifestEncode
=== PAUSE TestManifestEncode
=== RUN   TestManifestEncodeMulti
=== PAUSE TestManifestEncodeMulti
=== CONT  TestManifestDecodeMulti
=== CONT  TestManifestEncode
=== CONT  TestManifestDecode_ErrorOnMulti
=== CONT  TestManifestEncodeMulti
=== CONT  TestManifestDecode
--- PASS: TestManifestDecode_ErrorOnMulti (0.28s)
--- PASS: TestManifestDecode (0.49s)
--- PASS: TestManifestEncode (0.50s)
--- PASS: TestManifestEncodeMulti (0.50s)
--- PASS: TestManifestDecodeMulti (0.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/functions	1.436s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
