### PR TITLE
fix: filter server-managed annotations in kubernetes_manifest to prevent perpetual diffs

### DIFF
--- a/manifest/provider/resource.go
+++ b/manifest/provider/resource.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-kubernetes/manifest/openapi"
@@ -197,6 +198,18 @@ func RemoveServerSideFields(in map[string]interface{}) map[string]interface{} {
 	// TODO: we should be filtering API responses based on the contents of 'managedFields'
 	// and only retain the attributes for which the manager is Terraform
 	delete(meta, "managedFields")
+
+	// Remove server-managed annotations that cause perpetual diffs
+	if annotations, ok := meta["annotations"].(map[string]interface{}); ok {
+		for k := range annotations {
+			if strings.HasPrefix(k, "kubectl.kubernetes.io/") {
+				delete(annotations, k)
+			}
+			if strings.Contains(k, "deprecated.daemonset.template.generation") {
+				delete(annotations, k)
+			}
+		}
+	}
 
 	return in
 }


### PR DESCRIPTION
### Description

Server-managed annotations like `kubectl.kubernetes.io/restartedAt` and `deprecated.daemonset.template.generation` cause perpetual diffs in `kubernetes_manifest` because they are added by controllers after creation but not present in the planned state.

Fix: Remove well-known server-managed annotation patterns in `RemoveServerSideFields` to prevent annotation drift.

### Release Note

```release-note:bug
resource/kubernetes_manifest: Prevent perpetual diffs caused by server-managed annotations (kubectl.kubernetes.io/restartedAt, deprecated.daemonset.template.generation)
```

### References
Closes #2722, #2711