### PR TITLE
kubernetes:add host_users field to pod spec (hostUsers support)

### DIFF
--- a/.changelog/2914.txt
+++ b/.changelog/2914.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+kubernetes: Add `host_users` field to pod spec to support user namespace isolation (`hostUsers`)
+```

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -196,6 +196,14 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 			Description: "Use the host's pid namespace.",
 		},
 
+		"host_users": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    !isUpdatable,
+			Description: "Use the host's user namespace. Optional: Defaults to true. If set to true or not present, the pod will be run in the host user namespace. If set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host.",
+		},
+
 		"hostname": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -92,6 +92,10 @@ func flattenPodSpec(in v1.PodSpec, isTemplate bool) ([]interface{}, error) {
 	att["host_network"] = in.HostNetwork
 	att["host_pid"] = in.HostPID
 
+	if in.HostUsers != nil {
+		att["host_users"] = *in.HostUsers
+	}
+
 	if in.Hostname != "" {
 		att["hostname"] = in.Hostname
 	}
@@ -794,6 +798,10 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 
 	if v, ok := in["host_pid"]; ok {
 		obj.HostPID = v.(bool)
+	}
+
+	if v, ok := in["host_users"]; ok {
+		obj.HostUsers = ptr.To(v.(bool))
 	}
 
 	if v, ok := in["hostname"]; ok {

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -739,3 +739,65 @@ func TestFlattenCSIVolumeSource(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenExpandPodSpecHostUsers(t *testing.T) {
+	cases := []struct {
+		name              string
+		input             corev1.PodSpec
+		expectedFlattened *bool
+		expectedExpanded  *bool
+	}{
+		{
+			name:              "true",
+			input:             corev1.PodSpec{HostUsers: ptr.To(true)},
+			expectedFlattened: ptr.To(true),
+			expectedExpanded:  ptr.To(true),
+		},
+		{
+			name:              "false",
+			input:             corev1.PodSpec{HostUsers: ptr.To(false)},
+			expectedFlattened: ptr.To(false),
+			expectedExpanded:  ptr.To(false),
+		},
+		{
+			name:              "unset",
+			input:             corev1.PodSpec{},
+			expectedFlattened: nil,
+			expectedExpanded:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flattened, err := flattenPodSpec(tc.input, false)
+			if err != nil {
+				t.Fatalf("unexpected error flattening pod spec: %v", err)
+			}
+
+			flattenedSpec := flattened[0].(map[string]interface{})
+			flattenedHostUsers, present := flattenedSpec["host_users"]
+
+			if tc.expectedFlattened == nil {
+				if present {
+					t.Fatalf("expected host_users to be omitted from flattened pod spec, got %v", flattenedHostUsers)
+				}
+			} else {
+				if !present {
+					t.Fatalf("expected host_users to be present in flattened pod spec")
+				}
+				if diff := cmp.Diff(*tc.expectedFlattened, flattenedHostUsers); diff != "" {
+					t.Fatalf("unexpected flattened host_users (-want +got):\n%s", diff)
+				}
+			}
+
+			expanded, err := expandPodSpec(flattened)
+			if err != nil {
+				t.Fatalf("unexpected error expanding pod spec: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedExpanded, expanded.HostUsers); diff != "" {
+				t.Fatalf("unexpected expanded HostUsers (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary
----------
Adds the host_users optional field to the shared pod spec schema, exposing the kubernetes podSpec.hostUsers field.
When set to false, the pod runs in an isolated Linux user namespace-processes that appear as root inside the container map to an unprivileged UID on the host, significantly reducing the impact of container breakout vulnerabilities.

Changes
---------
1.schema_pod_spec.go-new host_users bool field:Optional,Computed:true,no Default.Flows automatically to all pod-template resources.
2.structures_pod.go-flatten nil-guards the *bool API field before reading;expand wraps with ptr.To() before writing.
3.strutures_pod_test.go-end to end round trip test covering true, false and unset(nil) via the real flattenPodSpec->expandPodSpec pipeline.

Backwards compatibility
------------------------
Omitting host_users from an existing config produces no plan diff.Verified with terraform plan against live cluster-confirmed No changes on a pre-existing pod that never had the field set.


