### PR TITLE
fix: skip sending backoffLimit for indexed jobs to allow API default of MaxInt32

### DIFF
--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -55,7 +55,7 @@ func jobSpecFields(specUpdatable bool) map[string]*schema.Schema {
 			Default:      6,
 			ForceNew:     false,
 			ValidateFunc: validateNonNegativeInteger,
-			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
+			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6, or MaxInt32 when `backoff_limit_per_index` is set.",
 		},
 		"backoff_limit_per_index": {
 			Type:         schema.TypeInt,

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -83,7 +83,7 @@ func expandJobV1Spec(j []interface{}) (batchv1.JobSpec, error) {
 		obj.ActiveDeadlineSeconds = ptr.To(int64(v))
 	}
 
-	if v, ok := in["backoff_limit"].(int); ok && v >= 0 {
+	if v, ok := in["backoff_limit"].(int); ok && v >= 0 && in["completion_mode"] != "Indexed" {
 		obj.BackoffLimit = ptr.To(int32(v))
 	}
 


### PR DESCRIPTION
Fixes #2861

## Problem
When `backoffLimitPerIndex` is set on an indexed Job, the Kubernetes API 
automatically defaults `backoffLimit` to MaxInt32 (2147483647), because 
the per-index limit handles the failure policy instead. However, the 
provider was always sending `backoffLimit: 6` (the hardcoded default), 
overriding the API's correct behavior and causing indexed jobs to fail 
prematurely.

## Root Cause
`schema_job_spec.go` has `Default: 6` for `backoff_limit`, which the 
provider sends unconditionally to the API regardless of completion mode.

## Fix
In the expand function (`structure_job.go`), skip setting `BackoffLimit` 
when `completion_mode` is `Indexed`. This allows the K8s API to apply 
its correct default of MaxInt32 when `backoffLimitPerIndex` is set.

## Testing
Verified locally with kind:
- Indexed job with `backoff_limit_per_index` set → `backoffLimit: 2147483647`
- Normal job without `backoff_limit_per_index` → `backoffLimit: 6` 