### PR TITLE
Add max_unavailable to StatefulSet rolling update strategy

### DIFF
--- a/kubernetes/schema_stateful_set_spec.go
+++ b/kubernetes/schema_stateful_set_spec.go
@@ -4,6 +4,8 @@
 package kubernetes
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -77,21 +79,27 @@ func statefulSetSpecFields() map[string]*schema.Schema {
 							"OnDelete",
 						}, false),
 					},
-					"rolling_update": {
-						Type:        schema.TypeList,
-						Description: "RollingUpdate strategy type for StatefulSet",
-						Optional:    true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"partition": {
-									Type:        schema.TypeInt,
-									Optional:    true,
-									Description: "Indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
-									Default:     0,
+						"rolling_update": {
+								Type:        schema.TypeList,
+								Description: "RollingUpdate strategy type for StatefulSet",
+								Optional:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"partition": {
+											Type:        schema.TypeInt,
+											Optional:    true,
+											Description: "Indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
+											Default:     0,
+										},
+										"max_unavailable": {
+											Type:         schema.TypeString,
+											Description:  "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0 if MaxSurge is 0. Defaults to 1.",
+											Optional:     true,
+											ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
+										},
+									},
 								},
 							},
-						},
-					},
 				},
 			},
 		},

--- a/kubernetes/schema_stateful_set_spec.go
+++ b/kubernetes/schema_stateful_set_spec.go
@@ -79,27 +79,27 @@ func statefulSetSpecFields() map[string]*schema.Schema {
 							"OnDelete",
 						}, false),
 					},
