### PR TITLE
Add image/artifact volume source support

### DIFF
--- a/kubernetes/schema_volume_source.go
+++ b/kubernetes/schema_volume_source.go
@@ -591,6 +591,27 @@ func commonVolumeSources() map[string]*schema.Schema {
 				},
 			},
 		},
+		"image": {
+			Type:        schema.TypeList,
+			Description: "Represents an OCI image/artifact volume source that is mounted as a volume on the host and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#image",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"reference": {
+						Type:        schema.TypeString,
+						Description: "The image/artifact reference to mount as a volume. Behaves in the same way as pod.spec.containers[*].image.",
+						Optional:    true,
+					},
+					"pull_policy": {
+						Type:         schema.TypeString,
+						Description:  "Policy for pulling OCI objects. Possible values: Always, Never, IfNotPresent.",
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"Always", "Never", "IfNotPresent"}, false),
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -438,6 +438,9 @@ func flattenVolumes(volumes []v1.Volume) []interface{} {
 		if v.PhotonPersistentDisk != nil {
 			obj["photon_persistent_disk"] = flattenPhotonPersistentDiskVolumeSource(v.PhotonPersistentDisk)
 		}
+		if v.Image != nil {
+			obj["image"] = flattenImageVolumeSource(v.Image)
+		}
 		if v.Ephemeral != nil {
 			obj["ephemeral"] = flattenPodEphemeralVolumeSource(v.Ephemeral)
 		}
@@ -698,6 +701,17 @@ func flattenPodEphemeralVolumeClaimTemplate(in *v1.PersistentVolumeClaimTemplate
 
 	att["spec"] = flattenPersistentVolumeClaimSpec(in.Spec)
 
+	return []interface{}{att}
+}
+
+func flattenImageVolumeSource(in *v1.ImageVolumeSource) []interface{} {
+	att := make(map[string]interface{})
+	if in.Reference != "" {
+		att["reference"] = in.Reference
+	}
+	if in.PullPolicy != "" {
+		att["pull_policy"] = string(in.PullPolicy)
+	}
 	return []interface{}{att}
 }
 
@@ -1148,6 +1162,21 @@ func expandDownwardAPIVolumeFile(in []interface{}) ([]v1.DownwardAPIVolumeFile, 
 		}
 	}
 	return dapivf, nil
+}
+
+func expandImageVolumeSource(l []interface{}) *v1.ImageVolumeSource {
+	if len(l) == 0 || l[0] == nil {
+		return &v1.ImageVolumeSource{}
+	}
+	in := l[0].(map[string]interface{})
+	obj := &v1.ImageVolumeSource{}
+	if v, ok := in["reference"].(string); ok && v != "" {
+		obj.Reference = v
+	}
+	if v, ok := in["pull_policy"].(string); ok && v != "" {
+		obj.PullPolicy = v1.PullPolicy(v)
+	}
+	return obj
 }
 
 func expandConfigMapVolumeSource(l []interface{}) (*v1.ConfigMapVolumeSource, error) {
@@ -1628,6 +1657,9 @@ func expandVolumes(volumes []interface{}) ([]v1.Volume, error) {
 		}
 		if v, ok := m["photon_persistent_disk"].([]interface{}); ok && len(v) > 0 {
 			vl[i].PhotonPersistentDisk = expandPhotonPersistentDiskVolumeSource(v)
+		}
+		if v, ok := m["image"].([]interface{}); ok && len(v) > 0 {
+			vl[i].Image = expandImageVolumeSource(v)
 		}
 		if v, ok := m["ephemeral"].([]interface{}); ok && len(v) > 0 {
 			ephemeral, err := expandEphemeralVolumeSource(v)

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -739,3 +739,95 @@ func TestFlattenCSIVolumeSource(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenImageVolumeSource(t *testing.T) {
+	cases := []struct {
+		Input          *corev1.ImageVolumeSource
+		ExpectedOutput []interface{}
+	}{
+		{
+			&corev1.ImageVolumeSource{
+				Reference:  "nginx:latest",
+				PullPolicy: corev1.PullAlways,
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"reference":   "nginx:latest",
+					"pull_policy": "Always",
+				},
+			},
+		},
+		{
+			&corev1.ImageVolumeSource{
+				Reference: "myregistry.io/my-image:v1.0",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"reference": "myregistry.io/my-image:v1.0",
+				},
+			},
+		},
+		{
+			&corev1.ImageVolumeSource{},
+			[]interface{}{
+				map[string]interface{}{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenImageVolumeSource(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandImageVolumeSource(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *corev1.ImageVolumeSource
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"reference":   "nginx:latest",
+					"pull_policy": "Always",
+				},
+			},
+			&corev1.ImageVolumeSource{
+				Reference:  "nginx:latest",
+				PullPolicy: corev1.PullAlways,
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"reference": "myregistry.io/my-image:v1.0",
+				},
+			},
+			&corev1.ImageVolumeSource{
+				Reference: "myregistry.io/my-image:v1.0",
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{},
+			},
+			&corev1.ImageVolumeSource{},
+		},
+		{
+			[]interface{}{},
+			&corev1.ImageVolumeSource{},
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandImageVolumeSource(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Adds support for the `ImageVolumeSource` volume type (GA since k8s 1.33), which allows mounting OCI images/artifacts as volumes in pods.

- Added `image` volume source to `commonVolumeSources` schema with `reference` and `pull_policy` fields
- Added `flattenImageVolumeSource` and `expandImageVolumeSource` functions
- Wired into `flattenVolumes` and `expandVolumes`
- Added unit tests for both flatten and expand

### Release Note

```release-note:enhancement
`resource/kubernetes_pod`, `resource/kubernetes_deployment`, `resource/kubernetes_stateful_set`, `resource/kubernetes_daemon_set`, `resource/kubernetes_job`, `resource/kubernetes_cron_job`: Add `image` volume source for mounting OCI artifacts
```

### References
Closes #2850