### PR TITLE
fix: apply ignore_annotations and ignore_labels to template metadata

### DIFF
--- a/kubernetes/structure_cron_job_v1.go
+++ b/kubernetes/structure_cron_job_v1.go
@@ -45,7 +45,13 @@ func flattenCronJobSpecV1(in batch.CronJobSpec, d *schema.ResourceData, meta int
 func flattenJobTemplateV1(in batch.JobTemplateSpec, d *schema.ResourceData, meta interface{}) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
-	att["metadata"] = flattenMetadataFields(in.ObjectMeta)
+	att["metadata"] = flattenMetadataFiltered(
+		in.ObjectMeta,
+		d.Get("spec.0.job_template.0.metadata.0.annotations").(map[string]interface{}),
+		d.Get("spec.0.job_template.0.metadata.0.labels").(map[string]interface{}),
+		meta.(providerMetadata).IgnoreAnnotations,
+		meta.(providerMetadata).IgnoreLabels,
+	)
 
 	jobSpec, err := flattenJobV1Spec(in.Spec, d, meta, "spec.0.job_template.0.spec.0.template.0.")
 	if err != nil {

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -57,7 +57,7 @@ func flattenJobV1Spec(in batchv1.JobSpec, d *schema.ResourceData, meta interface
 
 	removeGeneratedLabels(in.Template.ObjectMeta.Labels)
 
-	podSpec, err := flattenPodTemplateSpec(in.Template)
+	podSpec, err := flattenPodTemplateSpec(in.Template, d, meta)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -138,14 +138,15 @@ func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData, providerMet
 	metadataAnnotations := d.Get("metadata.0.annotations").(map[string]interface{})
 	metadataLabels := d.Get("metadata.0.labels").(map[string]interface{})
 
-	ignoreAnnotations := providerMeta.(providerMetadata).IgnoreAnnotations
-	removeInternalKeys(meta.Annotations, metadataAnnotations)
-	removeKeys(meta.Annotations, metadataAnnotations, ignoreAnnotations)
+	pm := providerMeta.(providerMetadata)
+	return flattenMetadataFiltered(meta, metadataAnnotations, metadataLabels, pm.IgnoreAnnotations, pm.IgnoreLabels)
+}
 
-	ignoreLabels := providerMeta.(providerMetadata).IgnoreLabels
-	removeInternalKeys(meta.Labels, metadataLabels)
-	removeKeys(meta.Labels, metadataLabels, ignoreLabels)
-
+func flattenMetadataFiltered(meta metav1.ObjectMeta, userAnnotations, userLabels map[string]interface{}, ignoreAnnotations, ignoreLabels []string) []interface{} {
+	removeInternalKeys(meta.Annotations, userAnnotations)
+	removeKeys(meta.Annotations, userAnnotations, ignoreAnnotations)
+	removeInternalKeys(meta.Labels, userLabels)
+	removeKeys(meta.Labels, userLabels, ignoreLabels)
 	return flattenMetadataFields(meta)
 }
 

--- a/kubernetes/structures_daemonset.go
+++ b/kubernetes/structures_daemonset.go
@@ -30,7 +30,13 @@ func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData, meta 
 	}
 	template := make(map[string]interface{})
 	template["spec"] = podSpec
-	template["metadata"] = flattenMetadataFields(in.Template.ObjectMeta)
+	template["metadata"] = flattenMetadataFiltered(
+		in.Template.ObjectMeta,
+		d.Get("template.0.metadata.0.annotations").(map[string]interface{}),
+		d.Get("template.0.metadata.0.labels").(map[string]interface{}),
+		meta.(providerMetadata).IgnoreAnnotations,
+		meta.(providerMetadata).IgnoreLabels,
+	)
 	att["template"] = []interface{}{template}
 
 	return []interface{}{att}, nil

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -41,7 +41,13 @@ func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData, met
 	}
 	template := make(map[string]interface{})
 	template["spec"] = podSpec
-	template["metadata"] = flattenMetadataFields(in.Template.ObjectMeta)
+	template["metadata"] = flattenMetadataFiltered(
+		in.Template.ObjectMeta,
+		d.Get("template.0.metadata.0.annotations").(map[string]interface{}),
+		d.Get("template.0.metadata.0.labels").(map[string]interface{}),
+		meta.(providerMetadata).IgnoreAnnotations,
+		meta.(providerMetadata).IgnoreLabels,
+	)
 	att["template"] = []interface{}{template}
 
 	return []interface{}{att}, nil

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -167,7 +167,7 @@ func flattenStatefulSetSpec(spec v1.StatefulSetSpec, d *schema.ResourceData, met
 	if spec.ServiceName != "" {
 		att["service_name"] = spec.ServiceName
 	}
-	template, err := flattenPodTemplateSpec(spec.Template)
+	template, err := flattenPodTemplateSpec(spec.Template, d, meta)
 	if err != nil {
 		return []interface{}{att}, err
 	}
@@ -189,10 +189,16 @@ func flattenStatefulSetSpec(spec v1.StatefulSetSpec, d *schema.ResourceData, met
 	return []interface{}{att}, nil
 }
 
-func flattenPodTemplateSpec(t corev1.PodTemplateSpec) ([]interface{}, error) {
+func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData, meta interface{}) ([]interface{}, error) {
 	template := make(map[string]interface{})
 
-	template["metadata"] = flattenMetadataFields(t.ObjectMeta)
+	template["metadata"] = flattenMetadataFiltered(
+		t.ObjectMeta,
+		d.Get("template.0.metadata.0.annotations").(map[string]interface{}),
+		d.Get("template.0.metadata.0.labels").(map[string]interface{}),
+		meta.(providerMetadata).IgnoreAnnotations,
+		meta.(providerMetadata).IgnoreLabels,
+	)
 	spec, err := flattenPodSpec(t.Spec, true)
 	if err != nil {
 		return []interface{}{template}, err


### PR DESCRIPTION
### Description

The provider-level `ignore_annotations` and `ignore_labels` settings were not being applied to pod template metadata in workload controllers (Deployments, DaemonSets, StatefulSets, Jobs, CronJobs). Only the top-level resource metadata and ReplicationController template metadata were filtering ignored keys.

Changes:
- Refactored `flattenMetadata` into `flattenMetadataFiltered` to allow reuse with custom d.Get paths
- Updated template metadata flattening in Deployment, DaemonSet, StatefulSet, Job, and CronJob (v1) to apply the ignore filters
- Added `d` and `meta` parameters to `flattenPodTemplateSpec` in StatefulSet

### Release Note

```release-note:bug
provider: Fix `ignore_annotations` and `ignore_labels` settings not applying to pod template metadata in Deployments, DaemonSets, StatefulSets, Jobs, and CronJobs
```

### References
Closes #2668