### PR TITLE
Add pod-level resources support (PodLevelResources feature gate)

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -195,6 +195,29 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 			Default:     conditionalDefault(!isComputed, false),
 			Description: "Use the host's pid namespace.",
 		},
+		"resources": {
+			Type:        schema.TypeList,
+			Description: "Resources describes the compute resource requirements (PodLevelResources feature gate).",
+			Optional:    true,
+			Computed:    isComputed,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"limits": {
+						Type:        schema.TypeMap,
+						Description: "Describes the maximum amount of compute resources allowed.",
+						Optional:    true,
+						Computed:    true,
+					},
+					"requests": {
+						Type:        schema.TypeMap,
+						Description: "Describes the minimum amount of compute resources required.",
+						Optional:    true,
+						Computed:    true,
+					},
+				},
+			},
+		},
 
 		"hostname": {
 			Type:        schema.TypeString,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -92,6 +92,10 @@ func flattenPodSpec(in v1.PodSpec, isTemplate bool) ([]interface{}, error) {
 	att["host_network"] = in.HostNetwork
 	att["host_pid"] = in.HostPID
 
+	if in.Resources != nil {
+		att["resources"] = flattenPodResourceRequirements(in.Resources)
+	}
+
 	if in.Hostname != "" {
 		att["hostname"] = in.Hostname
 	}
@@ -446,6 +450,17 @@ func flattenVolumes(volumes []v1.Volume) []interface{} {
 	return att
 }
 
+func flattenPodResourceRequirements(in *v1.ResourceRequirements) []interface{} {
+	att := make(map[string]interface{})
+	if len(in.Limits) > 0 {
+		att["limits"] = flattenResourceList(in.Limits)
+	}
+	if len(in.Requests) > 0 {
+		att["requests"] = flattenResourceList(in.Requests)
+	}
+	return []interface{}{att}
+}
+
 func flattenPersistentVolumeClaimVolumeSource(in *v1.PersistentVolumeClaimVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	if in.ClaimName != "" {
@@ -794,6 +809,10 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 
 	if v, ok := in["host_pid"]; ok {
 		obj.HostPID = v.(bool)
+	}
+
+	if v, ok := in["resources"].([]interface{}); ok && len(v) > 0 {
+		obj.Resources = expandPodResourceRequirements(v)
 	}
 
 	if v, ok := in["hostname"]; ok {
@@ -1148,6 +1167,27 @@ func expandDownwardAPIVolumeFile(in []interface{}) ([]v1.DownwardAPIVolumeFile, 
 		}
 	}
 	return dapivf, nil
+}
+
+func expandPodResourceRequirements(l []interface{}) *v1.ResourceRequirements {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	in := l[0].(map[string]interface{})
+	obj := &v1.ResourceRequirements{}
+	if v, ok := in["limits"].(map[string]interface{}); ok && len(v) > 0 {
+		rl, err := expandMapToResourceList(v)
+		if err == nil {
+			obj.Limits = *rl
+		}
+	}
+	if v, ok := in["requests"].(map[string]interface{}); ok && len(v) > 0 {
+		rq, err := expandMapToResourceList(v)
+		if err == nil {
+			obj.Requests = *rq
+		}
+	}
+	return obj
 }
 
 func expandConfigMapVolumeSource(l []interface{}) (*v1.ConfigMapVolumeSource, error) {

--- a/kubernetes/structures_pod_test.go
+++ b/kubernetes/structures_pod_test.go
@@ -739,3 +739,58 @@ func TestFlattenCSIVolumeSource(t *testing.T) {
 		}
 	}
 }
+
+func TestFlattenPodResourceRequirements(t *testing.T) {
+	input := &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+
+	output := flattenPodResourceRequirements(input)
+	if len(output) == 0 {
+		t.Fatal("Expected non-empty output")
+	}
+	m := output[0].(map[string]interface{})
+	limits, ok := m["limits"].(map[string]string)
+	if !ok {
+		t.Fatal("limits missing or wrong type")
+	}
+	if limits["memory"] != "4Gi" {
+		t.Fatalf("Expected limits[memory]=4Gi, got %q", limits["memory"])
+	}
+	requests, ok := m["requests"].(map[string]string)
+	if !ok {
+		t.Fatal("requests missing or wrong type")
+	}
+	if requests["memory"] != "2Gi" {
+		t.Fatalf("Expected requests[memory]=2Gi, got %q", requests["memory"])
+	}
+}
+
+func TestExpandPodResourceRequirements(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"limits": map[string]interface{}{
+				"memory": "4Gi",
+			},
+			"requests": map[string]interface{}{
+				"memory": "2Gi",
+			},
+		},
+	}
+
+	output := expandPodResourceRequirements(input)
+	if output == nil {
+		t.Fatal("Expected non-nil output")
+	}
+	if output.Limits.Memory().String() != "4Gi" {
+		t.Fatalf("Expected Limits[memory]=4Gi, got %q", output.Limits.Memory().String())
+	}
+	if output.Requests.Memory().String() != "2Gi" {
+		t.Fatalf("Expected Requests[memory]=2Gi, got %q", output.Requests.Memory().String())
+	}
+}


### PR DESCRIPTION
### Description

Adds a `resources` field to the pod spec schema, allowing configuration of compute resources at the pod level (in addition to the container level). This supports the Kubernetes `PodLevelResources` feature gate.

- Added `resources` field to `podSpecFields` schema
- Added `flattenPodResourceRequirements` function  
- Added `expandPodResourceRequirements` function
- Wired into `flattenPodSpec` and `expandPodSpec`
- Added unit tests

### Release Note
```release-note:enhancement
resource/kubernetes_pod, resource/kubernetes_deployment, resource/kubernetes_stateful_set, resource/kubernetes_daemon_set: Add `resources` field at pod spec level (PodLevelResources)
```

### References
Closes #2852