### PR TITLE
linux s390x build added

### DIFF
--- a/.changelog/2897.txt
+++ b/.changelog/2897.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added linux/s390x build target for IBM Z platform
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,18 +95,24 @@ jobs:
       fail-fast: true
       matrix:
         goos: [freebsd, windows, linux, darwin]
-        goarch: ["386", "amd64", "arm", "arm64"]
+        goarch: ["386", "amd64", "arm", "arm64", "s390x"]
         exclude:
           - goos: freebsd
             goarch: arm64
+          - goos: freebsd
+            goarch: s390x
           - goos: windows
             goarch: arm64
           - goos: windows
             goarch: arm
+          - goos: windows
+            goarch: s390x
           - goos: darwin
             goarch: 386
           - goos: darwin
             goarch: arm
+          - goos: darwin
+            goarch: s390x
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,7 +21,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@82d40c283aeb1f2b6595839195e95c2d6a49081b # v5.0.0
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: 'v1.64.2'
-          skip-pkg-cache: true
+          version: 'v2.12.2'

--- a/.release/terraform-provider-kubernetes-artifacts.hcl
+++ b/.release/terraform-provider-kubernetes-artifacts.hcl
@@ -10,6 +10,7 @@ artifacts {
     "terraform-provider-kubernetes_${version}_linux_amd64.zip",
     "terraform-provider-kubernetes_${version}_linux_arm.zip",
     "terraform-provider-kubernetes_${version}_linux_arm64.zip",
+    "terraform-provider-kubernetes_${version}_linux_s390x.zip",
     "terraform-provider-kubernetes_${version}_windows_386.zip",
     "terraform-provider-kubernetes_${version}_windows_amd64.zip",
   ]


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->


### Description
<!--- Please leave a helpful description of the pull request here. --->
- Add linux/s390x build target for IBM Z platform support
- Add s390x to the goarch build matrix in .github/workflows/build.yml with exclusions for freebsd, windows, and darwin
- Add linux_s390x.zip artifact entry to the CRT release manifest
-  updated golangci-lint to latest (not releated to s390x)


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added linux/s390x build target for IBM Z platform support'
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
