### PR TITLE
fix: remove nil pointer dereference in service account data source on 404

### DIFF
--- a/kubernetes/data_source_kubernetes_service_account_v1.go
+++ b/kubernetes/data_source_kubernetes_service_account_v1.go
@@ -73,7 +73,6 @@ func dataSourceKubernetesServiceAccountV1Read(ctx context.Context, d *schema.Res
 	sa, err := conn.CoreV1().ServiceAccounts(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			d.SetId(buildId(sa.ObjectMeta))
 			return nil
 		}
 		return diag.Errorf(`Unable to fetch service account "%s/%s" from Kubernetes: %s`, metadata.Namespace, metadata.Name, err)


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Fix a nil pointer dereference in `dataSourceKubernetesServiceAccountV1Read` that crashes the provider when a service account is not found.

When the Kubernetes API returns a 404, the response object `sa` is nil. The `IsNotFound` branch at line 75 calls `buildId(sa.ObjectMeta)` on the nil response, which panics:

```go
if apierrors.IsNotFound(err) {
    d.SetId(buildId(sa.ObjectMeta))  // sa is nil, panics here
    return nil
}
```

**Fix:** Remove the `d.SetId(buildId(sa.ObjectMeta))` line, matching the pattern used by all 13 other data sources in this provider, which simply `return nil` on 404 to signal the resource does not exist.

This bug was introduced in #2464 (2024-04-10) when reverting data sources from erroring on not-found to returning empty state. The `buildId` call was left in by mistake.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

This is a one-line deletion that aligns with the established pattern across all other data sources.

```release-note
fix: remove nil pointer dereference in `kubernetes_service_account_v1` data source when the service account does not exist
```

### References
- #2464 (introduced the bug)
- #731 (original data source implementation, without this issue)