### PR TITLE
Do not send absent computed_fields in kubernetes_manifest apply payload

### DIFF
--- a/manifest/provider/apply.go
+++ b/manifest/provider/apply.go
@@ -187,36 +187,13 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 		// planning in order to allow the response from apply to return potentially
 		// different values to the ones the user configured.
 		//
-		// Here we replace "computed" attributes (showing as Unknown) with their actual
-		// user-supplied values from "manifest" (if present).
-		obj, err = tftypes.Transform(obj, func(ap *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
-			_, isComputed := computedFields[ap.String()]
-			if !isComputed {
-				return v, nil
-			}
-			if v.IsKnown() {
-				return v, nil
-			}
-			ppMan, restPath, err := tftypes.WalkAttributePath(plannedStateVal["manifest"], ap)
-			if err != nil {
-				if len(restPath.Steps()) > 0 {
-					// attribute not in manifest
-					return v, nil
-				}
-				return v, ap.NewError(err)
-			}
-			nv, d := morph.ValueToType(ppMan.(tftypes.Value), v.Type(), tftypes.NewAttributePath())
-			if len(d) > 0 {
-				resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "Manifest configuration is incompatible with resource schema",
-					Detail:   "Detailed descriptions of errors will follow below.",
-				})
-				resp.Diagnostics = append(resp.Diagnostics, d...)
-				return v, nil
-			}
-			return nv, nil
-		})
+		// Here we replace "computed" attributes with their actual user-supplied
+		// values from "manifest" (if present). Computed fields absent from
+		// "manifest" remain Unknown so prior object state is not sent as desired
+		// server-side apply payload.
+		var diagnostics []*tfprotov5.Diagnostic
+		obj, diagnostics, err = backfillComputedFields(obj, plannedStateVal["manifest"], computedFields)
+		resp.Diagnostics = append(resp.Diagnostics, diagnostics...)
 		if err != nil {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,

--- a/manifest/provider/apply_test.go
+++ b/manifest/provider/apply_test.go
@@ -1,0 +1,85 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/payload"
+)
+
+func TestBackfillComputedFieldsOmitsManifestAbsentComputedAnnotation(t *testing.T) {
+	objectType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"apiVersion": tftypes.String,
+		"kind":       tftypes.String,
+		"metadata": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"name":        tftypes.String,
+			"namespace":   tftypes.String,
+			"annotations": tftypes.Map{ElementType: tftypes.String},
+		}},
+		"data": tftypes.Map{ElementType: tftypes.String},
+	}}
+	metadataType := objectType.AttributeTypes["metadata"]
+
+	manifest := tftypes.NewValue(objectType, map[string]tftypes.Value{
+		"apiVersion": tftypes.NewValue(tftypes.String, "v1"),
+		"kind":       tftypes.NewValue(tftypes.String, "ConfigMap"),
+		"metadata": tftypes.NewValue(metadataType, map[string]tftypes.Value{
+			"name":      tftypes.NewValue(tftypes.String, "example"),
+			"namespace": tftypes.NewValue(tftypes.String, "default"),
+			"annotations": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+				"example.com/managed": tftypes.NewValue(tftypes.String, "terraform"),
+			}),
+		}),
+		"data": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+			"value": tftypes.NewValue(tftypes.String, "v2"),
+		}),
+	})
+	plannedObject := tftypes.NewValue(objectType, map[string]tftypes.Value{
+		"apiVersion": tftypes.NewValue(tftypes.String, "v1"),
+		"kind":       tftypes.NewValue(tftypes.String, "ConfigMap"),
+		"metadata": tftypes.NewValue(metadataType, map[string]tftypes.Value{
+			"name":      tftypes.NewValue(tftypes.String, "example"),
+			"namespace": tftypes.NewValue(tftypes.String, "default"),
+			"annotations": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+				"controller.example.com/runtime": tftypes.NewValue(tftypes.String, "stale-runtime-value"),
+				"example.com/managed":            tftypes.NewValue(tftypes.String, "terraform"),
+			}),
+		}),
+		"data": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+			"value": tftypes.NewValue(tftypes.String, "v2"),
+		}),
+	})
+
+	annotationsPath := tftypes.NewAttributePath().WithAttributeName("metadata").WithAttributeName("annotations")
+	runtimeAnnotationPath := tftypes.NewAttributePath().WithAttributeName("metadata").WithAttributeName("annotations").WithElementKeyString("controller.example.com/runtime")
+	computedFields := map[string]*tftypes.AttributePath{
+		annotationsPath.String():       annotationsPath,
+		runtimeAnnotationPath.String(): runtimeAnnotationPath,
+	}
+
+	backfilled, diagnostics, err := backfillComputedFields(plannedObject, manifest, computedFields)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(diagnostics) > 0 {
+		t.Fatalf("unexpected diagnostics: %#v", diagnostics)
+	}
+
+	pu, err := payload.FromTFValue(morph.UnknownToNull(backfilled), nil, tftypes.NewAttributePath())
+	if err != nil {
+		t.Fatalf("unexpected payload conversion error: %s", err)
+	}
+	rqObj := mapRemoveNulls(pu.(map[string]interface{}))
+
+	annotations := rqObj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+	if _, ok := annotations["controller.example.com/runtime"]; ok {
+		t.Fatalf("runtime annotation should not be included in apply payload: %#v", annotations)
+	}
+	if got := annotations["example.com/managed"]; got != "terraform" {
+		t.Fatalf("managed annotation mismatch: got %#v", got)
+	}
+}

