### PR TITLE
fix: correct inverted error check in kubernetes_env managed fields lookup

### DIFF
--- a/kubernetes/resource_kubernetes_env.go
+++ b/kubernetes/resource_kubernetes_env.go
@@ -370,7 +370,7 @@ func getManagedEnvs(managedFields []v1.ManagedFieldsEntry, manager string, d *sc
 		if kind == "CronJob" {
 			spec, _, err = unstructured.NestedMap(u.Object, "f:spec", "f:jobTemplate", "f:spec", "f:template", "f:spec")
 		}
-		if err == nil {
+		if err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Fix an inverted error check in `getManagedEnvs()` (`kubernetes/resource_kubernetes_env.go:373`).

The condition `if err == nil` is backwards. On success, it returns `(nil, nil)` early, discarding the valid `spec` and causing the caller to receive a nil `managedEnvs` map. This means the `kubernetes_env` resource silently fails to track which env vars are managed via server-side field management.

On error, execution falls through to line 383, which performs unchecked type assertions on a nil `spec`, causing a runtime panic that crashes the Terraform provider.

**Call chain:** `resourceKubernetesEnvRead` (line 304) calls `getManagedEnvs`, which iterates managed field entries looking for the field manager. When it finds a match, it calls `unstructured.NestedMap` to extract the spec from the managed fields metadata. The inverted check at line 373 causes the function to exit on success and crash on failure.

**Fix:** Change `if err == nil` to `if err != nil` to match the standard Go error-handling pattern used everywhere else in this file (e.g., line 365).

This bug was introduced in #1869 (2022-10-23).

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

This is a one-character logic fix with no behavioral ambiguity. The existing `kubernetes_env` acceptance tests cover this code path.

```release-note
fix: correct inverted error check in `kubernetes_env` managed fields lookup that caused silent data loss on success and a panic on error
```

### References
- #1869 (introduced the bug)
- #2426 (potentially related `kubernetes_env` issue)