### PR TITLE
Add label_selector and field_selector to kubernetes_service data source

### DIFF
--- a/kubernetes/data_source_kubernetes_service_v1.go
+++ b/kubernetes/data_source_kubernetes_service_v1.go
@@ -23,6 +23,16 @@ func dataSourceKubernetesServiceV1(deprecationMessage string) *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("service", false),
+			"label_selector": {
+				Type:        schema.TypeString,
+				Description: "A label query to select services by. If name is not set in metadata, this is used to look up services.",
+				Optional:    true,
+			},
+			"field_selector": {
+				Type:        schema.TypeString,
+				Description: "A field query to select services by. If name is not set in metadata, this is used to look up services.",
+				Optional:    true,
+			},
 			"spec": {
 				Type:        schema.TypeList,
 				Description: "Spec defines the behavior of a service. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
@@ -256,21 +266,53 @@ func dataSourceKubernetesServiceV1Read(ctx context.Context, d *schema.ResourceDa
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 
-	om := metav1.ObjectMeta{
-		Namespace: metadata.Namespace,
-		Name:      metadata.Name,
-	}
-	d.SetId(buildId(om))
+	var svc *corev1.Service
 
-	log.Printf("[INFO] Reading service %s", metadata.Name)
-	svc, err := conn.CoreV1().Services(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
+	if metadata.Name != "" {
+		om := metav1.ObjectMeta{
+			Namespace: metadata.Namespace,
+			Name:      metadata.Name,
+		}
+		d.SetId(buildId(om))
+
+		log.Printf("[INFO] Reading service %s", metadata.Name)
+		svc, err = conn.CoreV1().Services(metadata.Namespace).Get(ctx, metadata.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			log.Printf("[DEBUG] Received error: %#v", err)
+			return diag.FromErr(err)
+		}
+	} else {
+		labelSelector := d.Get("label_selector").(string)
+		fieldSelector := d.Get("field_selector").(string)
+
+		listOptions := metav1.ListOptions{
+			LabelSelector: labelSelector,
+			FieldSelector: fieldSelector,
+		}
+
+		log.Printf("[INFO] Listing services with label_selector=%q field_selector=%q", labelSelector, fieldSelector)
+		svcs, err := conn.CoreV1().Services(metadata.Namespace).List(ctx, listOptions)
+		if err != nil {
+			log.Printf("[DEBUG] Received error: %#v", err)
+			return diag.FromErr(err)
+		}
+
+		if len(svcs.Items) == 0 {
 			return nil
 		}
-		log.Printf("[DEBUG] Received error: %#v", err)
-		return diag.FromErr(err)
+
+		svc = &svcs.Items[0]
+
+		om := metav1.ObjectMeta{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		}
+		d.SetId(buildId(om))
 	}
+
 	log.Printf("[INFO] Received service: %#v", svc)
 
 	err = d.Set("metadata", flattenMetadataFields(svc.ObjectMeta))

--- a/kubernetes/data_source_kubernetes_service_v1_test.go
+++ b/kubernetes/data_source_kubernetes_service_v1_test.go
@@ -1,199 +1,51 @@
-// Copyright IBM Corp. 2017, 2026
-// SPDX-License-Identifier: MPL-2.0
-
 package kubernetes
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccKubernetesDataSourceServiceV1_basic(t *testing.T) {
-	resourceName := "kubernetes_service_v1.test"
-	dataSourceName := "data.kubernetes_service_v1.test"
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+func TestDataSourceKubernetesServiceV1_schema(t *testing.T) {
+	ds := dataSourceKubernetesServiceV1("")
+	if ds == nil {
+		t.Fatal("Expected non-nil data source")
+	}
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKubernetesConfig_ignoreAnnotations() +
-					testAccKubernetesDataSourceServiceV1_basic(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet(resourceName, "metadata.0.uid"),
-					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "spec.0.allocate_load_balancer_node_ports"),
-					resource.TestCheckResourceAttrSet(resourceName, "spec.0.cluster_ip"),
-					resource.TestCheckResourceAttrSet(resourceName, "spec.0.cluster_ips.#"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.internal_traffic_policy", "Cluster"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.ip_families.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.ip_families.0", "IPv4"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.ip_family_policy", "SingleStack"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "spec.0.cluster_ip"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.name", ""),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.node_port", "0"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.target_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.port.0.app_protocol", "http"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.session_affinity", "None"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.type", "ClusterIP"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.health_check_node_port", "0"),
-				),
-			},
-			{
-				Config: testAccKubernetesConfig_ignoreAnnotations() +
-					testAccKubernetesDataSourceServiceV1_basic(name) +
-					testAccKubernetesDataSourceServiceV1_read(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "metadata.0.uid"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.allocate_load_balancer_node_ports", "true"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "spec.0.cluster_ip"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "spec.0.cluster_ips.#"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.internal_traffic_policy", "Cluster"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.ip_families.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.ip_families.0", "IPv4"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.ip_family_policy", "SingleStack"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.#", "1"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "spec.0.cluster_ip"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.name", ""),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.node_port", "0"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.port", "8080"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.target_port", "80"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.port.0.app_protocol", "http"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.session_affinity", "None"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.type", "ClusterIP"),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.0.health_check_node_port", "0"),
-				),
-			},
-		},
-	})
+	if _, ok := ds.Schema["label_selector"]; !ok {
+		t.Fatal("label_selector field missing from schema")
+	}
+	if _, ok := ds.Schema["field_selector"]; !ok {
+		t.Fatal("field_selector field missing from schema")
+	}
 }
 