--- a/manifest/provider/computed_fields.go
+++ b/manifest/provider/computed_fields.go
@@ -1,0 +1,50 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/manifest/morph"
+)
+
+// backfillComputedFields prepares computed fields for apply payload creation.
+// Configured computed fields are populated from manifest, while computed fields
+// absent from manifest stay unknown so prior object state is not sent as desired.
+func backfillComputedFields(obj tftypes.Value, manifest tftypes.Value, computedFields map[string]*tftypes.AttributePath) (tftypes.Value, []*tfprotov5.Diagnostic, error) {
+	var diagnostics []*tfprotov5.Diagnostic
+
+	backfilled, err := tftypes.Transform(obj, func(ap *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
+		_, isComputed := computedFields[ap.String()]
+		if !isComputed {
+			return v, nil
+		}
+
+		ppMan, restPath, err := tftypes.WalkAttributePath(manifest, ap)
+		if err != nil {
+			if len(restPath.Steps()) > 0 {
+				return tftypes.NewValue(v.Type(), tftypes.UnknownValue), nil
+			}
+			return v, ap.NewError(err)
+		}
+
+		nv, d := morph.ValueToType(ppMan.(tftypes.Value), v.Type(), tftypes.NewAttributePath())
+		if len(d) > 0 {
+			diagnostics = append(diagnostics, &tfprotov5.Diagnostic{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Manifest configuration is incompatible with resource schema",
+				Detail:   "Detailed descriptions of errors will follow below.",
+			})
+			diagnostics = append(diagnostics, d...)
+			return v, nil
+		}
+
+		return nv, nil
+	})
+	if err != nil {
+		return obj, diagnostics, err
+	}
+
+	return backfilled, diagnostics, nil
+}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This PR does not change access controls, encryption, or logging.

### Description

This fixes `kubernetes_manifest` apply payload construction for fields listed in `computed_fields`.

Previously, a computed field could remain known in the planned `object` and be sent in the server-side apply payload even when that field was absent from the configured `manifest`. This could cause field manager conflicts when another controller owned and updated that field between saved plan creation and apply.

With this change, computed fields are handled as follows during apply:

- if the computed field exists in `manifest`, the provider backfills it from `manifest`
- if the computed field is absent from `manifest`, the provider leaves it unknown so it is omitted from the server-side apply payload
- prior/live object values are not treated as desired values for manifest-absent computed fields

This keeps Terraform from sending stale runtime fields owned by another server-side apply field manager.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```text
Not run. This change is covered by unit tests.
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Fix kubernetes_manifest computed_fields handling so fields absent from manifest are omitted from the server-side apply payload instead of being populated from prior object state.
```

### References

- Closes #2894

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment