### PR TITLE
Add match_label_keys and mismatch_label_keys to pod affinity terms

### DIFF
--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -186,6 +186,20 @@ func podAffinityTermFields() map[string]*schema.Schema {
 			Description: "empty topology key is interpreted by the scheduler as 'all topologies'",
 			Required:    true,
 		},
+		"match_label_keys": {
+			Type:        schema.TypeSet,
+			Description: "A set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored.",
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Set:         schema.HashString,
+		},
+		"mismatch_label_keys": {
+			Type:        schema.TypeSet,
+			Description: "A set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored.",
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Set:         schema.HashString,
+		},
 	}
 }
 

--- a/kubernetes/structure_affinity_test.go
+++ b/kubernetes/structure_affinity_test.go
@@ -1,0 +1,109 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFlattenPodAffinityTerms_matchLabelKeys(t *testing.T) {
+	input := []v1.PodAffinityTerm{
+		{
+			TopologyKey:       "topology.kubernetes.io/zone",
+			MatchLabelKeys:    []string{"pod-template-hash"},
+			MismatchLabelKeys: []string{"app"},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	output := flattenPodAffinityTerms(input)
+	if len(output) != 1 {
+		t.Fatalf("Expected 1 element, got %d", len(output))
+	}
+	m := output[0].(map[string]interface{})
+
+	if v, ok := m["match_label_keys"].(*schema.Set); ok {
+		if v.Len() != 1 || !v.Contains("pod-template-hash") {
+			t.Fatalf("Expected match_label_keys to contain 'pod-template-hash', got %#v", v.List())
+		}
+	} else {
+		t.Fatal("match_label_keys missing or wrong type")
+	}
+
+	if v, ok := m["mismatch_label_keys"].(*schema.Set); ok {
+		if v.Len() != 1 || !v.Contains("app") {
+			t.Fatalf("Expected mismatch_label_keys to contain 'app', got %#v", v.List())
+		}
+	} else {
+		t.Fatal("mismatch_label_keys missing or wrong type")
+	}
+}
+
+func TestFlattenPodAffinityTerms_noMatchLabelKeys(t *testing.T) {
+	input := []v1.PodAffinityTerm{
+		{
+			TopologyKey: "topology.kubernetes.io/zone",
+		},
+	}
+
+	output := flattenPodAffinityTerms(input)
+	if len(output) != 1 {
+		t.Fatalf("Expected 1 element, got %d", len(output))
+	}
+	m := output[0].(map[string]interface{})
+
+	if _, ok := m["match_label_keys"]; ok {
+		t.Fatal("match_label_keys should not be present when empty")
+	}
+	if _, ok := m["mismatch_label_keys"]; ok {
+		t.Fatal("mismatch_label_keys should not be present when empty")
+	}
+}
+
+func TestExpandPodAffinityTerms_matchLabelKeys(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"topology_key":        "topology.kubernetes.io/zone",
+			"match_label_keys":    schema.NewSet(schema.HashString, []interface{}{"pod-template-hash"}),
+			"mismatch_label_keys": schema.NewSet(schema.HashString, []interface{}{"app"}),
+		},
+	}
+
+	output := expandPodAffinityTerms(input)
+	if len(output) != 1 {
+		t.Fatalf("Expected 1 element, got %d", len(output))
+	}
+	term := output[0]
+
+	if len(term.MatchLabelKeys) != 1 || term.MatchLabelKeys[0] != "pod-template-hash" {
+		t.Fatalf("Expected MatchLabelKeys=[pod-template-hash], got %#v", term.MatchLabelKeys)
+	}
+	if len(term.MismatchLabelKeys) != 1 || term.MismatchLabelKeys[0] != "app" {
+		t.Fatalf("Expected MismatchLabelKeys=[app], got %#v", term.MismatchLabelKeys)
+	}
+}
+
+func TestExpandPodAffinityTerms_noMatchLabelKeys(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"topology_key": "topology.kubernetes.io/zone",
+		},
+	}
+
+	output := expandPodAffinityTerms(input)
+	if len(output) != 1 {
+		t.Fatalf("Expected 1 element, got %d", len(output))
+	}
+	term := output[0]
+
+	if len(term.MatchLabelKeys) != 0 {
+		t.Fatalf("Expected empty MatchLabelKeys, got %#v", term.MatchLabelKeys)
+	}
+	if len(term.MismatchLabelKeys) != 0 {
+		t.Fatalf("Expected empty MismatchLabelKeys, got %#v", term.MismatchLabelKeys)
+	}
+}

--- a/kubernetes/structures_affinity.go
+++ b/kubernetes/structures_affinity.go
@@ -86,6 +86,12 @@ func flattenPodAffinityTerms(in []v1.PodAffinityTerm) []interface{} {
 		m := make(map[string]interface{})
 		m["namespaces"] = newStringSet(schema.HashString, n.Namespaces)
 		m["topology_key"] = n.TopologyKey
+		if len(n.MatchLabelKeys) != 0 {
+			m["match_label_keys"] = newStringSet(schema.HashString, n.MatchLabelKeys)
+		}
+		if len(n.MismatchLabelKeys) != 0 {
+			m["mismatch_label_keys"] = newStringSet(schema.HashString, n.MismatchLabelKeys)
+		}
 		if n.NamespaceSelector != nil {
 			m["namespace_selector"] = flattenNamespaceSelector(n.NamespaceSelector)
 		}
@@ -228,6 +234,12 @@ func expandPodAffinityTerms(t []interface{}) []v1.PodAffinityTerm {
 		}
 		if v, ok := in["namespaces"].(*schema.Set); ok {
 			obj[i].Namespaces = sliceOfString(v.List())
+		}
+		if v, ok := in["match_label_keys"].(*schema.Set); ok {
+			obj[i].MatchLabelKeys = sliceOfString(v.List())
+		}
+		if v, ok := in["mismatch_label_keys"].(*schema.Set); ok {
+			obj[i].MismatchLabelKeys = sliceOfString(v.List())
 		}
 		if v, ok := in["topology_key"].(string); ok {
 			obj[i].TopologyKey = v


### PR DESCRIPTION
### Description

Adds support for the `matchLabelKeys` and `mismatchLabelKeys` fields in `PodAffinityTerm`, which are stable as of Kubernetes 1.32. These fields allow scoping pod (anti)affinity rules by matching label keys from the incoming pod, preventing rolling update deadlocks when zone-spread anti-affinity rules are in use.

Changes:
- Added `match_label_keys` and `mismatch_label_keys` to `podAffinityTermFields()` schema
- Added flatten logic in `flattenPodAffinityTerms()`
- Added expand logic in `expandPodAffinityTerms()`

### Release Note

```release-note:enhancement
`resource/kubernetes_pod`, `resource/kubernetes_deployment`, `resource/kubernetes_stateful_set`, `resource/kubernetes_daemon_set`, `resource/kubernetes_job`, `resource/kubernetes_cron_job`: Add `match_label_keys` and `mismatch_label_keys` fields to `pod_affinity_term` and `pod_anti_affinity` blocks
```

### References

Closes #2906