### PR TITLE
Add restart_policy to init_container docs for job_v1 and cron_job_v1

### DIFF
--- a/docs/resources/cron_job_v1.md
+++ b/docs/resources/cron_job_v1.md
@@ -1027,6 +1027,7 @@ Optional:
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount))
 - `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+- `restart_policy` (String) Restart policy for designating init container as a sidecar. Can only be `Always`. More info: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#pod-sidecar-containers.
 
 <a id="nestedblock--spec--job_template--spec--template--spec--init_container--env"></a>
 ### Nested Schema for `spec.job_template.spec.template.spec.init_container.env`

--- a/docs/resources/job_v1.md
+++ b/docs/resources/job_v1.md
@@ -984,6 +984,7 @@ Optional:
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
 - `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+- `restart_policy` (String) Restart policy for designating init container as a sidecar. Can only be `Always`. More info: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#pod-sidecar-containers.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
 ### Nested Schema for `spec.template.spec.init_container.env`


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan
> If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
> Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description
> Please leave a helpful description of the pull request here.

The `restart_policy` attribute was added to the container schema in #2786 (v3.0.0) to support Kubernetes 1.28+ native sidecar containers, but the documentation for `job_v1` and `cron_job_v1` was not updated accordingly.

Other resource docs (`deployment_v1`, `daemon_set_v1`, `pod_v1`, `stateful_set_v1`) already include the `restart_policy` entry in their `init_container` nested schema. This PR brings `job_v1` and `cron_job_v1` in line.

### Acceptance tests
> - [ ] Have you added an acceptance test for the functionality being added?
> - [ ] Have you run the acceptance tests on this branch?

N/A — documentation-only change.

### Release Note
> Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References
> Are there any other GitHub issues (open or closed) or pull requests that should be linked here?

- #2786 (original PR adding the attribute)
- #2446 (feature request for sidecar container support)

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment