### PR TITLE
fix: kubernetes_resources datasource list across all namespaces when namespace is empty

### DIFF
--- a/manifest/provider/datasource.go
+++ b/manifest/provider/datasource.go
@@ -154,9 +154,10 @@ func (s *RawProviderServer) ReadPluralDataSource(ctx context.Context, req *tfpro
 		var namespace string
 		dsConfig["namespace"].As(&namespace)
 		if namespace == "" {
-			namespace = "default"
+			res, err = rcl.List(ctx, listOptions)
+		} else {
+			res, err = rcl.Namespace(namespace).List(ctx, listOptions)
 		}
-		res, err = rcl.Namespace(namespace).List(ctx, listOptions)
 	} else {
 		res, err = rcl.List(ctx, listOptions)
 	}


### PR DESCRIPTION
### Description

When `namespace` is not specified in `kubernetes_resources` data source, list resources across all namespaces instead of defaulting to `"default"`. This matches `kubectl get <resource> --all-namespaces` behavior.

### Release Note

```release-note:bug
`data.kubernetes_resources`: When namespace is not set, list resources across all namespaces instead of defaulting to "default"
```

### References
Closes #2849