### PR TITLE
fix: allow empty string and 'None' for load_balancer_ip

### DIFF
--- a/kubernetes/resource_kubernetes_service_v1.go
+++ b/kubernetes/resource_kubernetes_service_v1.go
@@ -155,10 +155,9 @@ func resourceKubernetesServiceSchemaV1() map[string]*schema.Schema {
 						ForceNew:    true,
 					},
 					"load_balancer_ip": {
-						Type:         schema.TypeString,
-						Description:  "Only applies to `type = LoadBalancer`. LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying this field when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.",
-						Optional:     true,
-						ValidateFunc: validation.IsIPAddress,
+						Type:        schema.TypeString,
+						Description: "Only applies to `type = LoadBalancer`. LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying this field when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Set to an empty string or `None` to clear a previously assigned IP.",
+						Optional:    true,
 					},
 					"load_balancer_source_ranges": {
 						Type:        schema.TypeSet,

--- a/kubernetes/structure_service_spec.go
+++ b/kubernetes/structure_service_spec.go
@@ -102,9 +102,7 @@ func flattenServiceSpec(in v1.ServiceSpec) []interface{} {
 	if in.SessionAffinityConfig != nil {
 		att["session_affinity_config"] = flattenSessionAffinityConfig(*in.SessionAffinityConfig)
 	}
-	if in.LoadBalancerIP != "" {
-		att["load_balancer_ip"] = in.LoadBalancerIP
-	}
+	att["load_balancer_ip"] = in.LoadBalancerIP
 	if len(in.LoadBalancerSourceRanges) > 0 {
 		att["load_balancer_source_ranges"] = newStringSet(schema.HashString, in.LoadBalancerSourceRanges)
 	}

--- a/kubernetes/structure_service_spec_test.go
+++ b/kubernetes/structure_service_spec_test.go
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestFlattenServiceSpecLoadBalancerIP(t *testing.T) {
+	cases := []struct {
+		Input    v1.ServiceSpec
+		Expected string
+	}{
+		{
+			v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer, LoadBalancerIP: "192.168.1.1"},
+			"192.168.1.1",
+		},
+		{
+			v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer, LoadBalancerIP: ""},
+			"",
+		},
+		{
+			v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer, LoadBalancerIP: "None"},
+			"None",
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenServiceSpec(tc.Input)
+		m := output[0].(map[string]interface{})
+		got, ok := m["load_balancer_ip"]
+		if !ok {
+			t.Fatalf("load_balancer_ip key missing from flattened output for LoadBalancerIP=%q", tc.Input.LoadBalancerIP)
+		}
+		if got != tc.Expected {
+			t.Fatalf("Expected load_balancer_ip=%q, got %q", tc.Expected, got)
+		}
+	}
+}
+
+func TestExpandServiceSpecLoadBalancerIP(t *testing.T) {
+	cases := []struct {
+		Input    []interface{}
+		Expected v1.ServiceSpec
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"load_balancer_ip": "192.168.1.1",
+				},
+			},
+			v1.ServiceSpec{
+				LoadBalancerIP: "192.168.1.1",
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"load_balancer_ip": "",
+				},
+			},
+			v1.ServiceSpec{
+				LoadBalancerIP: "",
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"load_balancer_ip": "None",
+				},
+			},
+			v1.ServiceSpec{
+				LoadBalancerIP: "None",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandServiceSpec(tc.Input)
+		if output.LoadBalancerIP != tc.Expected.LoadBalancerIP {
+			t.Fatalf("Expected LoadBalancerIP=%q, got %q", tc.Expected.LoadBalancerIP, output.LoadBalancerIP)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Removes the strict IP validation on `load_balancer_ip` to allow clearing a previously assigned IP by setting an empty string or `"None"`. Also always emits the field in `flattenServiceSpec` to properly reflect empty/None values in state.

### Release Note

```release-note:bug
`resource/kubernetes_service_v1`: Allow `load_balancer_ip` to be set to an empty string or `"None"` to clear a previously assigned IP
```

### References

Closes #2791