### PR TITLE
fix: allow status key in kubernetes_manifest for CRDs like Gateway-API

### DIFF
--- a/manifest/provider/validate.go
+++ b/manifest/provider/validate.go
@@ -17,7 +17,7 @@ import (
 func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req *tfprotov5.ValidateResourceTypeConfigRequest) (*tfprotov5.ValidateResourceTypeConfigResponse, error) {
 	resp := &tfprotov5.ValidateResourceTypeConfigResponse{}
 	requiredKeys := []string{"apiVersion", "kind", "metadata"}
-	forbiddenKeys := []string{"status"}
+	forbiddenKeys := []string{}
 
 	rt, err := GetResourceType(req.TypeName)
 	if err != nil {


### PR DESCRIPTION
### Description

The `ValidateResourceTypeConfig` function was rejecting any manifest that includes a top-level `status` key. This prevents installing Gateway-API CRDs whose manifests include a `status` field.

The downstream `TFTypeFromOpenAPI` function already strips `status` from the schema (passing `status=false`), so removing it from `forbiddenKeys` is safe and the validation was overly strict.

### Release Note

```release-note:bug
resource/kubernetes_manifest: Allow `status` key in manifest configuration to support CRDs like Gateway-API
```

### References
Closes #2739