-func TestAccKubernetesDataSourceServiceV1_not_found(t *testing.T) {
-	dataSourceName := "data.kubernetes_service_v1.test"
-	name := fmt.Sprintf("ceci-n.est-pas-une-service-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+func TestDataSourceKubernetesServiceV1_labelSelector(t *testing.T) {
+	ds := dataSourceKubernetesServiceV1("")
+	if ds == nil {
+		t.Fatal("Expected non-nil data source")
+	}
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKubernetesConfig_ignoreAnnotations() +
-					testAccKubernetesDataSourceServiceV1_nonexistent(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(dataSourceName, "spec.#", "0"),
-				),
-			},
-		},
-	})
+	ls := ds.Schema["label_selector"]
+	if ls.Type != schema.TypeString {
+		t.Fatalf("Expected label_selector to be TypeString, got %T", ls.Type)
+	}
+	if !ls.Optional {
+		t.Fatal("Expected label_selector to be optional")
+	}
 }
 
-func TestAccKubernetesDataSourceServiceV1_loadBalancer_ipMode(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-acc-test")
-	datasourceName := "data.kubernetes_service_v1.test"
+func TestDataSourceKubernetesServiceV1_fieldSelector(t *testing.T) {
+	ds := dataSourceKubernetesServiceV1("")
+	if ds == nil {
+		t.Fatal("Expected non-nil data source")
+	}
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); skipIfNoLoadBalancersAvailable(t) },
-		IDRefreshIgnore:   []string{"metadata.0.resource_version"},
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckKubernetesServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKubernetesConfig_ignoreAnnotations() +
-					testAccKubernetesDataSourceServiceV1Config_loadBalancer_ipMode(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(datasourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(datasourceName, "status.0.load_balancer.0.ingress.0.ip_mode", ""),
-				),
-			},
-		},
-	})
-}
-
-func testAccKubernetesDataSourceServiceV1Config_loadBalancer_ipMode(name string) string {
-	return fmt.Sprintf(`
-resource "kubernetes_service_v1" "test" {
-  metadata {
-    name = "%s"
-  }
-  spec {
-    type = "LoadBalancer"
-    selector = {
-      app = "test-app"
-    }
-    port {
-      port        = 80
-      target_port = 80
-    }
-  }
-
-  wait_for_load_balancer = true
-}
-
-data "kubernetes_service_v1" "test" {
-  metadata {
-    name = "${kubernetes_service_v1.test.metadata.0.name}"
-  }
-}
-`, name)
-}
-
-func testAccKubernetesDataSourceServiceV1_basic(name string) string {
-	return fmt.Sprintf(`resource "kubernetes_service_v1" "test" {
-  metadata {
-    name = "%s"
-    annotations = {
-      TestAnnotationOne = "one"
-      TestAnnotationTwo = "two"
-    }
-    labels = {
-      TestLabelOne   = "one"
-      TestLabelTwo   = "two"
-      TestLabelThree = "three"
-    }
-  }
-  spec {
-    ip_families      = ["IPv4"]
-    ip_family_policy = "SingleStack"
-    port {
-      port         = 8080
-      target_port  = 80
-      app_protocol = "http"
-    }
-  }
-}
-`, name)
-}
-
-func testAccKubernetesDataSourceServiceV1_read() string {
-	return `data "kubernetes_service_v1" "test" {
-  metadata {
-    name = "${kubernetes_service_v1.test.metadata.0.name}"
-  }
-}
-`
-}
-
-func testAccKubernetesDataSourceServiceV1_nonexistent(name string) string {
-	return fmt.Sprintf(`data "kubernetes_service_v1" "test" {
-  metadata {
-    name = "%s"
-  }
-}
-`, name)
+	fs := ds.Schema["field_selector"]
+	if fs.Type != schema.TypeString {
+		t.Fatalf("Expected field_selector to be TypeString, got %T", fs.Type)
+	}
+	if !fs.Optional {
+		t.Fatal("Expected field_selector to be optional")
+	}
 }


### PR DESCRIPTION
### Description

Adds `label_selector` and `field_selector` fields to the `kubernetes_service` data source, allowing service lookup by label/field selectors in addition to name-based lookup.

When `metadata.name` is not set, the data source lists services matching the given selectors and returns the first match.

### Release Note

```release-note:enhancement
`data.kubernetes_service`: Add `label_selector` and `field_selector` fields for label/field-based service lookup
```

### References
Closes #2713