### PR TITLE
fix: allow custom api_group values in kubernetes_role_binding role_ref

### DIFF
--- a/kubernetes/schema_rbac.go
+++ b/kubernetes/schema_rbac.go
@@ -44,11 +44,10 @@ func validateRBACNameFunc(value interface{}, key string) (ws []string, es []erro
 func rbacRoleRefSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"api_group": {
-			Type:         schema.TypeString,
-			Description:  "The API group of the user. The only value possible at the moment is `rbac.authorization.k8s.io`.",
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"rbac.authorization.k8s.io"}, false),
+			Type:        schema.TypeString,
+			Description: "The API group of the user. The only value possible at the moment is `rbac.authorization.k8s.io`.",
+			Required:    true,
+			ForceNew:    true,
 		},
 		"kind": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
### Description

Removes the strict `ValidateFunc` that restricted `role_ref.api_group` to only `rbac.authorization.k8s.io`. This allows compatibility with OpenShift and other platforms that use custom API groups (e.g. `roles.authorization.openshift.io`).

### Release Note
```release-note:bug
resource/kubernetes_role_binding, resource/kubernetes_cluster_role_binding: Allow non-standard `api_group` values in `role_ref` for OpenShift compatibility
```

### References
Closes #903