### PR TITLE
Add persistent volume datasource support.

### DIFF
--- a/.changelog/2923.txt
+++ b/.changelog/2923.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added support for `data_source` blocks in all resources leveraging `PersistentVolumeClaim` (pods, cronjobs, deploymentsets, etc.)
+```

--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -1886,10 +1886,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/cron_job_v1.md
+++ b/docs/resources/cron_job_v1.md
@@ -1881,10 +1881,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--job_template--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.job_template.spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/daemon_set_v1.md
+++ b/docs/resources/daemon_set_v1.md
@@ -1833,10 +1833,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/daemonset.md
+++ b/docs/resources/daemonset.md
@@ -1831,10 +1831,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -1831,10 +1831,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/deployment_v1.md
+++ b/docs/resources/deployment_v1.md
@@ -1841,10 +1841,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -1839,10 +1839,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/job_v1.md
+++ b/docs/resources/job_v1.md
@@ -1837,10 +1837,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/persistent_volume_claim.md
+++ b/docs/resources/persistent_volume_claim.md
@@ -54,10 +54,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--data_source"></a>
+### Nested Schema for `spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--resources"></a>
 ### Nested Schema for `spec.resources`

--- a/docs/resources/persistent_volume_claim_v1.md
+++ b/docs/resources/persistent_volume_claim_v1.md
@@ -54,10 +54,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--data_source"></a>
+### Nested Schema for `spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--resources"></a>
 ### Nested Schema for `spec.resources`

--- a/docs/resources/pod.md
+++ b/docs/resources/pod.md
@@ -1792,10 +1792,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/pod_v1.md
+++ b/docs/resources/pod_v1.md
@@ -1792,10 +1792,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/replication_controller.md
+++ b/docs/resources/replication_controller.md
@@ -1826,10 +1826,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/replication_controller_v1.md
+++ b/docs/resources/replication_controller_v1.md
@@ -1826,10 +1826,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`

--- a/docs/resources/stateful_set.md
+++ b/docs/resources/stateful_set.md
@@ -1858,10 +1858,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
@@ -2314,10 +2328,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.volume_claim_template.spec.resources`

--- a/docs/resources/stateful_set_v1.md
+++ b/docs/resources/stateful_set_v1.md
@@ -1862,10 +1862,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--template--spec--volume--ephemeral--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.template.spec.volume.ephemeral.volume_claim_template.spec.resources`
@@ -2318,10 +2332,24 @@ Required:
 
 Optional:
 
+- `data_source` (Block List, Max: 1) Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--data_source))
 - `selector` (Block List, Max: 1) A label query over volumes to consider for binding. (see [below for nested schema](#nestedblock--spec--volume_claim_template--spec--selector))
 - `storage_class_name` (String) Name of the storage class requested by the claim
 - `volume_mode` (String) Defines what type of volume is required by the claim.
 - `volume_name` (String) The binding reference to the PersistentVolume backing this claim.
+
+<a id="nestedblock--spec--volume_claim_template--spec--data_source"></a>
+### Nested Schema for `spec.volume_claim_template.spec.data_source`
+
+Required:
+
+- `kind` (String) The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.
+- `name` (String) The name of the resource being referenced.
+
+Optional:
+
+- `api_group` (String) The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.
+
 
 <a id="nestedblock--spec--volume_claim_template--spec--resources"></a>
 ### Nested Schema for `spec.volume_claim_template.spec.resources`

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -1478,3 +1478,86 @@ func testAccKubernetesStatefulSetV1ConfigMinimalWithTemplateNamespace(name, imag
 }
 `, name, imageName)
 }
