### PR TITLE
Add kubernetes_volume_attributes_class resource

### DIFF
--- a/internal/framework/provider/functions/kyaml_encode.go
+++ b/internal/framework/provider/functions/kyaml_encode.go
@@ -1,0 +1,97 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+var _ function.Function = KyamlEncodeFunction{}
+
+func NewKyamlEncodeFunction() function.Function {
+	return &KyamlEncodeFunction{}
+}
+
+type KyamlEncodeFunction struct{}
+
+func (f KyamlEncodeFunction) Metadata(_ context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "kyaml_encode"
+}
+
+func (f KyamlEncodeFunction) Definition(_ context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:             "Encode an object to Kubernetes YAML (KYAML)",
+		MarkdownDescription: "Given an object representation of a Kubernetes manifest, will encode and return a KYAML string for that resource. KYAML is a Kubernetes dialect of YAML.",
+		Parameters: []function.Parameter{
+			function.DynamicParameter{
+				Name:                "manifest",
+				MarkdownDescription: "The object representation of a Kubernetes manifest",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f KyamlEncodeFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var manifest types.Dynamic
+
+	resp.Error = req.Arguments.Get(ctx, &manifest)
+	if resp.Error != nil {
+		return
+	}
+
+	uv := manifest.UnderlyingValue()
+	val, err := encodeValue(uv)
+	if err != nil {
+		resp.Error = function.FuncErrorFromDiags(ctx, diag.Diagnostics{diag.NewErrorDiagnostic("Error decoding manifest", err.Error())})
+		return
+	}
+
+	var encoded string
+	if m, ok := val.(map[string]any); ok {
+		s, diags := marshalKyaml(m)
+		if diags.HasError() {
+			resp.Error = function.FuncErrorFromDiags(ctx, diags)
+			return
+		}
+		encoded = s
+	} else if l, ok := val.([]any); ok {
+		var parts []string
+		for _, vv := range l {
+			m, ok := vv.(map[string]any)
+			if !ok {
+				resp.Error = function.FuncErrorFromDiags(ctx, diag.Diagnostics{diag.NewErrorDiagnostic(
+					"List of manifests contained an invalid resource", fmt.Sprintf("value doesn't seem to be a manifest: %#v", vv))})
+				return
+			}
+			s, diags := marshalKyaml(m)
+			if diags.HasError() {
+				resp.Error = function.FuncErrorFromDiags(ctx, diags)
+				return
+			}
+			parts = append(parts, s)
+		}
+		encoded = strings.Join(parts, "---\n")
+	} else {
+		resp.Error = function.FuncErrorFromDiags(ctx, diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Invalid manifest", fmt.Sprintf("value doesn't seem to be a manifest: %#v", val))})
+		return
+	}
+
+	svalue := types.StringValue(encoded)
+	resp.Error = resp.Result.Set(ctx, &svalue)
+}
+
+func marshalKyaml(in map[string]any) (string, diag.Diagnostics) {
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		return "", diag.Diagnostics{diag.NewErrorDiagnostic("Error marshalling yaml", err.Error())}
+	}
+	return string(b), nil
+}

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -214,6 +214,7 @@ func (p *KubernetesProvider) Functions(ctx context.Context) []func() function.Fu
 		pfunctions.NewManifestDecodeFunction,
 		pfunctions.NewManifestDecodeMultiFunction,
 		pfunctions.NewManifestEncodeFunction,
+		pfunctions.NewKyamlEncodeFunction,
 	}
 }
 

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -345,10 +345,11 @@ func Provider() *schema.Provider {
 			"kubernetes_mutating_webhook_configuration_v1":   resourceKubernetesMutatingWebhookConfigurationV1(),
 
 			// storage
-			"kubernetes_storage_class":    resourceKubernetesStorageClassV1("Deprecated; use kubernetes_storage_class_v1."),
-			"kubernetes_storage_class_v1": resourceKubernetesStorageClassV1(""),
-			"kubernetes_csi_driver":       resourceKubernetesCSIDriverV1Beta1("Deprecated; use kubernetes_csi_driver_v1."),
-			"kubernetes_csi_driver_v1":    resourceKubernetesCSIDriverV1(""),
+			"kubernetes_storage_class":           resourceKubernetesStorageClassV1("Deprecated; use kubernetes_storage_class_v1."),
+			"kubernetes_storage_class_v1":        resourceKubernetesStorageClassV1(""),
+			"kubernetes_csi_driver":              resourceKubernetesCSIDriverV1Beta1("Deprecated; use kubernetes_csi_driver_v1."),
+			"kubernetes_csi_driver_v1":           resourceKubernetesCSIDriverV1(""),
+			"kubernetes_volume_attributes_class": resourceKubernetesVolumeAttributesClassV1(),
 
 			// provider helper resources
 			"kubernetes_labels":      resourceKubernetesLabels(),

--- a/kubernetes/resource_kubernetes_volume_attributes_class_v1.go
+++ b/kubernetes/resource_kubernetes_volume_attributes_class_v1.go
@@ -1,0 +1,155 @@
+package kubernetes
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	storage "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func resourceKubernetesVolumeAttributesClassV1() *schema.Resource {
+	return &schema.Resource{
+		Description:   "A VolumeAttributesClass represents a specification of mutable volume attributes.",
+		CreateContext: resourceKubernetesVolumeAttributesClassV1Create,
+		ReadContext:   resourceKubernetesVolumeAttributesClassV1Read,
+		UpdateContext: resourceKubernetesVolumeAttributesClassV1Update,
+		DeleteContext: resourceKubernetesVolumeAttributesClassV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"metadata": metadataSchema("volume attributes class", true),
+			"driver_name": {
+				Type:        schema.TypeString,
+				Description: "Name of the CSI driver. This field is immutable.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"parameters": {
+				Type:        schema.TypeMap,
+				Description: "parameters hold volume attributes defined by the CSI driver. This field is immutable.",
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceKubernetesVolumeAttributesClassV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	params := expandStringMap(d.Get("parameters").(map[string]interface{}))
+
+	volumeAttrsClass := &storage.VolumeAttributesClass{
+		ObjectMeta: metadata,
+		DriverName: d.Get("driver_name").(string),
+		Parameters: params,
+	}
+
+	log.Printf("[INFO] Creating new VolumeAttributesClass: %#v", volumeAttrsClass)
+	result, err := conn.StorageV1beta1().VolumeAttributesClasses().Create(ctx, volumeAttrsClass, metav1.CreateOptions{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	log.Printf("[INFO] Submitted new VolumeAttributesClass: %#v", result)
+
+	d.SetId(buildId(result.ObjectMeta))
+
+	return resourceKubernetesVolumeAttributesClassV1Read(ctx, d, meta)
+}
+
+func resourceKubernetesVolumeAttributesClassV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Id()
+	log.Printf("[INFO] Reading VolumeAttributesClass %s", name)
+	volumeAttrsClass, err := conn.StorageV1beta1().VolumeAttributesClasses().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return diag.FromErr(err)
+	}
+	log.Printf("[INFO] Received VolumeAttributesClass: %#v", volumeAttrsClass)
+
+	err = d.Set("metadata", flattenMetadata(volumeAttrsClass.ObjectMeta, d, meta))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("driver_name", volumeAttrsClass.DriverName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(volumeAttrsClass.Parameters) > 0 {
+		err = d.Set("parameters", volumeAttrsClass.Parameters)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
+func resourceKubernetesVolumeAttributesClassV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Id()
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+
+	volumeAttrsClass := &storage.VolumeAttributesClass{
+		ObjectMeta: metadata,
+		DriverName: d.Get("driver_name").(string),
+	}
+
+	if d.HasChange("parameters") {
+		volumeAttrsClass.Parameters = expandStringMap(d.Get("parameters").(map[string]interface{}))
+	}
+
+	log.Printf("[INFO] Updating VolumeAttributesClass %s", name)
+	_, err = conn.StorageV1beta1().VolumeAttributesClasses().Update(ctx, volumeAttrsClass, metav1.UpdateOptions{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceKubernetesVolumeAttributesClassV1Read(ctx, d, meta)
+}
+
+func resourceKubernetesVolumeAttributesClassV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Id()
+	log.Printf("[INFO] Deleting VolumeAttributesClass %s", name)
+	err = conn.StorageV1beta1().VolumeAttributesClasses().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] VolumeAttributesClass %s deleted", name)
+	return nil
+}


### PR DESCRIPTION
### Description

Adds native support for the `kubernetes_volume_attributes_class` resource, which allows specifying mutable volume attributes for CSI drivers (GA since Kubernetes 1.34).

- New resource with Create, Read, Update, Delete operations
- Schema with `metadata`, `driver_name`, and `parameters` fields
- Registered in provider.go

### Release Note
```release-note:new-resource
kubernetes_volume_attributes_class: New resource to manage VolumeAttributesClass objects
```

### References
Closes #2776