### PR TITLE
manifest: don't format the full resource schema on GET failure

### DIFF
--- a/.changelog/2957.txt
+++ b/.changelog/2957.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_manifest`: fix `ReadResource` diagnostic constructing an unbounded (~100KB for large CRD schemas) formatted dump of the resource's type on every failed GET, via a helper meant only for lazy hclog logging; this could produce an unreadable diagnostic and, in some cases, empty diagnostics
+```

--- a/manifest/provider/read.go
+++ b/manifest/provider/read.go
@@ -163,7 +163,7 @@ func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Rea
 		}
 		d := tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
-			Summary:  fmt.Sprintf("Cannot GET resource %s", dump(co)),
+			Summary:  "Cannot GET resource",
 			Detail:   err.Error(),
 		}
 		resp.Diagnostics = append(resp.Diagnostics, &d)


### PR DESCRIPTION
## What

`ReadResource`'s error path builds its diagnostic `Summary` with:

```go
Summary: fmt.Sprintf("Cannot GET resource %s", dump(co)),
```

`dump()` returns an `hclog.Format` (`[]interface{}{"%v", v}`), a type `hclog`'s own logger methods (`Trace`/`Debug`/`Error`) special-case for lazy formatting. Passed to plain `fmt.Sprintf` instead, nothing recognizes it, so Go just prints the underlying slice — literally the two characters `%v` followed by `co`'s default `String()` — producing a `Summary` like:

```
Cannot GET resource [%v tftypes.Object[...]]
```

That alone is a readability bug. But `co` here is the *entire* OpenAPI-derived `tftypes.Value` type for the resource — for a CRD with a large schema (e.g. `external-secrets.io` `SecretStore`, whose `spec.provider` unions dozens of backend variants: aws, vault, gcp, azure, akeyless, ibm, doppler, onepassword, yandex...), formatting it via `%v` recurses through the entire nested `Object`/`Map`/`List` type tree and produces on the order of **100KB of text**, unconditionally, on every failed GET.

## Why this is more than cosmetic

In a real failure I was investigating (a `terraform plan` against a live cluster, `SecretStore` refresh failing under a restricted-permission identity), the plan log shows repeated:

```
provider.stdio: received EOF, stopping recv loop:
err="rpc error: code = Unavailable desc = error reading from server: EOF"
```

— i.e. Terraform core detecting the provider subprocess's stdio pipe close unexpectedly, 14 times in one run. That's consistent with the process dying (OOM or similar) while building this diagnostic, before it can send anything back. It would explain why the resulting diagnostic rendered as a genuinely *empty* error block (no Summary, no Detail) rather than merely an ugly one: the RPC never completed, so `err.Error()` in `Detail` never reached the user either — even though it was already being populated correctly.

A second, working `kubernetes_manifest.secret_store` instance in the same plan (identical resource type, identical provider version, different cluster) never hit this: its GET succeeded, so it never reached this branch, never called `dump(co)`, and refreshed cleanly. That asymmetry is fully explained by this code path rather than anything specific to the provider version or the object's content.

## Fix

`Detail` already carries `err.Error()`. `Summary` doesn't need to duplicate the resource's entire type — drop the `dump(co)` call so this path does a cheap, bounded diagnostic construction, and `Detail`'s real error text (the actually load-bearing information) gets a chance to reach the user instead of the process potentially dying first.

## Testing

- Reproduced the formatting bug standalone (outside this repo) with a byte-for-byte match to the observed `[%v ...]` output, confirming the mechanism: `hclog.Format` passed to `fmt.Sprintf` prints as a raw `[]interface{}` slice.
- `gofmt -l` clean, `go vet ./manifest/...` clean, existing `go test ./manifest/provider/...` passes.
- Diff against current `main` is a single line; no new test added — the existing suite has no mock-client scaffolding for `ReadResource`'s error path, and none of the ~30 other diagnostic literals in this file are unit-tested either, so a dedicated test here would be disproportionate to the fix.

Happy to add a changelog fragment once this has a PR number, and to expand the fix (e.g. include a short resource identifier in `Summary`) if maintainers would prefer that over the bare static string.