### PR TITLE
feat: use the standard Terraform User-Agent for Kubernetes API requests

### DIFF
--- a/.changelog/2912.txt
+++ b/.changelog/2912.txt
@@ -1,0 +1,11 @@
+```release-note:improvement
+provider: Send the standard Terraform User-Agent to the Kubernetes API server, including the Terraform version, plugin SDK version, provider version, and any value set in `TF_APPEND_USER_AGENT`, which was previously ignored
+```
+
+```release-note:bug
+`resource/kubernetes_manifest`, `data_source/kubernetes_resource`, `data_source/kubernetes_resources`: Identify the provider in requests to the Kubernetes API server. These sent either `Go-http-client/1.1` or the `client-go` library default, neither of which names Terraform or the provider version
+```
+
+```release-note:bug
+provider: Report the real provider version in release builds; the `-X main.Version` linker flag was silently ignored because `Version` was declared as a constant
+```

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package useragent builds the User-Agent header the provider sends to the
+// Kubernetes API server.
+package useragent
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ProviderName is the reporting name of this provider, as it appears in the
+// User-Agent header.
+const ProviderName = "terraform-provider-kubernetes"
+
+// ProviderVersion is the provider version reported in the User-Agent header.
+// It defaults to "dev" and is set by main to the version stamped into the
+// binary at build time.
+var ProviderVersion = "dev"
+
+// Build returns the standard Terraform User-Agent string for the given
+// Terraform version, in the form:
+//
+//	Terraform/<tf-version> (+https://www.terraform.io) Terraform-Plugin-SDK/<sdk-version> terraform-provider-kubernetes/<provider-version>
+//
+// If TF_APPEND_USER_AGENT is set, its value is appended to the result.
+func Build(terraformVersion string) string {
+	// The generated string is owned by the plugin SDK so that this provider
+	// reports the same format, and honours the same environment variables, as
+	// every other Terraform provider. UserAgent only reads TerraformVersion
+	// off the Provider, so a bare Provider is enough to call it -- this lets
+	// the manifest provider, which is not built on the SDK, report the same
+	// User-Agent as the SDKv2 provider.
+	p := &schema.Provider{TerraformVersion: terraformVersion}
+	return p.UserAgent(ProviderName, ProviderVersion)
+}

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package useragent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
+)
+
+func TestBuild(t *testing.T) {
+	//nolint:staticcheck // matches the deprecated call the SDK itself makes
+	sdkVersion := meta.SDKVersionString()
+
+	cases := map[string]struct {
+		terraformVersion string
+		appendUserAgent  string
+		expected         string
+	}{
+		"standard": {
+			terraformVersion: "1.9.5",
+			expected: fmt.Sprintf(
+				"Terraform/1.9.5 (+https://www.terraform.io) Terraform-Plugin-SDK/%s terraform-provider-kubernetes/dev",
+				sdkVersion),
+		},
+		"appended": {
+			terraformVersion: "1.9.5",
+			appendUserAgent:  "MyCompany/1.2.3",
+			expected: fmt.Sprintf(
+				"Terraform/1.9.5 (+https://www.terraform.io) Terraform-Plugin-SDK/%s terraform-provider-kubernetes/dev MyCompany/1.2.3",
+				sdkVersion),
+		},
+		"appended value is trimmed": {
+			terraformVersion: "1.9.5",
+			appendUserAgent:  "  MyCompany/1.2.3\n",
+			expected: fmt.Sprintf(
+				"Terraform/1.9.5 (+https://www.terraform.io) Terraform-Plugin-SDK/%s terraform-provider-kubernetes/dev MyCompany/1.2.3",
+				sdkVersion),
+		},
+		"unknown terraform version": {
+			terraformVersion: "",
+			expected: fmt.Sprintf(
+				"Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/%s terraform-provider-kubernetes/dev",
+				sdkVersion),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TF_APPEND_USER_AGENT", tc.appendUserAgent)
+
+			got := Build(tc.terraformVersion)
+			if got != tc.expected {
+				t.Fatalf("unexpected User-Agent\n got: %q\nwant: %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildReportsProviderVersion(t *testing.T) {
+	original := ProviderVersion
+	t.Cleanup(func() { ProviderVersion = original })
+
+	ProviderVersion = "3.2.1"
+
+	got := Build("1.9.5")
+	if want := "terraform-provider-kubernetes/3.2.1"; !strings.HasSuffix(got, want) {
+		t.Fatalf("User-Agent %q does not end with %q", got, want)
+	}
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/useragent"
+
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -467,7 +469,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		cfg = &restclient.Config{}
 	}
 
-	cfg.UserAgent = fmt.Sprintf("HashiCorp/1.0 Terraform/%s", terraformVersion)
+	cfg.UserAgent = useragent.Build(terraformVersion)
 
 	if logging.IsDebugOrHigher() {
 		log.Printf("[DEBUG] Enabling HTTP requests/responses tracing")

--- a/kubernetes/provider_useragent_test.go
+++ b/kubernetes/provider_useragent_test.go
@@ -1,0 +1,74 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/useragent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestProviderConfigureUserAgent asserts that the client the SDKv2 provider
+// configures identifies itself to the API server, and that TF_APPEND_USER_AGENT
+// reaches the wire.
+func TestProviderConfigureUserAgent(t *testing.T) {
+	cases := map[string]string{
+		"without TF_APPEND_USER_AGENT": "",
+		"with TF_APPEND_USER_AGENT":    "AcmeCorp/9.9.9",
+	}
+
+	for name, appendUA := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("KUBE_CONFIG_PATH", "")
+			t.Setenv("KUBE_CONFIG_PATHS", "")
+			t.Setenv("TF_APPEND_USER_AGENT", appendUA)
+
+			var mu sync.Mutex
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				got = r.Header.Get("User-Agent")
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"default"}}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			d := schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
+				"host": srv.URL,
+			})
+			meta, diags := providerConfigure(context.Background(), d, "1.9.5")
+			if diags.HasError() {
+				t.Fatalf("providerConfigure: %+v", diags)
+			}
+
+			clientset, err := meta.(providerMetadata).MainClientset()
+			if err != nil {
+				t.Fatalf("clientset: %v", err)
+			}
+			if _, err := clientset.CoreV1().Namespaces().Get(context.Background(), "default", metav1.GetOptions{}); err != nil {
+				t.Fatalf("namespace get: %v", err)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if !strings.HasPrefix(got, "Terraform/1.9.5 ") {
+				t.Errorf("unidentified User-Agent %q", got)
+			}
+			if want := "terraform-provider-kubernetes/" + useragent.ProviderVersion; !strings.Contains(got, want) {
+				t.Errorf("User-Agent %q does not contain %q", got, want)
+			}
+			if appendUA != "" && !strings.HasSuffix(got, appendUA) {
+				t.Errorf("User-Agent %q did not append TF_APPEND_USER_AGENT", got)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,13 +17,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 	"github.com/hashicorp/terraform-provider-kubernetes/internal/mux"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/useragent"
 )
 
-const (
-	providerName = "registry.terraform.io/hashicorp/kubernetes"
+const providerName = "registry.terraform.io/hashicorp/kubernetes"
 
-	Version = "dev"
-)
+// Version is the provider version. Release builds overwrite it with
+// -ldflags "-X 'main.Version=<version>'", which only works on a variable, so
+// this must not become a constant.
+var Version = "dev"
 
 // Generate docs for website
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
@@ -31,6 +33,8 @@ const (
 func main() {
 	debugFlag := flag.Bool("debug", false, "Start provider in stand-alone debug mode.")
 	flag.Parse()
+
+	useragent.ProviderVersion = Version
 
 	ctx := context.Background()
 	muxer, err := mux.MuxServer(ctx, Version)

--- a/manifest/provider/configure.go
+++ b/manifest/provider/configure.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/useragent"
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -586,6 +587,8 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 		})
 		return response, nil
 	}
+
+	clientConfig.UserAgent = useragent.Build(req.TerraformVersion)
 
 	if s.logger.IsTrace() {
 		clientConfig.WrapTransport = loggingTransport

--- a/manifest/provider/configure_useragent_test.go
+++ b/manifest/provider/configure_useragent_test.go
@@ -1,0 +1,172 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/useragent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type recordedRequest struct {
+	path      string
+	userAgent string
+}
+
+// TestConfigureProviderUserAgent asserts that every client the manifest provider
+// builds sends the provider's User-Agent. The clients default differently when
+// rest.Config.UserAgent is left empty -- the raw REST client sends Go's
+// "Go-http-client/1.1", while the dynamic and discovery clients substitute the
+// client-go default -- so each flavour is checked against the wire rather than
+// trusting that one assignment covers them all.
+func TestConfigureProviderUserAgent(t *testing.T) {
+	cases := map[string]string{
+		"without TF_APPEND_USER_AGENT": "",
+		"with TF_APPEND_USER_AGENT":    "AcmeCorp/9.9.9",
+	}
+
+	for name, appendUA := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("KUBE_CONFIG_PATH", "")
+			t.Setenv("KUBE_CONFIG_PATHS", "")
+			t.Setenv("TF_APPEND_USER_AGENT", appendUA)
+
+			srv, recorded := fakeClusterServer(t)
+			s := configureProviderAgainst(t, srv.URL)
+
+			// Raw REST client: used for the OpenAPI spec fetch and the
+			// credential check.
+			restClient, err := s.getRestClient()
+			if err != nil {
+				t.Fatalf("rest client: %v", err)
+			}
+			if res := restClient.Get().AbsPath("/apis").Do(context.Background()); res.Error() != nil {
+				t.Fatalf("rest client request: %v", res.Error())
+			}
+
+			// Discovery client: used to build the RESTMapper.
+			discoveryClient, err := s.getDiscoveryClient()
+			if err != nil {
+				t.Fatalf("discovery client: %v", err)
+			}
+			if _, err := discoveryClient.ServerVersion(); err != nil {
+				t.Fatalf("discovery client request: %v", err)
+			}
+
+			// Dynamic client: what kubernetes_manifest does CRUD with.
+			dynamicClient, err := s.getDynamicClient()
+			if err != nil {
+				t.Fatalf("dynamic client: %v", err)
+			}
+			gvr := schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+			if _, err := dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{}); err != nil {
+				t.Fatalf("dynamic client request: %v", err)
+			}
+
+			reqs := recorded()
+			if len(reqs) != 3 {
+				t.Fatalf("expected one request per client, recorded %d: %+v", len(reqs), reqs)
+			}
+
+			wantProvider := "terraform-provider-kubernetes/" + useragent.ProviderVersion
+			for _, r := range reqs {
+				if !strings.HasPrefix(r.userAgent, "Terraform/1.9.5 ") {
+					t.Errorf("request to %s sent unidentified User-Agent %q", r.path, r.userAgent)
+				}
+				if !strings.Contains(r.userAgent, wantProvider) {
+					t.Errorf("request to %s omitted %q: %q", r.path, wantProvider, r.userAgent)
+				}
+				if appendUA != "" && !strings.HasSuffix(r.userAgent, appendUA) {
+					t.Errorf("request to %s did not append TF_APPEND_USER_AGENT: %q", r.path, r.userAgent)
+				}
+			}
+		})
+	}
+}
+
+// configureProviderAgainst runs the real ConfigureProvider RPC with every
+// attribute null except host, as Terraform would for
+// `provider "kubernetes" { host = ... }`.
+func configureProviderAgainst(t *testing.T, host string) *RawProviderServer {
+	t.Helper()
+
+	cfgType := GetObjectTypeFromSchema(GetProviderConfigSchema())
+	attrTypes := cfgType.(tftypes.Object).AttributeTypes
+
+	vals := make(map[string]tftypes.Value, len(attrTypes))
+	for name, ty := range attrTypes {
+		vals[name] = tftypes.NewValue(ty, nil)
+	}
+	vals["host"] = tftypes.NewValue(tftypes.String, host)
+
+	cfg, err := tfprotov5.NewDynamicValue(cfgType, tftypes.NewValue(cfgType, vals))
+	if err != nil {
+		t.Fatalf("encoding provider config: %v", err)
+	}
+
+	s := &RawProviderServer{logger: hclog.NewNullLogger()}
+	resp, err := s.ConfigureProvider(context.Background(), &tfprotov5.ConfigureProviderRequest{
+		TerraformVersion: "1.9.5",
+		Config:           &cfg,
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider: %v", err)
+	}
+	for _, d := range resp.Diagnostics {
+		if d.Severity == tfprotov5.DiagnosticSeverityError {
+			t.Fatalf("ConfigureProvider diagnostic: %s: %s", d.Summary, d.Detail)
+		}
+	}
+	if s.clientConfig == nil {
+		t.Fatal("ConfigureProvider produced no client config")
+	}
+	return s
+}
+
+// fakeClusterServer serves just enough of the Kubernetes API for client-go to
+// build clients and issue one request each, recording the User-Agent of every
+// request it receives.
+func fakeClusterServer(t *testing.T) (*httptest.Server, func() []recordedRequest) {
+	t.Helper()
+
+	responses := map[string]string{
+		"/version":           `{"major":"1","minor":"33","gitVersion":"v1.33.0"}`,
+		"/api":               `{"kind":"APIVersions","versions":["v1"]}`,
+		"/apis":              `{"kind":"APIGroupList","apiVersion":"v1","groups":[]}`,
+		"/api/v1/namespaces": `{"kind":"NamespaceList","apiVersion":"v1","metadata":{"resourceVersion":"1"},"items":[]}`,
+	}
+
+	var mu sync.Mutex
+	var recorded []recordedRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		recorded = append(recorded, recordedRequest{path: r.URL.Path, userAgent: r.Header.Get("User-Agent")})
+		mu.Unlock()
+
+		body, ok := responses[r.URL.Path]
+		if !ok {
+			body = "{}"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, func() []recordedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]recordedRequest(nil), recorded...)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-kubernetes/issues/2951 and https://github.com/hashicorp/terraform-provider-kubernetes/issues/2952

## Description

The provider built its `User-Agent` by hand instead of using the plugin SDK helper intended for it, and the manifest provider did not set one at all.

`kubernetes/provider.go` sent `HashiCorp/1.0 Terraform/<version>`, which ignores `TF_APPEND_USER_AGENT` and reports neither the provider version nor the plugin SDK version. `manifest/provider/configure.go` never assigned `UserAgent` on the `rest.Config` it builds, so its requests fell back to whatever each client constructor happens to default to — and those differ.

This adds `internal/useragent`, which delegates to `(*schema.Provider).UserAgent` so both configure paths emit the same standard string, and applies it to both `rest.Config`s. All three manifest clients (raw REST, discovery, dynamic) derive from the one config, so a single assignment covers them.

## Measured behaviour

Captured by driving each provider's real configure path against a stub API server that records request headers.

**Before:**

```
SDKv2    GET /api/v1/namespaces/default    HashiCorp/1.0 Terraform/1.9.5
SDKv2    (TF_APPEND_USER_AGENT set)        HashiCorp/1.0 Terraform/1.9.5      <- byte-identical; ignored
manifest GET /apis            (raw REST)   Go-http-client/1.1
manifest GET /version        (discovery)   provider.test/v0.0.0 (darwin/arm64) kubernetes/$Format
manifest GET /api/v1/namespaces (dynamic)  provider.test/v0.0.0 (darwin/arm64) kubernetes/$Format
```

The raw REST client — used for the `/openapi/v2` fetch and the credential check — sent no `User-Agent` at all: `rest.UnversionedRESTClientFor` does not apply `rest.DefaultKubernetesUserAgent()`, and `transport.HTTPWrappersForConfig` only sets the header when the field is non-empty, so Go's `net/http` supplied its own. The discovery and dynamic clients substituted the client-go library default, whose version and commit fields are unset when client-go is consumed as a library (hence `v0.0.0` and the literal `$Format`) and whose leading token is just `os.Args[0]`.

**After** — every request from every path:

```
Terraform/1.9.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.38.2 terraform-provider-kubernetes/3.2.1
```

and with `TF_APPEND_USER_AGENT=AcmeCorp/9.9.9`:

```
Terraform/1.9.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.38.2 terraform-provider-kubernetes/3.2.1 AcmeCorp/9.9.9
```

## Also fixed: the provider version never reached release binaries

`.github/workflows/build.yml` sets the version with `-ldflags "-X 'main.Version=<version>'"`, but `main.Version` was declared as a `const`. `-X` only patches string *variables*, so the flag was silently ignored and released binaries reported `dev`. It is now a `var`, with a comment saying why it must stay one. This also means `resp.Version` from the framework provider starts reporting the real version.

## Design note

The helper returns the SDK's string verbatim rather than combining it with `rest.DefaultKubernetesUserAgent()`. `rest.AddUserAgent` slash-joins the two, which produces `kubernetes/$Format/Terraform/1.9.5 …` — the `Terraform/` prefix ends up buried mid-string, defeating server-side matching, and of the four fields the client-go default contributes, two are unset placeholders and one duplicates the provider version. `TF_APPEND_USER_AGENT` remains the escape hatch for anyone wanting extra tokens, and it must stay last.

## Backwards compatibility

This changes a header value. Any server-side rule matching the literal `HashiCorp/1.0` prefix — audit filters, FlowSchemas, WAF rules, log dashboards — needs updating. Nothing in Terraform or the provider consumes the header, so there is no functional break. Called out in the changelog.

## Testing

- `internal/useragent/useragent_test.go` — pins the exact string; covers `TF_APPEND_USER_AGENT` including whitespace trimming, empty Terraform version, and provider-version reporting.
- `kubernetes/provider_useragent_test.go` — configures the SDKv2 provider against an `httptest` server and asserts the header on the wire.
- `manifest/provider/configure_useragent_test.go` — drives the real `ConfigureProvider` RPC, then asserts the header for each of the three client flavours separately, since they default differently when `UserAgent` is empty. This is the shape of the original defect: one missing assignment, three clients.

Both wire tests were confirmed to fail on `main` with the exact strings listed above, and to pass with this change. `go vet ./...` and `gofmt` are clean and the unit suite is green. No acceptance tests were run — nothing here was exercised against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
