### PR TITLE
Plugin Framework Migration - config_map datasource

### DIFF
--- a/.changelog/2961.txt
+++ b/.changelog/2961.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`data-source/kubernetes_config_map_v1`: Migrated from SDKv2 to the Plugin Framework
+```

--- a/internal/framework/provider/corev1/corev1_test.go
+++ b/internal/framework/provider/corev1/corev1_test.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1_test
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/mux"
+)
+
+var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"kubernetes": func() (tfprotov6.ProviderServer, error) {
+		return mux.MuxServer(context.Background(), "test")
+	},
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var (
+	_ datasource.DataSource              = (*ConfigMapV1DataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*ConfigMapV1DataSource)(nil)
+)
+
+type ConfigMapV1DataSource struct {
+	SDKv2Meta func() any
+}
+
+func NewConfigMapV1DataSource() datasource.DataSource {
+	return &ConfigMapV1DataSource{}
+}
+
+func (d *ConfigMapV1DataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_config_map_v1"
+}
+
+func (d *ConfigMapV1DataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.SDKv2Meta = req.ProviderData.(func() any)
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1_helpers.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_helpers.go
@@ -6,7 +6,6 @@ package corev1
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -65,7 +64,7 @@ func typedStringMapToAttrMap(ctx context.Context, m map[string]types.String) (ty
 	}
 	elems := make(map[string]attr.Value, len(m))
 	for k, v := range m {
-		elems[k] = types.StringValue(fmt.Sprintf("%s", v.ValueString()))
+		elems[k] = types.StringValue(v.ValueString())
 	}
 	return types.MapValue(types.StringType, elems)
 }

--- a/internal/framework/provider/corev1/data_source_config_map_v1_helpers.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_helpers.go
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func expandStringMap(m map[string]types.String) map[string]string {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		if !v.IsNull() && !v.IsUnknown() {
+			result[k] = v.ValueString()
+		}
+	}
+	return result
+}
+
+func flattenStringMap(m map[string]string) map[string]types.String {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]types.String, len(m))
+	for k, v := range m {
+		result[k] = types.StringValue(v)
+	}
+	return result
+}
+
+func flattenByteMapToBase64Map(m map[string][]byte) map[string]types.String {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]types.String, len(m))
+	for k, v := range m {
+		result[k] = types.StringValue(base64.StdEncoding.EncodeToString(v))
+	}
+	return result
+}
+
+func stringMapToAttrMap(ctx context.Context, m map[string]string) (types.Map, diag.Diagnostics) {
+	if len(m) == 0 {
+		return types.MapValueMust(types.StringType, map[string]attr.Value{}), nil
+	}
+	elems := make(map[string]attr.Value, len(m))
+	for k, v := range m {
+		elems[k] = types.StringValue(v)
+	}
+	return types.MapValue(types.StringType, elems)
+}
+
+func typedStringMapToAttrMap(ctx context.Context, m map[string]types.String) (types.Map, diag.Diagnostics) {
+	if len(m) == 0 {
+		return types.MapValueMust(types.StringType, map[string]attr.Value{}), nil
+	}
+	elems := make(map[string]attr.Value, len(m))
+	for k, v := range m {
+		elems[k] = types.StringValue(fmt.Sprintf("%s", v.ValueString()))
+	}
+	return types.MapValue(types.StringType, elems)
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1_migration_test.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_migration_test.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccKubernetesDataSourceConfigMapV1_migration proves that a user who had
+// data "kubernetes_config_map_v1" written against the SDKv2 provider can upgrade
+// to the Framework provider without changing a single line of their HCL config.
+//
+// Step 1: applies with the released SDKv2 hashicorp/kubernetes provider.
+// Step 2: applies the IDENTICAL config with the local Framework provider — plan must be empty.
+func TestAccKubernetesDataSourceConfigMapV1_migration(t *testing.T) {
+	dataSourceName := "data.kubernetes_config_map_v1.test"
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				// Step 1: apply with the released SDKv2 provider (last major series).
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"kubernetes": {
+						Source:            "hashicorp/kubernetes",
+						VersionConstraint: "~> 2.0",
+					},
+				},
+				Config: testAccKubernetesDataSourceConfigMapV1_migrationConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "data.one", "first"),
+				),
+			},
+			{
+				// Step 2: same HCL config, now served by the local Framework provider.
+				// The plan must be empty — proving the transition is fully transparent.
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Config:                   testAccKubernetesDataSourceConfigMapV1_migrationConfig(name),
+				ExpectNonEmptyPlan:       false,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "data.one", "first"),
+				),
+			},
+		},
+	})
+}
+
+// testAccKubernetesDataSourceConfigMapV1_migrationConfig returns the combined resource +
+// data source HCL used in both steps of the migration test. The config is byte-for-byte
+// identical between the SDKv2 step and the Framework step.
+func testAccKubernetesDataSourceConfigMapV1_migrationConfig(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_config_map_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data = {
+    one = "first"
+  }
+}
+
+data "kubernetes_config_map_v1" "test" {
+  metadata {
+    name = kubernetes_config_map_v1.test.metadata.0.name
+  }
+}
+`, name)
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1_model.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_model.go
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ConfigMapV1Model struct {
+	Metadata   []ConfigMapMetadataModel `tfsdk:"metadata"`
+	Data       types.Map                `tfsdk:"data"`
+	BinaryData types.Map                `tfsdk:"binary_data"`
+	Immutable  types.Bool               `tfsdk:"immutable"`
+}
+
+type ConfigMapMetadataModel struct {
+	Name            types.String            `tfsdk:"name"`
+	Namespace       types.String            `tfsdk:"namespace"`
+	Annotations     map[string]types.String `tfsdk:"annotations"`
+	Labels          map[string]types.String `tfsdk:"labels"`
+	ResourceVersion types.String            `tfsdk:"resource_version"`
+	UID             types.String            `tfsdk:"uid"`
+	Generation      types.Int64             `tfsdk:"generation"`
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1_read.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_read.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-kubernetes/kubernetes"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (d *ConfigMapV1DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var model ConfigMapV1Model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(model.Metadata) == 0 {
+		return
+	}
+
+	name := model.Metadata[0].Name.ValueString()
+	namespace := model.Metadata[0].Namespace.ValueString()
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	conn, err := d.SDKv2Meta().(kubernetes.KubeClientsets).MainClientset()
+	if err != nil {
+		resp.Diagnostics.AddError("kubernetes client error", err.Error())
+		return
+	}
+
+	log.Printf("[INFO] Reading config map %s", name)
+	cfgMap, err := conn.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Printf("[DEBUG] Received error: %#v", err)
+			model.Data = types.MapValueMust(types.StringType, map[string]attr.Value{})
+			model.BinaryData = types.MapValueMust(types.StringType, map[string]attr.Value{})
+			resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+			return
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+		resp.Diagnostics.AddError(
+			"error reading ConfigMap",
+			err.Error(),
+		)
+		return
+	}
+	log.Printf("[INFO] Received config map: %#v", cfgMap)
+
+	// Populate server-set metadata fields
+	model.Metadata[0].UID = types.StringValue(string(cfgMap.UID))
+	model.Metadata[0].ResourceVersion = types.StringValue(cfgMap.ResourceVersion)
+	model.Metadata[0].Generation = types.Int64Value(cfgMap.Generation)
+
+	if len(cfgMap.Annotations) > 0 {
+		model.Metadata[0].Annotations = flattenStringMap(cfgMap.Annotations)
+	}
+	if len(cfgMap.Labels) > 0 {
+		model.Metadata[0].Labels = flattenStringMap(cfgMap.Labels)
+	}
+
+	// Populate data
+	dataMap, diags := stringMapToAttrMap(ctx, cfgMap.Data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	model.Data = dataMap
+
+	// Populate binary_data (base64-encoded)
+	b64Map := flattenByteMapToBase64Map(cfgMap.BinaryData)
+	binaryDataMap, diags := typedStringMapToAttrMap(ctx, b64Map)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	model.BinaryData = binaryDataMap
+
+	// Populate immutable — safely dereference *bool
+	immutable := false
+	if cfgMap.Immutable != nil {
+		immutable = *cfgMap.Immutable
+	}
+	model.Immutable = types.BoolValue(immutable)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1_schema.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_schema.go
@@ -1,0 +1,74 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package corev1
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (d *ConfigMapV1DataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Config Maps are key-value pairs containing configuration data. The Config Map data source provides a mechanism for extracting these key-value pairs.",
+		Blocks: map[string]schema.Block{
+			"metadata": schema.ListNestedBlock{
+				Description: "Standard config_map's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Name of the config_map, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+							Required:    true,
+						},
+						"namespace": schema.StringAttribute{
+							Description: "Namespace defines the space within which name of the config_map must be unique.",
+							Optional:    true,
+						},
+						"annotations": schema.MapAttribute{
+							Description: "An unstructured key value map stored with the config_map that may be used to store arbitrary metadata. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/",
+							ElementType: types.StringType,
+							Optional:    true,
+						},
+						"labels": schema.MapAttribute{
+							Description: "Map of string keys and values that can be used to organize and categorize (scope and select) the config_map. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+							ElementType: types.StringType,
+							Optional:    true,
+						},
+						"resource_version": schema.StringAttribute{
+							Description: "An opaque value that represents the internal version of this config_map that can be used by clients to determine when config_map has changed.",
+							Computed:    true,
+						},
+						"uid": schema.StringAttribute{
+							Description: "The unique in time and space value for this config_map. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+							Computed:    true,
+						},
+						"generation": schema.Int64Attribute{
+							Description: "A sequence number representing a specific generation of the desired state.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+		Attributes: map[string]schema.Attribute{
+			"data": schema.MapAttribute{
+				Description: "A map of the config map data.",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"binary_data": schema.MapAttribute{
+				Description: "A map of the config map binary data.",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"immutable": schema.BoolAttribute{
+				Description: "Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}

--- a/internal/framework/provider/corev1/data_source_config_map_v1_test.go
+++ b/internal/framework/provider/corev1/data_source_config_map_v1_test.go
@@ -1,17 +1,17 @@
 // Copyright IBM Corp. 2017, 2026
 // SPDX-License-Identifier: MPL-2.0
 
-package kubernetes
+package corev1_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccKubernetesDataSourceConfigMap_basic tests that the data source is able to read
+// TestAccKubernetesDataSourceConfigMapV1_basic tests that the data source is able to read
 // plaintext data, binary data, annotation, label, and name of the config map resource.
 func TestAccKubernetesDataSourceConfigMapV1_basic(t *testing.T) {
 	resourceName := "kubernetes_config_map_v1.test"
@@ -19,8 +19,7 @@ func TestAccKubernetesDataSourceConfigMapV1_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{ // First, create the resource. Data sources are evaluated before resources, and therefore need to be created in a second apply.
 				Config: testAccKubernetesDataSourceConfigMapV1_basic(name),
@@ -52,10 +51,9 @@ func TestAccKubernetesDataSourceConfigMapV1_not_found(t *testing.T) {
 	name := fmt.Sprintf("ceci-n.est-pas-une-config-map-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			{ // Use the data source to read the existing resource.
+			{
 				Config: testAccKubernetesDataSourceConfigMapV1_nonexistent(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "metadata.0.name", name),
@@ -66,8 +64,6 @@ func TestAccKubernetesDataSourceConfigMapV1_not_found(t *testing.T) {
 	})
 }
 
-// testAccKubernetesDataSourceConfigMapConfig_basic provides the terraform config
-// used to test basic functionality of the config_map data source.
 func testAccKubernetesDataSourceConfigMapV1_basic(name string) string {
 	return fmt.Sprintf(`resource "kubernetes_config_map_v1" "test" {
   metadata {

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/admissionregistrationv1"
 	"github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/authenticationv1"
 	"github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/certificatesv1"
+	"github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/corev1"
 	pfunctions "github.com/hashicorp/terraform-provider-kubernetes/internal/framework/provider/functions"
 )
 
@@ -199,7 +200,9 @@ func (p *KubernetesProvider) Resources(ctx context.Context) []func() resource.Re
 }
 
 func (p *KubernetesProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		corev1.NewConfigMapV1DataSource,
+	}
 }
 
 func (p *KubernetesProvider) EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -218,7 +218,6 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			// core
 			"kubernetes_config_map":                 dataSourceKubernetesConfigMapV1("Deprecated; use kubernetes_config_map_v1."),
-			"kubernetes_config_map_v1":              dataSourceKubernetesConfigMapV1(""),
 			"kubernetes_namespace":                  dataSourceKubernetesNamespaceV1("Deprecated; use kubernetes_namespace_v1."),
 			"kubernetes_namespace_v1":               dataSourceKubernetesNamespaceV1(""),
 			"kubernetes_all_namespaces":             dataSourceKubernetesAllNamespaces(),


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Migrates the <code>data.kubernetes_config_map_v1</code> data source from the Terraform Plugin SDK v2 to the Terraform Plugin Framework, using the existing mux architecture.</p>

<p><strong>No breaking changes for users.</strong></p>
<h2>Files Changed</h2>
<h3>New — <code>internal/framework/provider/corev1/</code></h3>
<div data-assistant-markdown-table="" data-assistant-table="" class="_wdUoQG_tableFrame"><div data-assistant-markdown-table-scroller="" class="_wdUoQG_tableScroller">


File - Purpose
data_source_config_map_v1.go	-Entry point. Defines the ConfigMapV1DataSource struct, registers the type name kubernetes_config_map_v1, and wires in the Kubernetes client via the SDKv2 meta bridge.

data_source_config_map_v1_model.go	-Typed Go structs with tfsdk: tags mapping directly to Terraform state fields: metadata, data, binary_data, and immutable.

data_source_config_map_v1_schema.go	-Framework schema declaration. Uses ListNestedBlock for metadata to preserve the existing metadata.0.* attribute paths.

data_source_config_map_v1_read.go	-Read logic. Fetches the ConfigMap from the Kubernetes API, handles not-found gracefully by returning empty data without an error, safely dereferences the nullable *bool immutable field, and base64-encodes binary data.

data_source_config_map_v1_helpers.go	-Type conversion utilities between Kubernetes API types and Framework types, including string maps and byte-to-base64 maps.

corev1_test.go	-Package-level test setup. Provides testAccProtoV6ProviderFactories using the full mux server so SDKv2 resources and Framework data sources are available in the same test.

data_source_config_map_v1_test.go	-Acceptance tests ported from the deleted SDKv2 test file. All assertions remain unchanged, including metadata.0.name paths.

data_source_config_map_v1_migration_test.go	-Two-step migration test. Step 1 applies the configuration using the released SDKv2 provider (hashicorp/kubernetes ~> 2.0). Step 2 applies the identical HCL configuration using the local Framework provider and asserts an empty plan, proving zero breaking changes.


</div><button class="wm-button wm-button--small wm-button--ghost wm-button--radius-full _wdUoQG_codeBlockCopyButton _wdUoQG_tableCopyButton" data-icon-only="" data-radius="full" data-size="small" data-variant="ghost" data-w-component="button" type="button" aria-label="Copy table" data-oai-tooltip="" data-table-copy-state="idle"><span class="_wdUoQG_codeBlockCopyIcon"><svg aria-hidden="true" fill="none" height="16" viewBox="0 0 16 16" width="16" class="_wdUoQG_messageActionIcon"><use href="#lightweight-conversation-copy-compact"></use></svg></span></button></div>
<h2>No Breaking Changes</h2>
<ul>
<li><code>metadata { name = "..." }</code> block syntax remains identical.</li>
<li><code>metadata.0.*</code> attribute paths are preserved through <code>ListNestedBlock</code>.</li>
<li>Existing <code>.tf</code> files require no changes.</li>

</ul>
<h2>Testing</h2>
<h3>Unit Tests</h3>
<p>No Kubernetes cluster is required.</p>
<pre><code class="language-sh">make test
</code><button class="wm-button wm-button--small wm-button--ghost wm-button--radius-full _wdUoQG_codeBlockCopyButton" data-icon-only="" data-radius="full" data-size="small" data-variant="ghost" data-w-component="button" type="button" aria-label="Copy code" data-code-copy-state="idle" data-oai-tooltip=""><span class="_wdUoQG_codeBlockCopyIcon"><svg aria-hidden="true" fill="none" height="16" viewBox="0 0 16 16" width="16" class="_wdUoQG_messageActionIcon"><use href="#lightweight-conversation-copy-compact"></use></svg></span></button></pre>
<h3>Acceptance Tests</h3>
<p>Requires a live Kubernetes cluster:</p>
<pre><code class="language-sh">export KUBE_CONFIG_PATH="$HOME/.kube/config"
export KUBE_CTX="kind-demo"

TF_ACC=1 go test ./internal/framework/provider/corev1/... \
  -v -vet=off -parallel 4 -timeout 3h \
  -run TestAccKubernetesDataSourceConfigMapV1
</code><button class="wm-button wm-button--small wm-button--ghost wm-button--radius-full _wdUoQG_codeBlockCopyButton" data-icon-only="" data-radius="full" data-size="small" data-variant="ghost" data-w-component="button" type="button" aria-label="Copy code" data-code-copy-state="idle" data-oai-tooltip=""><span class="_wdUoQG_codeBlockCopyIcon"><svg aria-hidden="true" fill="none" height="16" viewBox="0 0 16 16" width="16" class="_wdUoQG_messageActionIcon"><use href="#lightweight-conversation-copy-compact"></use></svg></span></button></pre>
</body></html>