### PR TITLE
Add match_conditions support to MutatingWebhookConfiguration and ValidatingWebhookConfiguration

### DIFF
--- a/kubernetes/data_source_kubernetes_mutating_webhook_configuration_v1.go
+++ b/kubernetes/data_source_kubernetes_mutating_webhook_configuration_v1.go
@@ -107,6 +107,24 @@ func dataSourceKubernetesMutatingWebhookConfigurationV1() *schema.Resource {
 							Description: webhookDoc["timeoutSeconds"],
 							Computed:    true,
 						},
+						"match_conditions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of the match condition.",
+										Required:    true,
+									},
+									"expression": {
+										Type:        schema.TypeString,
+										Description: "Represents the expression which will be evaluated by the API.",
+										Required:    true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration.go
@@ -137,6 +137,25 @@ func resourceKubernetesMutatingWebhookConfiguration() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 30),
 						},
+						"match_conditions": {
+							Type:        schema.TypeList,
+							Description: webhookDoc["matchConditions"],
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of the match condition.",
+										Required:    true,
+									},
+									"expression": {
+										Type:        schema.TypeString,
+										Description: "Represents the expression which will be evaluated by the API.",
+										Required:    true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_mutating_webhook_configuration_v1.go
@@ -134,6 +134,25 @@ func resourceKubernetesMutatingWebhookConfigurationV1() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 30),
 						},
+						"match_conditions": {
+							Type:        schema.TypeList,
+							Description: webhookDoc["matchConditions"],
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of the match condition.",
+										Required:    true,
+									},
+									"expression": {
+										Type:        schema.TypeString,
+										Description: "Represents the expression which will be evaluated by the API.",
+										Required:    true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1.go
@@ -127,6 +127,25 @@ func resourceKubernetesValidatingWebhookConfigurationV1(deprecationMessage strin
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 30),
 						},
+						"match_conditions": {
+							Type:        schema.TypeList,
+							Description: webhookDoc["matchConditions"],
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of the match condition.",
+										Required:    true,
+									},
+									"expression": {
+										Type:        schema.TypeString,
+										Description: "Represents the expression which will be evaluated by the API.",
+										Required:    true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_validating_webhook_configuration_v1beta1.go
+++ b/kubernetes/resource_kubernetes_validating_webhook_configuration_v1beta1.go
@@ -126,6 +126,25 @@ func resourceKubernetesValidatingWebhookConfigurationV1Beta1(deprecationMessage 
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 30),
 						},
+						"match_conditions": {
+							Type:        schema.TypeList,
+							Description: webhookDoc["matchConditions"],
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of the match condition.",
+										Required:    true,
+									},
+									"expression": {
+										Type:        schema.TypeString,
+										Description: "Represents the expression which will be evaluated by the API.",
+										Required:    true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/kubernetes/structure_mutating_webhook_configuration.go
+++ b/kubernetes/structure_mutating_webhook_configuration.go
@@ -55,6 +55,17 @@ func flattenMutatingWebhook(in admissionregistrationv1.MutatingWebhook) map[stri
 		att["timeout_seconds"] = *in.TimeoutSeconds
 	}
 
+	if len(in.MatchConditions) > 0 {
+		mc := []interface{}{}
+		for _, c := range in.MatchConditions {
+			mc = append(mc, map[string]interface{}{
+				"name":       c.Name,
+				"expression": c.Expression,
+			})
+		}
+		att["match_conditions"] = mc
+	}
+
 	return att
 }
 
@@ -111,6 +122,18 @@ func expandMutatingWebhook(in map[string]interface{}) admissionregistrationv1.Mu
 
 	if v, ok := in["timeout_seconds"].(int); ok {
 		obj.TimeoutSeconds = ptr.To(int32(v))
+	}
+
+	if v, ok := in["match_conditions"].([]interface{}); ok && len(v) > 0 {
+		mc := []admissionregistrationv1.MatchCondition{}
+		for _, c := range v {
+			m := c.(map[string]interface{})
+			mc = append(mc, admissionregistrationv1.MatchCondition{
+				Name:       m["name"].(string),
+				Expression: m["expression"].(string),
+			})
+		}
+		obj.MatchConditions = mc
 	}
 
 	return obj

--- a/kubernetes/structure_validating_webhook_configuration.go
+++ b/kubernetes/structure_validating_webhook_configuration.go
@@ -51,6 +51,17 @@ func flattenValidatingWebhook(in admissionregistrationv1.ValidatingWebhook) map[
 		att["timeout_seconds"] = *in.TimeoutSeconds
 	}
 
+	if len(in.MatchConditions) > 0 {
+		mc := []interface{}{}
+		for _, c := range in.MatchConditions {
+			mc = append(mc, map[string]interface{}{
+				"name":       c.Name,
+				"expression": c.Expression,
+			})
+		}
+		att["match_conditions"] = mc
+	}
+
 	return att
 }
 
@@ -102,6 +113,18 @@ func expandValidatingWebhook(in map[string]interface{}) admissionregistrationv1.
 
 	if v, ok := in["timeout_seconds"].(int); ok {
 		obj.TimeoutSeconds = ptr.To(int32(v))
+	}
+
+	if v, ok := in["match_conditions"].([]interface{}); ok && len(v) > 0 {
+		mc := []admissionregistrationv1.MatchCondition{}
+		for _, c := range v {
+			m := c.(map[string]interface{})
+			mc = append(mc, admissionregistrationv1.MatchCondition{
+				Name:       m["name"].(string),
+				Expression: m["expression"].(string),
+			})
+		}
+		obj.MatchConditions = mc
 	}
 
 	return obj


### PR DESCRIPTION
### Description

Adds support for the `matchConditions` field in webhook configurations, which allows filtering admission requests based on CEL expressions (stable since Kubernetes 1.32).

- Added `match_conditions` schema field to both MutatingWebhookConfiguration and ValidatingWebhookConfiguration (v1 and v1beta1)
- Added to mutating webhook data source
- Added flatten/expand logic for both mutating and validating webhooks

### Release Note
```release-note:enhancement
resource/kubernetes_mutating_webhook_configuration_v1, resource/kubernetes_validating_webhook_configuration_v1: Add `match_conditions` block for CEL-based admission filtering
```

### References
Closes #2750