### PR TITLE
fix: prevent nil pointer crash in expandResourceQuotaSpec when hard is empty

### DIFF
--- a/kubernetes/structure_resource_quota_test.go
+++ b/kubernetes/structure_resource_quota_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestExpandResourceQuotaSpec_emptyHard(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"hard": map[string]interface{}{},
+		},
+	}
+
+	output, err := expandResourceQuotaSpec(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output == nil {
+		t.Fatal("Expected non-nil output")
+	}
+}
+
+func TestExpandResourceQuotaSpec_nilHard(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"hard": nil,
+		},
+	}
+
+	output, err := expandResourceQuotaSpec(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output == nil {
+		t.Fatal("Expected non-nil output")
+	}
+}
+
+func TestExpandResourceQuotaSpec_noHard(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{},
+	}
+
+	output, err := expandResourceQuotaSpec(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output == nil {
+		t.Fatal("Expected non-nil output")
+	}
+}
+
+func TestExpandResourceQuotaSpec_emptyInput(t *testing.T) {
+	output, err := expandResourceQuotaSpec([]interface{}{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output == nil {
+		t.Fatal("Expected non-nil output")
+	}
+}

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -335,8 +335,12 @@ func expandResourceQuotaSpec(s []interface{}) (*api.ResourceQuotaSpec, error) {
 	}
 	m := s[0].(map[string]interface{})
 
-	if v, ok := m["hard"]; ok {
-		list, err := expandMapToResourceList(v.(map[string]interface{}))
+	if v, ok := m["hard"]; ok && v != nil {
+		hardMap, ok := v.(map[string]interface{})
+		if !ok {
+			return out, fmt.Errorf("unexpected type for hard: %T", v)
+		}
+		list, err := expandMapToResourceList(hardMap)
 		if err != nil {
 			return out, err
 		}


### PR DESCRIPTION
### Description

When a `kubernetes_resource_quota_v1` has an empty `hard` block (`hard = {}`), Terraform's SDK can return a nil interface{} value. The type assertion `v.(map[string]interface{})` in `expandResourceQuotaSpec` panics on nil values, crashing the provider.

This fix adds a nil check and a safe type assertion with proper error handling.

### Release Note

```release-note:bug
`resource/kubernetes_resource_quota_v1`: Fix provider crash when `hard` block is empty
```

### References

Related to #2709