### PR TITLE
Add se_linux_change_policy to Pod SecurityContext

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -329,16 +329,26 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 							Schema: seLinuxOptionsField(isUpdatable),
 						},
 					},
-					"fs_group_change_policy": {
-						Type:        schema.TypeString,
-						Description: "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir.",
-						Optional:    true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(corev1.FSGroupChangeAlways),
-							string(corev1.FSGroupChangeOnRootMismatch),
-						}, false),
-						ForceNew: !isUpdatable,
-					},
+				"fs_group_change_policy": {
+					Type:        schema.TypeString,
+					Description: "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume...",
+					Optional:    true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(corev1.FSGroupChangeAlways),
+						string(corev1.FSGroupChangeOnRootMismatch),
+					}, false),
+					ForceNew: !isUpdatable,
+				},
+				"se_linux_change_policy": {
+					Type:        schema.TypeString,
+					Description: "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.",
+					Optional:    true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(corev1.SELinuxChangePolicyRecursive),
+						string(corev1.SELinuxChangePolicyMountOption),
+					}, false),
+					ForceNew: !isUpdatable,
+				},
 					"supplemental_groups": {
 						Type:        schema.TypeSet,
 						Description: "A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.",

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -329,26 +329,26 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 							Schema: seLinuxOptionsField(isUpdatable),
 						},
 					},
-				"fs_group_change_policy": {
-					Type:        schema.TypeString,
-					Description: "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume...",
-					Optional:    true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(corev1.FSGroupChangeAlways),
-						string(corev1.FSGroupChangeOnRootMismatch),
-					}, false),
-					ForceNew: !isUpdatable,
-				},
-				"se_linux_change_policy": {
-					Type:        schema.TypeString,
-					Description: "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.",
-					Optional:    true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(corev1.SELinuxChangePolicyRecursive),
-						string(corev1.SELinuxChangePolicyMountOption),
-					}, false),
-					ForceNew: !isUpdatable,
-				},
+					"fs_group_change_policy": {
+						Type:        schema.TypeString,
+						Description: "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume...",
+						Optional:    true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(corev1.FSGroupChangeAlways),
+							string(corev1.FSGroupChangeOnRootMismatch),
+						}, false),
+						ForceNew: !isUpdatable,
+					},
+					"se_linux_change_policy": {
+						Type:        schema.TypeString,
+						Description: "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.",
+						Optional:    true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(corev1.SELinuxChangePolicyRecursive),
+							string(corev1.SELinuxChangePolicyMountOption),
+						}, false),
+						ForceNew: !isUpdatable,
+					},
 					"supplemental_groups": {
 						Type:        schema.TypeSet,
 						Description: "A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.",

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -227,6 +227,9 @@ func flattenPodSecurityContext(in *v1.PodSecurityContext) []interface{} {
 	if in.FSGroupChangePolicy != nil {
 		att["fs_group_change_policy"] = *in.FSGroupChangePolicy
 	}
+	if in.SELinuxChangePolicy != nil {
+		att["se_linux_change_policy"] = string(*in.SELinuxChangePolicy)
+	}
 	if len(in.SupplementalGroups) > 0 {
 		att["supplemental_groups"] = newInt64Set(schema.HashSchema(&schema.Schema{
 			Type: schema.TypeInt,
@@ -1032,6 +1035,10 @@ func expandPodSecurityContext(l []interface{}) (*v1.PodSecurityContext, error) {
 	if v, ok := in["fs_group_change_policy"].(string); ok && v != "" {
 		policy := v1.PodFSGroupChangePolicy(v)
 		obj.FSGroupChangePolicy = &policy
+	}
+	if v, ok := in["se_linux_change_policy"].(string); ok && v != "" {
+		policy := v1.PodSELinuxChangePolicy(v)
+		obj.SELinuxChangePolicy = &policy
 	}
 	if v, ok := in["windows_options"].([]interface{}); ok && len(v) > 0 {
 		obj.WindowsOptions = expandWindowsOptions(v)

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -778,5 +778,3 @@ func TestExpandPodSecurityContext_SeLinuxChangePolicy(t *testing.T) {
 		t.Fatalf("Expected SELinuxChangePolicy=%q, got %q", corev1.SELinuxChangePolicyRecursive, *output.SELinuxChangePolicy)
 	}
 }
-
-

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -739,3 +739,44 @@ func TestFlattenCSIVolumeSource(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenPodSecurityContext_SeLinuxChangePolicy(t *testing.T) {
+	policy := corev1.SELinuxChangePolicyRecursive
+	input := &corev1.PodSecurityContext{
+		SELinuxChangePolicy: &policy,
+	}
+
+	output := flattenPodSecurityContext(input)
+	if len(output) == 0 {
+		t.Fatal("Expected non-empty output")
+	}
+	m := output[0].(map[string]interface{})
+	got, ok := m["se_linux_change_policy"]
+	if !ok {
+		t.Fatal("se_linux_change_policy missing from flattened output")
+	}
+	if got != string(corev1.SELinuxChangePolicyRecursive) {
+		t.Fatalf("Expected se_linux_change_policy=%q, got %q", corev1.SELinuxChangePolicyRecursive, got)
+	}
+}
+
+func TestExpandPodSecurityContext_SeLinuxChangePolicy(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"se_linux_change_policy": "Recursive",
+		},
+	}
+
+	output, err := expandPodSecurityContext(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output.SELinuxChangePolicy == nil {
+		t.Fatal("Expected SELinuxChangePolicy to be set")
+	}
+	if *output.SELinuxChangePolicy != corev1.SELinuxChangePolicyRecursive {
+		t.Fatalf("Expected SELinuxChangePolicy=%q, got %q", corev1.SELinuxChangePolicyRecursive, *output.SELinuxChangePolicy)
+	}
+}
+
+


### PR DESCRIPTION
### Description

Adds support for the `seLinuxChangePolicy` field in `PodSecurityContext`, which defines how the container's SELinux label is applied to all volumes used by the Pod. Supported values: `Recursive`, `MountOption`.

- Added `se_linux_change_policy` to pod security context schema
- Added flatten logic in `flattenPodSecurityContext`
- Added expand logic in `expandPodSecurityContext`

### Release Note

```release-note:enhancement
`resource/kubernetes_pod`, `resource/kubernetes_deployment`, `resource/kubernetes_stateful_set`, `resource/kubernetes_daemon_set`, `resource/kubernetes_job`, `resource/kubernetes_cron_job`: Add `se_linux_change_policy` field to `security_context` block
```

### References

Closes #2891