+
+func TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource(t *testing.T) {
+	var conf appsv1.StatefulSet
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_stateful_set_v1.test"
+	imageName := busyboxImage
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesStatefulSetV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStatefulSetV1ConfigVolumeClaimTemplateDataSource(name, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.volume_claim_template.0.spec.0.data_source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.volume_claim_template.0.spec.0.data_source.0.kind", "VolumeSnapshot"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.volume_claim_template.0.spec.0.data_source.0.name", name+"-snapshot"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.volume_claim_template.0.spec.0.data_source.0.api_group", "snapshot.storage.k8s.io"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesStatefulSetV1ConfigVolumeClaimTemplateDataSource(name, imageName string) string {
+	return fmt.Sprintf(`resource "kubernetes_stateful_set_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "ss-test"
+      }
+    }
+    service_name = "ss-test-service"
+    replicas     = 0
+    template {
+      metadata {
+        labels = {
+          app = "ss-test"
+        }
+      }
+      spec {
+        container {
+          name    = "ss-test"
+          image   = "%s"
+          command = ["sleep", "300"]
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/data"
+          }
+        }
+        termination_grace_period_seconds = 1
+      }
+    }
+    volume_claim_template {
+      metadata {
+        name = "data"
+      }
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "standard"
+        resources {
+          requests = {
+            storage = "1Gi"
+          }
+        }
+        data_source {
+          api_group = "snapshot.storage.k8s.io"
+          kind      = "VolumeSnapshot"
+          name      = "%s-snapshot"
+        }
+      }
+    }
+  }
+  wait_for_rollout = false
+}
+`, name, imageName, name)
+}

--- a/kubernetes/schema_persistent_volume_claim.go
+++ b/kubernetes/schema_persistent_volume_claim.go
@@ -101,5 +101,34 @@ func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
 				string(corev1.PersistentVolumeFilesystem),
 			}, false),
 		},
+		"data_source": {
+			Type:        schema.TypeList,
+			Description: "Specifies the data source for the volume. This can be used to create a pre-populated volume from an existing volume snapshot, PVC, or other source.",
+			Optional:    true,
+			ForceNew:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"api_group": {
+						Type:        schema.TypeString,
+						Description: "The group for the resource being referenced. If not specified, the specified Kind must be in the core API group. For any other third-party types, the API group is required.",
+						Optional:    true,
+						ForceNew:    true,
+					},
+					"kind": {
+						Type:        schema.TypeString,
+						Description: "The type of resource being referenced. Valid values are 'PersistentVolumeClaim' or 'VolumeSnapshot'.",
+						Required:    true,
+						ForceNew:    true,
+					},
+					"name": {
+						Type:        schema.TypeString,
+						Description: "The name of the resource being referenced.",
+						Required:    true,
+						ForceNew:    true,
+					},
+				},
+			},
+		},
 	}
 }

--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -29,6 +29,20 @@ func flattenPersistentVolumeClaimSpec(in corev1.PersistentVolumeClaimSpec) []int
 	if in.VolumeMode != nil {
 		att["volume_mode"] = in.VolumeMode
 	}
+	if in.DataSource != nil {
+		att["data_source"] = flattenDataSource(in.DataSource)
+	}
+	return []interface{}{att}
+}
+
+func flattenDataSource(in *corev1.TypedLocalObjectReference) []interface{} {
+	att := map[string]interface{}{
+		"kind": in.Kind,
+		"name": in.Name,
+	}
+	if in.APIGroup != nil {
+		att["api_group"] = *in.APIGroup
+	}
 	return []interface{}{att}
 }
 
