### PR TITLE
Expose status.capacity.storage on kubernetes_persistent_volume_claim data source

### DIFF
--- a/kubernetes/data_source_kubernetes_persistent_volume_claim_v1.go
+++ b/kubernetes/data_source_kubernetes_persistent_volume_claim_v1.go
@@ -87,6 +87,37 @@ func dataSourceKubernetesPersistentVolumeClaimV1(deprecationMessage string) *sch
 					},
 				},
 			},
+			"status": {
+				Type:        schema.TypeList,
+				Description: "Status represents the current information/status of a persistent volume claim.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"phase": {
+							Type:        schema.TypeString,
+							Description: "Phase represents the current phase of PersistentVolumeClaim.",
+							Computed:    true,
+						},
+						"access_modes": {
+							Type:        schema.TypeSet,
+							Description: "A set of the actual access modes the volume backing the PVC has.",
+							Computed:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Set: schema.HashString,
+						},
+						"capacity": {
+							Type:        schema.TypeMap,
+							Description: "A map of actual resources of the underlying volume, e.g. { storage = \"50Gi\" }.",
+							Computed:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -122,6 +153,11 @@ func dataSourceKubernetesPersistentVolumeClaimV1Read(ctx context.Context, d *sch
 	}
 
 	err = d.Set("spec", flattenPersistentVolumeClaimSpec(claim.Spec))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("status", flattenPersistentVolumeClaimStatus(claim.Status))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -116,3 +116,17 @@ func expandResourceRequirements(l []interface{}) (*corev1.VolumeResourceRequirem
 	}
 	return obj, nil
 }
+
+func flattenPersistentVolumeClaimStatus(in corev1.PersistentVolumeClaimStatus) []interface{} {
+	att := make(map[string]interface{})
+	if in.Phase != "" {
+		att["phase"] = string(in.Phase)
+	}
+	if len(in.AccessModes) > 0 {
+		att["access_modes"] = flattenPersistentVolumeAccessModes(in.AccessModes)
+	}
+	if len(in.Capacity) > 0 {
+		att["capacity"] = flattenResourceList(in.Capacity)
+	}
+	return []interface{}{att}
+}

--- a/kubernetes/structure_persistent_volume_claim_test.go
+++ b/kubernetes/structure_persistent_volume_claim_test.go
@@ -1,0 +1,58 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestFlattenPersistentVolumeClaimStatus(t *testing.T) {
+	input := corev1.PersistentVolumeClaimStatus{
+		Phase: corev1.ClaimBound,
+		AccessModes: []corev1.PersistentVolumeAccessMode{
+			corev1.ReadWriteOnce,
+		},
+		Capacity: corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse("50Gi"),
+		},
+	}
+
+	output := flattenPersistentVolumeClaimStatus(input)
+	if len(output) == 0 {
+		t.Fatal("Expected non-empty output")
+	}
+	m := output[0].(map[string]interface{})
+
+	if m["phase"] != string(corev1.ClaimBound) {
+		t.Fatalf("Expected phase=%q, got %q", corev1.ClaimBound, m["phase"])
+	}
+
+	accessModes, ok := m["access_modes"].(*schema.Set)
+	if !ok {
+		t.Fatal("access_modes missing or wrong type")
+	}
+	if !accessModes.Contains("ReadWriteOnce") {
+		t.Fatalf("Expected access_modes to contain ReadWriteOnce, got %#v", accessModes.List())
+	}
+
+	capacity, ok := m["capacity"].(map[string]string)
+	if !ok {
+		t.Fatal("capacity missing or wrong type")
+	}
+	if capacity["storage"] != "50Gi" {
+		t.Fatalf("Expected capacity[storage]=50Gi, got %q", capacity["storage"])
+	}
+}
+
+func TestFlattenPersistentVolumeClaimStatus_empty(t *testing.T) {
+	output := flattenPersistentVolumeClaimStatus(corev1.PersistentVolumeClaimStatus{})
+	if len(output) == 0 {
+		t.Fatal("Expected non-empty output")
+	}
+	m := output[0].(map[string]interface{})
+	if len(m) != 0 {
+		t.Fatalf("Expected empty map, got %#v", m)
+	}
+}


### PR DESCRIPTION
### Description

Adds `status` block to the `kubernetes_persistent_volume_claim` data source with `phase`, `access_modes`, and `capacity` fields, allowing users to read the actual provisioned storage capacity (e.g. after cloud provider rounding up).

### Release Note

```release-note:enhancement
data.kubernetes_persistent_volume_claim: Add `status` block with `phase`, `access_modes`, and `capacity` fields
```

### References
Closes #2680