### PR TITLE
Add proc_mount support to container SecurityContext

### DIFF
--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -839,12 +839,22 @@ func securityContextSchema(isUpdatable bool) *schema.Resource {
 		},
 		"se_linux_options": {
 			Type:        schema.TypeList,
-			Description: "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+			Description: "The SELinux context to be applied to the container...",
 			Optional:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: seLinuxOptionsField(isUpdatable),
 			},
+		},
+		"proc_mount": {
+			Type:        schema.TypeString,
+			Description: "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. Requires the ProcMountType feature flag to be enabled.",
+			Optional:    true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(api.DefaultProcMount),
+				string(api.UnmaskedProcMount),
+			}, false),
+			ForceNew: !isUpdatable,
 		},
 	}
 

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -52,6 +52,9 @@ func flattenContainerSecurityContext(in *v1.SecurityContext) []interface{} {
 	if in.SELinuxOptions != nil {
 		att["se_linux_options"] = flattenSeLinuxOptions(in.SELinuxOptions)
 	}
+	if in.ProcMount != nil {
+		att["proc_mount"] = string(*in.ProcMount)
+	}
 	return []interface{}{att}
 }
 
@@ -658,6 +661,10 @@ func expandContainerSecurityContext(l []interface{}) (*v1.SecurityContext, error
 	}
 	if v, ok := in["se_linux_options"].([]interface{}); ok && len(v) > 0 {
 		obj.SELinuxOptions = expandSeLinuxOptions(v)
+	}
+	if v, ok := in["proc_mount"].(string); ok && v != "" {
+		procMount := v1.ProcMountType(v)
+		obj.ProcMount = &procMount
 	}
 
 	return &obj, nil

--- a/kubernetes/structures_container_test.go
+++ b/kubernetes/structures_container_test.go
@@ -312,3 +312,42 @@ func TestFlattenContainerVolumeMounts_mountPropogation(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenContainerSecurityContext_ProcMount(t *testing.T) {
+	procMount := v1.UnmaskedProcMount
+	input := &v1.SecurityContext{
+		ProcMount: &procMount,
+	}
+
+	output := flattenContainerSecurityContext(input)
+	if len(output) == 0 {
+		t.Fatal("Expected non-empty output")
+	}
+	m := output[0].(map[string]interface{})
+	got, ok := m["proc_mount"]
+	if !ok {
+		t.Fatal("proc_mount missing from flattened output")
+	}
+	if got != string(v1.UnmaskedProcMount) {
+		t.Fatalf("Expected proc_mount=%q, got %q", v1.UnmaskedProcMount, got)
+	}
+}
+
+func TestExpandContainerSecurityContext_ProcMount(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"proc_mount": "Unmasked",
+		},
+	}
+
+	output, err := expandContainerSecurityContext(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output.ProcMount == nil {
+		t.Fatal("Expected ProcMount to be set")
+	}
+	if *output.ProcMount != v1.UnmaskedProcMount {
+		t.Fatalf("Expected ProcMount=%q, got %q", v1.UnmaskedProcMount, *output.ProcMount)
+	}
+}


### PR DESCRIPTION
### Description

Adds support for the `procMount` field in container SecurityContext, which controls the type of proc mount to use. Supported values: `Default`, `Unmasked`.

- Added `proc_mount` to container security context schema
- Added flatten logic in `flattenContainerSecurityContext`
- Added expand logic in `expandContainerSecurityContext`

### Release Note

```release-note:enhancement
`resource/kubernetes_pod`, `resource/kubernetes_deployment`, `resource/kubernetes_stateful_set`, `resource/kubernetes_daemon_set`, `resource/kubernetes_job`, `resource/kubernetes_cron_job`: Add `proc_mount` field to container `security_context` block
```

### References

Closes #2803