### PR TITLE
fix: preserve empty lists in kubernetes_manifest to prevent inconsistent result

### DIFF
--- a/manifest/payload/from_value.go
+++ b/manifest/payload/from_value.go
@@ -67,7 +67,7 @@ func FromTFValue(in tftypes.Value, th map[string]string, ap *tftypes.AttributePa
 			return nil, ap.NewErrorf("[%s] cannot extract contents of attribute: %s", ap.String(), err)
 		}
 		if len(l) == 0 {
-			return lv, nil
+			return []interface{}{}, nil
 		}
 		for k, le := range l {
 			nextAp := ap.WithElementKeyInt(k)

--- a/manifest/payload/to_value.go
+++ b/manifest/payload/to_value.go
@@ -27,7 +27,14 @@ func ToTFValue(in interface{}, st tftypes.Type, th map[string]string, at *tftype
 		return tftypes.Value{}, at.NewErrorf("[%s] type cannot be nil", at.String())
 	}
 	if in == nil {
-		return tftypes.NewValue(st, nil), nil
+		switch st.(type) {
+		case tftypes.List:
+			return tftypes.NewValue(st, []tftypes.Value{}), nil
+		case tftypes.Set:
+			return tftypes.NewValue(st, []tftypes.Value{}), nil
+		default:
+			return tftypes.NewValue(st, nil), nil
+		}
 	}
 	switch t := in.(type) {
 	case string:

--- a/manifest/payload/to_value_test.go
+++ b/manifest/payload/to_value_test.go
@@ -141,6 +141,16 @@ func TestToTFValue(t *testing.T) {
 			Out: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
 			Err: nil,
 		},
+		"list (nil)": {
+			In:  sampleInType{nil, tftypes.List{ElementType: tftypes.String}},
+			Out: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
+			Err: nil,
+		},
+		"set (nil)": {
+			In:  sampleInType{nil, tftypes.Set{ElementType: tftypes.String}},
+			Out: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{}),
+			Err: nil,
+		},
 		"set": {
 			In: sampleInType{[]interface{}{"test1", "test2"}, tftypes.Set{ElementType: tftypes.String}},
 			Out: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{


### PR DESCRIPTION
### Description

When a user specifies an empty list (e.g. `ports: []`) in a `kubernetes_manifest`, the provider was converting it to `nil` when sending to the Kubernetes API via `FromTFValue`. The API then returned `null` for the field. On read-back via `ToTFValue`, the `null` was compared against the planned empty list, triggering "Provider produced inconsistent result after apply" errors.

**Root cause in `manifest/payload/from_value.go`**: an empty list of tftypes values was returned as a nil Go slice (`var lv []interface{}`), losing the distinction between "user specified an empty list" and "the field was absent."

**Root cause in `manifest/payload/to_value.go`**: a nil Go value for list/set types was returned as a null tftypes value, which then differed from the planned non-null empty list.

**Fix**:
- `FromTFValue`: return `[]interface{}{}` (non-nil empty slice) for empty lists
- `ToTFValue`: convert nil to empty list/set for List and Set types (preserving the empty collection semantic)

Includes tests for nil-to-empty-list conversion.

### Release Note

```release-note:bug
resource/kubernetes_manifest: Fix "inconsistent result after apply" error when manifest contains empty list/array fields
```

### References
Closes #2783