### PR TITLE
test: add regression test for init_container restart_policy (sidecar support)

### DIFF
--- a/.changelog/2912.txt
+++ b/.changelog/2912.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/kubernetes_job_v1`, `resource/kubernetes_cron_job_v1`: Document `restart_policy` attribute on `init_container` block for sidecar container support (Kubernetes 1.28+)
+```

--- a/docs/resources/cron_job_v1.md
+++ b/docs/resources/cron_job_v1.md
@@ -1027,6 +1027,7 @@ Optional:
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_mount))
 - `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+- `restart_policy` (String) Restart policy for designating init container as a sidecar. Can only be `Always`. More info: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#pod-sidecar-containers.
 
 <a id="nestedblock--spec--job_template--spec--template--spec--init_container--env"></a>
 ### Nested Schema for `spec.job_template.spec.template.spec.init_container.env`

--- a/docs/resources/job_v1.md
+++ b/docs/resources/job_v1.md
@@ -984,6 +984,7 @@ Optional:
 - `volume_mount` (Block List) Pod volumes to mount into the container's filesystem. Cannot be updated. (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_mount))
 - `volume_device` (Block List) Raw volume devices to attach into the container's filesystem as raw block devices. Cannot be updated. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 (see [below for nested schema](#nestedblock--spec--template--spec--init_container--volume_device))
 - `working_dir` (String) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+- `restart_policy` (String) Restart policy for designating init container as a sidecar. Can only be `Always`. More info: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#pod-sidecar-containers.
 
 <a id="nestedblock--spec--template--spec--init_container--env"></a>
 ### Nested Schema for `spec.template.spec.init_container.env`

--- a/kubernetes/schema_container_test.go
+++ b/kubernetes/schema_container_test.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubernetes
+
+import (
+	"testing"
+)
+
+// TestInitContainerRestartPolicyValidation verifies that the restart_policy
+// field on init_container accepts only "Always" (sidecar promotion) and rejects
+// every other value. No cluster required — the ValidateFunc is exercised directly.
+func TestInitContainerRestartPolicyValidation(t *testing.T) {
+	s := containerFields(false)
+	field, ok := s["restart_policy"]
+	if !ok {
+		t.Fatal("restart_policy field missing from containerFields schema")
+	}
+	if field.ValidateFunc == nil {
+		t.Fatal("restart_policy ValidateFunc is nil")
+	}
+
+	validCases := []string{"Always"}
+	for _, v := range validCases {
+		_, es := field.ValidateFunc(v, "restart_policy")
+		if len(es) > 0 {
+			t.Errorf("expected %q to be valid, got errors: %v", v, es)
+		}
+	}
+
+	invalidCases := []string{"Never", "OnFailure", "always", ""}
+	for _, v := range invalidCases {
+		_, es := field.ValidateFunc(v, "restart_policy")
+		if len(es) == 0 {
+			t.Errorf("expected %q to be invalid, but no errors were returned", v)
+		}
+	}
+}


### PR DESCRIPTION
Summary

This PR combines two small improvements around the `restart_policy` field on `init_container` (introduced in #2786 to support Kubernetes 1.28+ native sidecar containers):

1. Docs fix (credit: @mruell, originally proposed in #2893) — `restart_policy` was missing from the `init_container` nested schema block in the generated docs for `kubernetes_job_v1` and `kubernetes_cron_job_v1`. One line added to each file to match the existing documentation in `pod_v1`, `deployment_v1`, `daemon_set_v1`, and `stateful_set_v1`.

2. Regression test — adds `TestInitContainerRestartPolicyValidation` in `kubernetes/schema_container_test.go` to assert that:
   - `"Always"` is accepted (the only valid value per the Kubernetes API)
   - `"Never"`, `"OnFailure"`, `"always"` (wrong case), and `""` are all rejected
   - the field is not accidentally removed from `containerFields()` in a future refactor

Changes

- `docs/resources/job_v1.md` — added `restart_policy` to `init_container` nested schema block
- `docs/resources/cron_job_v1.md` — added `restart_policy` to `init_container` nested schema block
- `kubernetes/schema_container_test.go` — new unit regression test

Related

- Builds on #2893 — please close that PR in favour of this one
- Field originally added in #2786