### PR TITLE
Add env_from_map provider function

### DIFF
--- a/.changelog/2905.txt
+++ b/.changelog/2905.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+New function `env_from_map` converts a map of strings into a sorted list of `{ name, value }` objects, useful for populating container `env` blocks in a `kubernetes_manifest` resource
+```

--- a/docs/functions/env_from_map.md
+++ b/docs/functions/env_from_map.md
@@ -1,0 +1,53 @@
+---
+subcategory: ""
+page_title: "env_from_map function"
+description: |-
+  Convert a map of strings into a list of name/value objects
+---
+
+# function: env_from_map
+
+Given a map of strings, returns a list of objects with `name` and `value` attributes, sorted by key. This is useful for populating the `env` field of a container in a `kubernetes_manifest` resource without repeating the `name`/`value` boilerplate for every variable.
+
+## Example Usage
+
+```terraform
+# Configuration using provider functions must include required_providers configuration.
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      # Setting the provider version is a strongly recommended practice
+      # version = "..."
+    }
+  }
+  # Provider functions require Terraform 1.8 and later.
+  required_version = ">= 1.8.0"
+}
+
+locals {
+  env = provider::kubernetes::env_from_map({
+    GREETING = "Hello from the environment"
+    NAME     = "Kubernetes"
+  })
+}
+
+# Use the result to populate the env block of a container in a manifest.
+output "env" {
+  value = local.env
+}
+```
+
+## Signature
+
+```text
+env_from_map(env map of string) list of object
+```
+
+## Arguments
+
+1. `env` (Map of String) A map of environment variable names to values
+
+## Return Type
+
+The `list of object` returned from `env_from_map` contains one object per map entry, each with a `name` and `value` attribute, ordered by `name`.

--- a/examples/functions/env_from_map/example_1.tf
+++ b/examples/functions/env_from_map/example_1.tf
@@ -1,0 +1,24 @@
+# Configuration using provider functions must include required_providers configuration.
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      # Setting the provider version is a strongly recommended practice
+      # version = "..."
+    }
+  }
+  # Provider functions require Terraform 1.8 and later.
+  required_version = ">= 1.8.0"
+}
+
+locals {
+  env = provider::kubernetes::env_from_map({
+    GREETING = "Hello from the environment"
+    NAME     = "Kubernetes"
+  })
+}
+
+# Use the result to populate the env block of a container in a manifest.
+output "env" {
+  value = local.env
+}

--- a/internal/framework/provider/functions/env_from_map.go
+++ b/internal/framework/provider/functions/env_from_map.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package functions
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ function.Function = EnvFromMapFunction{}
+
+func NewEnvFromMapFunction() function.Function {
+	return &EnvFromMapFunction{}
+}
+
+type EnvFromMapFunction struct{}
+
+// envObjectType is the element type returned by env_from_map: an object with
+// name and value attributes, matching the shape of a Kubernetes container
+// environment variable.
+var envObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"name":  types.StringType,
+		"value": types.StringType,
+	},
+}
+
+func (f EnvFromMapFunction) Metadata(_ context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "env_from_map"
+}
+
+func (f EnvFromMapFunction) Definition(_ context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:             "Convert a map of strings into a list of name/value objects",
+		MarkdownDescription: "Given a map of strings, returns a list of objects with `name` and `value` attributes, sorted by key. This is useful for populating the `env` field of a container in a `kubernetes_manifest` resource without repeating the `name`/`value` boilerplate for every variable.",
+		Parameters: []function.Parameter{
+			function.MapParameter{
+				Name:                "env",
+				ElementType:         types.StringType,
+				MarkdownDescription: "A map of environment variable names to values",
+			},
+		},
+		Return: function.ListReturn{
+			ElementType: envObjectType,
+		},
+	}
+}
+
+func (f EnvFromMapFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var env map[string]string
+
+	resp.Error = req.Arguments.Get(ctx, &env)
+	if resp.Error != nil {
+		return
+	}
+
+	// Sort the keys so the resulting list is deterministic and does not
+	// produce a perpetual diff when the input map is reordered.
+	names := make([]string, 0, len(env))
+	for name := range env {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	elements := make([]attr.Value, 0, len(env))
+	for _, name := range names {
+		obj, diags := types.ObjectValue(envObjectType.AttrTypes, map[string]attr.Value{
+			"name":  types.StringValue(name),
+			"value": types.StringValue(env[name]),
+		})
+		if diags.HasError() {
+			resp.Error = function.FuncErrorFromDiags(ctx, diags)
+			return
+		}
+		elements = append(elements, obj)
+	}
+
+	result, diags := types.ListValue(envObjectType, elements)
+	if diags.HasError() {
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+
+	resp.Error = resp.Result.Set(ctx, &result)
+}

--- a/internal/framework/provider/functions/env_from_map_test.go
+++ b/internal/framework/provider/functions/env_from_map_test.go
@@ -1,0 +1,89 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package functions_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestEnvFromMap(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testEnvFromMapConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The list is sorted by key, so GREETING comes before NAME
+					// regardless of the order the map literal was written in.
+					resource.TestCheckOutput("length", "2"),
+					resource.TestCheckOutput("name_0", "GREETING"),
+					resource.TestCheckOutput("value_0", "Hello from the environment"),
+					resource.TestCheckOutput("name_1", "NAME"),
+					resource.TestCheckOutput("value_1", "Kubernetes"),
+				),
+			},
+		},
+	})
+}
+
+func TestEnvFromMapEmpty(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testEnvFromMapEmptyConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("length", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testEnvFromMapConfig() string {
+	return `
+locals {
+  env = provider::kubernetes::env_from_map({
+    NAME     = "Kubernetes"
+    GREETING = "Hello from the environment"
+  })
+}
+
+output "length" {
+  value = tostring(length(local.env))
+}
+
+output "name_0" {
+  value = local.env[0].name
+}
+
+output "value_0" {
+  value = local.env[0].value
+}
+
+output "name_1" {
+  value = local.env[1].name
+}
+
+output "value_1" {
+  value = local.env[1].value
+}`
+}
+
+func testEnvFromMapEmptyConfig() string {
+	return `
+locals {
+  env = provider::kubernetes::env_from_map({})
+}
+
+output "length" {
+  value = tostring(length(local.env))
+}`
+}

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -211,6 +211,7 @@ func (p *KubernetesProvider) EphemeralResources(ctx context.Context) []func() ep
 
 func (p *KubernetesProvider) Functions(ctx context.Context) []func() function.Function {
 	return []func() function.Function{
+		pfunctions.NewEnvFromMapFunction,
 		pfunctions.NewManifestDecodeFunction,
 		pfunctions.NewManifestDecodeMultiFunction,
 		pfunctions.NewManifestEncodeFunction,

--- a/templates/functions/env_from_map.md.tmpl
+++ b/templates/functions/env_from_map.md.tmpl
@@ -1,0 +1,32 @@
+---
+subcategory: ""
+page_title: "env_from_map function"
+description: |-
+  Convert a map of strings into a list of name/value objects
+---
+
+{{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
+
+For example, the {{ .FunctionArgumentsMarkdown }} template can be used to replace manual argument documentation if descriptions of function arguments are added in the provider source code. */ -}}
+
+# function: env_from_map
+
+Given a map of strings, returns a list of objects with `name` and `value` attributes, sorted by key. This is useful for populating the `env` field of a container in a `kubernetes_manifest` resource without repeating the `name`/`value` boilerplate for every variable.
+
+## Example Usage
+
+{{tffile "examples/functions/env_from_map/example_1.tf"}}
+
+## Signature
+
+```text
+env_from_map(env map of string) list of object
+```
+
+## Arguments
+
+1. `env` (Map of String) A map of environment variable names to values
+
+## Return Type
+
+The `list of object` returned from `env_from_map` contains one object per map entry, each with a `name` and `value` attribute, ordered by `name`.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds a new provider-defined function, `provider::kubernetes::env_from_map`, that converts a `map(string)` into a `list(object({ name = string, value = string }))` sorted by key. Resolves #2767.

It removes the repetitive `name`/`value` boilerplate when populating the `env` field of a container in a `kubernetes_manifest` resource:

```hcl
env = provider::kubernetes::env_from_map({
  GREETING = "Hello from the environment"
  NAME     = "Kubernetes"
})
```

The result is sorted by key, so the list is deterministic and does not produce a perpetual diff when the input map is reordered. Variables that need `valueFrom` are out of scope (as noted in the issue) and can be appended with `concat()`:

```hcl
env = concat(
  provider::kubernetes::env_from_map({ GREETING = "Hello" }),
  [{ name = "SECRET", valueFrom = { secretKeyRef = { name = "s", key = "k" } } }],
)
```

Naming mirrors the existing `manifest_*` functions (no `k8s_` / `kubernetes_` prefix, since the provider namespace is already `kubernetes`). Happy to rename if the maintainers prefer something else — the issue noted naming is open.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

This is a provider-defined function covered by unit tests (no cluster required):

```
$ make testfuncs
--- PASS: TestEnvFromMap (0.78s)
--- PASS: TestEnvFromMapEmpty (0.76s)
--- PASS: TestManifestDecode (0.77s)
--- PASS: TestManifestDecodeMulti (1.13s)
--- PASS: TestManifestEncode (0.77s)
--- PASS: TestManifestEncodeMulti (0.78s)
ok  github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/functions
```

### Release Note

```release-note:feature
New function `env_from_map` converts a map of strings into a sorted list of `{ name, value }` objects, useful for populating container `env` blocks in a `kubernetes_manifest` resource
```

### References

Closes #2767