-						"rolling_update": {
-								Type:        schema.TypeList,
-								Description: "RollingUpdate strategy type for StatefulSet",
-								Optional:    true,
-								Elem: &schema.Resource{
-									Schema: map[string]*schema.Schema{
-										"partition": {
-											Type:        schema.TypeInt,
-											Optional:    true,
-											Description: "Indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
-											Default:     0,
-										},
-										"max_unavailable": {
-											Type:         schema.TypeString,
-											Description:  "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0 if MaxSurge is 0. Defaults to 1.",
-											Optional:     true,
-											ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
-										},
-									},
+					"rolling_update": {
+						Type:        schema.TypeList,
+						Description: "RollingUpdate strategy type for StatefulSet",
+						Optional:    true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"partition": {
+									Type:        schema.TypeInt,
+									Optional:    true,
+									Description: "Indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
+									Default:     0,
+								},
+								"max_unavailable": {
+									Type:         schema.TypeString,
+									Description:  "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0 if MaxSurge is 0. Defaults to 1.",
+									Optional:     true,
+									ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]+|[0-9]+%|)$`), ""),
 								},
 							},
+						},
+					},
 				},
 			},
 		},

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -118,6 +119,10 @@ func expandStatefulSetSpecUpdateStrategy(s []interface{}) (*v1.StatefulSetUpdate
 			return ust, errors.New("failed to expand 'spec.update_strategy.rolling_update.partition'")
 		}
 		u.Partition = ptr.To(int32(p))
+		if v, ok := r["max_unavailable"].(string); ok && v != "" {
+			val := intstr.Parse(v)
+			u.MaxUnavailable = &val
+		}
 		ust.RollingUpdate = &u
 	}
 	log.Printf("[DEBUG] Expanded StatefulSet.Spec.UpdateStrategy: %#v", ust)
@@ -222,6 +227,9 @@ func flattenStatefulSetSpecUpdateStrategy(s v1.StatefulSetUpdateStrategy) []inte
 		ru := make(map[string]interface{})
 		if s.RollingUpdate.Partition != nil {
 			ru["partition"] = *s.RollingUpdate.Partition
+		}
+		if s.RollingUpdate.MaxUnavailable != nil {
+			ru["max_unavailable"] = s.RollingUpdate.MaxUnavailable.String()
 		}
 		att["rolling_update"] = []interface{}{ru}
 	}

--- a/kubernetes/structures_stateful_set_test.go
+++ b/kubernetes/structures_stateful_set_test.go
@@ -1,0 +1,114 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+func TestFlattenStatefulSetSpecUpdateStrategy_maxUnavailable(t *testing.T) {
+	maxUnavailable := intstr.FromInt32(2)
+	input := v1.StatefulSetUpdateStrategy{
+		Type: v1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &v1.RollingUpdateStatefulSetStrategy{
+			Partition:       ptr.To(int32(1)),
+			MaxUnavailable:  &maxUnavailable,
+		},
+	}
+
+	output := flattenStatefulSetSpecUpdateStrategy(input)
+	if len(output) == 0 {
+		t.Fatal("Expected non-empty output")
+	}
+	m := output[0].(map[string]interface{})
+	ru := m["rolling_update"].([]interface{})
+	if len(ru) == 0 {
+		t.Fatal("Expected rolling_update to be non-empty")
+	}
+	ruMap := ru[0].(map[string]interface{})
+
+	got, ok := ruMap["max_unavailable"]
+	if !ok {
+		t.Fatal("max_unavailable missing from flattened output")
+	}
+	if got != "2" {
+		t.Fatalf("Expected max_unavailable='2', got %q", got)
+	}
+	if ruMap["partition"] != int32(1) {
+		t.Fatalf("Expected partition=1, got %v", ruMap["partition"])
+	}
+}
+
+func TestFlattenStatefulSetSpecUpdateStrategy_noMaxUnavailable(t *testing.T) {
+	input := v1.StatefulSetUpdateStrategy{
+		Type: v1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &v1.RollingUpdateStatefulSetStrategy{
+			Partition: ptr.To(int32(0)),
+		},
+	}
+
+	output := flattenStatefulSetSpecUpdateStrategy(input)
+	m := output[0].(map[string]interface{})
+	ru := m["rolling_update"].([]interface{})
+	ruMap := ru[0].(map[string]interface{})
+
+	if _, ok := ruMap["max_unavailable"]; ok {
+		t.Fatal("max_unavailable should not be present when nil")
+	}
+}
+
+func TestExpandStatefulSetSpecUpdateStrategy_maxUnavailable(t *testing.T) {
+	maxUnavailable := intstr.FromString("25%")
+	input := []interface{}{
+		map[string]interface{}{
+			"type": string(v1.RollingUpdateStatefulSetStrategyType),
+			"rolling_update": []interface{}{
+				map[string]interface{}{
+					"partition":       0,
+					"max_unavailable": "25%",
+				},
+			},
+		},
+	}
+
+	output, err := expandStatefulSetSpecUpdateStrategy(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output.RollingUpdate == nil {
+		t.Fatal("Expected RollingUpdate to be set")
+	}
+	if output.RollingUpdate.MaxUnavailable == nil {
+		t.Fatal("Expected MaxUnavailable to be set")
+	}
+	if !reflect.DeepEqual(*output.RollingUpdate.MaxUnavailable, maxUnavailable) {
+		t.Fatalf("Expected MaxUnavailable=%#v, got %#v", maxUnavailable, *output.RollingUpdate.MaxUnavailable)
+	}
+}
+
+func TestExpandStatefulSetSpecUpdateStrategy_noMaxUnavailable(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"type": string(v1.RollingUpdateStatefulSetStrategyType),
+			"rolling_update": []interface{}{
+				map[string]interface{}{
+					"partition": 0,
+				},
+			},
+		},
+	}
+
+	output, err := expandStatefulSetSpecUpdateStrategy(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if output.RollingUpdate == nil {
+		t.Fatal("Expected RollingUpdate to be set")
+	}
+	if output.RollingUpdate.MaxUnavailable != nil {
+		t.Fatal("Expected MaxUnavailable to be nil when not set")
+	}
+}

--- a/kubernetes/structures_stateful_set_test.go
+++ b/kubernetes/structures_stateful_set_test.go
@@ -14,8 +14,8 @@ func TestFlattenStatefulSetSpecUpdateStrategy_maxUnavailable(t *testing.T) {
 	input := v1.StatefulSetUpdateStrategy{
 		Type: v1.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: &v1.RollingUpdateStatefulSetStrategy{
-			Partition:       ptr.To(int32(1)),
-			MaxUnavailable:  &maxUnavailable,
+			Partition:      ptr.To(int32(1)),
+			MaxUnavailable: &maxUnavailable,
 		},
 	}
 


### PR DESCRIPTION
### Description

Adds support for the `maxUnavailable` field in StatefulSet rolling update strategy, available in Kubernetes v1.35+. Controls how many Pods can be unavailable during a rolling update.

- Added `max_unavailable` to rolling_update schema
- Added flatten/expand logic

### Release Note
```release-note:enhancement
resource/kubernetes_stateful_set_v1: Add max_unavailable field to rolling_update block
```

### References
Closes #2827