### PR TITLE
fix: always emit read_only in flattenNFSVolumeSource

### DIFF
--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -287,9 +287,7 @@ func flattenNFSVolumeSource(in *v1.NFSVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["server"] = in.Server
 	att["path"] = in.Path
-	if in.ReadOnly {
-		att["read_only"] = in.ReadOnly
-	}
+	att["read_only"] = in.ReadOnly
 	return []interface{}{att}
 }
 

--- a/kubernetes/structure_persistent_volume_spec_test.go
+++ b/kubernetes/structure_persistent_volume_spec_test.go
@@ -41,3 +41,57 @@ func TestFlattenObjectRef(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenNFSVolumeSource(t *testing.T) {
+	cases := []struct {
+		Input          *v1.NFSVolumeSource
+		ExpectedOutput []interface{}
+	}{
+		{
+			&v1.NFSVolumeSource{
+				Server:   "192.168.1.1",
+				Path:     "/exports/data",
+				ReadOnly: true,
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"server":    "192.168.1.1",
+					"path":      "/exports/data",
+					"read_only": true,
+				},
+			},
+		},
+		{
+			&v1.NFSVolumeSource{
+				Server:   "192.168.1.2",
+				Path:     "/exports/ro",
+				ReadOnly: false,
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"server":    "192.168.1.2",
+					"path":      "/exports/ro",
+					"read_only": false,
+				},
+			},
+		},
+		{
+			&v1.NFSVolumeSource{},
+			[]interface{}{
+				map[string]interface{}{
+					"server":    "",
+					"path":      "",
+					"read_only": false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenNFSVolumeSource(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

When `read_only` is `false`, `flattenNFSVolumeSource` previously omitted the field, causing a mismatch with the schema default and resulting in "Provider produced inconsistent result after apply" errors for PVs with NFS sources.

### Release Note

```release-note:bug
`resource/kubernetes_persistent_volume`: Fix "inconsistent result after apply" error for NFS volumes with `read_only = false`
```

### References

Closes #2768