@@ -91,7 +105,25 @@ func expandPersistentVolumeClaimSpec(l []interface{}) (*corev1.PersistentVolumeC
 	if v, ok := in["volume_mode"].(string); ok && v != "" {
 		obj.VolumeMode = ptr.To(corev1.PersistentVolumeMode(v))
 	}
+	if v, ok := in["data_source"].([]interface{}); ok && len(v) > 0 {
+		obj.DataSource = expandDataSource(v)
+	}
 	return obj, nil
+}
+
+func expandDataSource(l []interface{}) *corev1.TypedLocalObjectReference {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	in := l[0].(map[string]interface{})
+	obj := &corev1.TypedLocalObjectReference{
+		Kind: in["kind"].(string),
+		Name: in["name"].(string),
+	}
+	if v, ok := in["api_group"].(string); ok && v != "" {
+		obj.APIGroup = ptr.To(v)
+	}
+	return obj
 }
 
 func expandResourceRequirements(l []interface{}) (*corev1.VolumeResourceRequirements, error) {

--- a/kubernetes/structure_persistent_volume_claim_test.go
+++ b/kubernetes/structure_persistent_volume_claim_test.go
@@ -1,0 +1,95 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestFlattenDataSource(t *testing.T) {
+	cases := []struct {
+		Input          *corev1.TypedLocalObjectReference
+		ExpectedOutput []interface{}
+	}{
+		{
+			&corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To("snapshot.storage.k8s.io"),
+				Kind:     "VolumeSnapshot",
+				Name:     "my-snapshot",
+			},
+			[]interface{}{map[string]interface{}{
+				"api_group": "snapshot.storage.k8s.io",
+				"kind":      "VolumeSnapshot",
+				"name":      "my-snapshot",
+			}},
+		},
+		{
+			&corev1.TypedLocalObjectReference{
+				Kind: "PersistentVolumeClaim",
+				Name: "source-pvc",
+			},
+			[]interface{}{map[string]interface{}{
+				"kind": "PersistentVolumeClaim",
+				"name": "source-pvc",
+			}},
+		},
+	}
+
+	for i, tc := range cases {
+		output := flattenDataSource(tc.Input)
+		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
+			t.Fatalf("Case %d: unexpected result (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
+func TestExpandDataSource(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *corev1.TypedLocalObjectReference
+	}{
+		{
+			[]interface{}{map[string]interface{}{
+				"api_group": "snapshot.storage.k8s.io",
+				"kind":      "VolumeSnapshot",
+				"name":      "my-snapshot",
+			}},
+			&corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To("snapshot.storage.k8s.io"),
+				Kind:     "VolumeSnapshot",
+				Name:     "my-snapshot",
+			},
+		},
+		{
+			[]interface{}{map[string]interface{}{
+				"api_group": "",
+				"kind":      "PersistentVolumeClaim",
+				"name":      "source-pvc",
+			}},
+			&corev1.TypedLocalObjectReference{
+				Kind: "PersistentVolumeClaim",
+				Name: "source-pvc",
+			},
+		},
+		{
+			[]interface{}{},
+			nil,
+		},
+		{
+			[]interface{}{nil},
+			nil,
+		},
+	}
+
+	for i, tc := range cases {
+		output := expandDataSource(tc.Input)
+		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
+			t.Fatalf("Case %d: unexpected result (-want +got):\n%s", i, diff)
+		}
+	}
+}


### PR DESCRIPTION
Assisted-by: Claude Opus 4.6

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Backwards-compatible, but revert and republish is fine.

## Changes to Security Controls

No changes to logging, encryption, or authorization. Just a small schema update affecting a few resources.


### Description

PersistentVolumeClaim supports the `dataSource` field which let's you delegate either a snapshot or copy of some pre-existing data source when creating a new PVC. Resources like `deploymentset`, `statefulset`, etc could all take advantage of this for horizontally scaling by delegating to a CSI volume provisioner to do such a copy from a `volumeClaimTemplate`. Here, I:
* update `schema_persistent_volume_claim.go` to support the `data_source` field for referencing some pre-existing volume
* have claude code update the documentation on all the affected resources which could take advantage of the schema change

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?
- [X] Used local provider installation from this branch against some existing terraform state I had with a `stateflu_set_v1` to witness the behavior on an existing resource (and see the `dataSource` applied on new PVCs:
```
provider_installation {
  dev_overrides {
    "hashicorp/kubernetes" = "/Users/rremer/bin"
  }
  direct {}
}
```

Output from acceptance testing:
```
> make testacc TESTARGS="-run ^TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource"
==> Checking that code complies with gofmt requirements...
go vet ./...
TF_ACC=1 go test "/Users/rremer/src/github.com/hashicorp/terraform-provider-kubernetes/kubernetes" -v -vet=off -run ^TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource -parallel 8 -timeout 3h
=== RUN   TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource
=== PAUSE TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource
=== CONT  TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource
--- PASS: TestAccKubernetesStatefulSetV1_volumeClaimTemplateDataSource (3.11s)
PASS
ok      github.com/hashicorp/terraform-provider-kubernetes/kubernetes   3.973
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):

```release-note
Added support for `data_source` blocks in all resources leveraging `PersistentVolumeClaim` (pods, cronjobs, deploymentsets, etc.)
```

### References

Glad this question was asked, I found [pull/2664](https://github.com/hashicorp/terraform-provider-kubernetes/pull/2644) was a partial/incomplete implementation of this! If I had seen that first I might have forked from there to give them some credit. If we merge this, that one should probably be closed.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
