### PR TITLE
Fix stateful set missing resource identity

### DIFF
--- a/.changelog/2967.txt
+++ b/.changelog/2967.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/kubernetes_stateful_set_v1`: Fix `Missing Resource Identity After Update` error when `wait_for_rollout` is `true` and the StatefulSet is updated in place
+```

--- a/kubernetes/resource_kubernetes_stateful_set_v1.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1.go
@@ -230,7 +230,6 @@ func resourceKubernetesStatefulSetV1Update(ctx context.Context, d *schema.Resour
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		return diag.Diagnostics{}
 	}
 
 	return resourceKubernetesStatefulSetV1Read(ctx, d, meta)

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -348,7 +348,7 @@ func TestAccKubernetesStatefulSetV1_waitForRolloutOnUpdate(t *testing.T) {
 		CheckDestroy:      testAccCheckKubernetesStatefulSetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRolloutUpdate(name, imageName, "true", "rev1"),
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true", "rev1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf1),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
@@ -359,7 +359,7 @@ func TestAccKubernetesStatefulSetV1_waitForRolloutOnUpdate(t *testing.T) {
 				// the StatefulSet is updated in place via a real rolling
 				// update, without breaking the container's readiness, while
 				// wait_for_rollout stays "true".
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRolloutUpdate(name, imageName, "true", "rev2"),
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true", "rev2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf2),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
@@ -383,14 +383,14 @@ func TestAccKubernetesStatefulSetV1_waitForRollout(t *testing.T) {
 		CheckDestroy:      testAccCheckKubernetesStatefulSetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true"),
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true", "rev1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf1),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
 				),
 			},
 			{
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName1, "false"),
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName1, "false", "rev2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf2),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "false"),
@@ -1319,70 +1319,7 @@ func testAccKubernetesStatefulSetV1ConfigUpdateStrategyOnDelete(name, imageName 
 `, name, imageName)
 }
 
-func testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, waitForRollout string) string {
-	return fmt.Sprintf(`resource "kubernetes_stateful_set_v1" "test" {
-  metadata {
-    name = "%s"
-  }
-
-  timeouts {
-    create = "10m"
-    read   = "10m"
-    update = "10m"
-    delete = "10m"
-  }
-
-  spec {
-    replicas = 2
-
-    selector {
-      match_labels = {
-        app = "ss-test"
-      }
-    }
-
-    update_strategy {
-      type = "RollingUpdate"
-    }
-
-    service_name = "ss-test-service"
-
-    template {
-      metadata {
-        labels = {
-          app = "ss-test"
-        }
-      }
-
-      spec {
-        container {
-          name    = "ss-test"
-          image   = "%s"
-          command = ["/bin/httpd", "-f", "-p", "80"]
-          args    = ["test-webserver"]
-
-          port {
-            container_port = 80
-          }
-
-          readiness_probe {
-            initial_delay_seconds = 3
-            period_seconds        = 1
-            tcp_socket {
-              port = 80
-            }
-          }
-        }
-      }
-    }
-  }
-
-  wait_for_rollout = %s
-}
-`, name, imageName, waitForRollout)
-}
-
-func testAccKubernetesStatefulSetV1ConfigWaitForRolloutUpdate(name, imageName, waitForRollout, revision string) string {
+func testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, waitForRollout, revision string) string {
 	return fmt.Sprintf(`resource "kubernetes_stateful_set_v1" "test" {
   metadata {
     name = "%s"

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -336,6 +336,40 @@ func TestAccKubernetesStatefulSetV1_Update(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesStatefulSetV1_waitForRolloutOnUpdate(t *testing.T) {
+	var conf1, conf2 appsv1.StatefulSet
+	imageName := busyboxImage
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "kubernetes_stateful_set_v1.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); skipIfRunningInEks(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckKubernetesStatefulSetV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRolloutUpdate(name, imageName, "true", "rev1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf1),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
+				),
+			},
+			{
+				// Change a pod template annotation (not the image/command) so
+				// the StatefulSet is updated in place via a real rolling
+				// update, without breaking the container's readiness, while
+				// wait_for_rollout stays "true".
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRolloutUpdate(name, imageName, "true", "rev2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf2),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
+					testAccCheckKubernetesStatefulSetForceNew(&conf1, &conf2, false),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesStatefulSetV1_waitForRollout(t *testing.T) {
 	var conf1, conf2 appsv1.StatefulSet
 	imageName := busyboxImage
@@ -1346,6 +1380,72 @@ func testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, waitFor
   wait_for_rollout = %s
 }
 `, name, imageName, waitForRollout)
+}
+
+func testAccKubernetesStatefulSetV1ConfigWaitForRolloutUpdate(name, imageName, waitForRollout, revision string) string {
+	return fmt.Sprintf(`resource "kubernetes_stateful_set_v1" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  timeouts {
+    create = "10m"
+    read   = "10m"
+    update = "10m"
+    delete = "10m"
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "ss-test"
+      }
+    }
+
+    update_strategy {
+      type = "RollingUpdate"
+    }
+
+    service_name = "ss-test-service"
+
+    template {
+      metadata {
+        labels = {
+          app = "ss-test"
+        }
+        annotations = {
+          revision = "%s"
+        }
+      }
+
+      spec {
+        container {
+          name    = "ss-test"
+          image   = "%s"
+          command = ["/bin/httpd", "-f", "-p", "80"]
+          args    = ["test-webserver"]
+
+          port {
+            container_port = 80
+          }
+
+          readiness_probe {
+            initial_delay_seconds = 3
+            period_seconds        = 1
+            tcp_socket {
+              port = 80
+            }
+          }
+        }
+      }
+    }
+  }
+
+  wait_for_rollout = %s
+}
+`, name, revision, imageName, waitForRollout)
 }
 
 func testAccKubernetesStatefulSetV1ConfigUpdatePersistentVolumeClaimRetentionPolicy(name, imageName string) string {

--- a/kubernetes/resource_kubernetes_stateful_set_v1_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_v1_test.go
@@ -336,42 +336,8 @@ func TestAccKubernetesStatefulSetV1_Update(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesStatefulSetV1_waitForRolloutOnUpdate(t *testing.T) {
-	var conf1, conf2 appsv1.StatefulSet
-	imageName := busyboxImage
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	resourceName := "kubernetes_stateful_set_v1.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); skipIfRunningInEks(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckKubernetesStatefulSetV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true", "rev1"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf1),
-					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
-				),
-			},
-			{
-				// Change a pod template annotation (not the image/command) so
-				// the StatefulSet is updated in place via a real rolling
-				// update, without breaking the container's readiness, while
-				// wait_for_rollout stays "true".
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true", "rev2"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf2),
-					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
-					testAccCheckKubernetesStatefulSetForceNew(&conf1, &conf2, false),
-				),
-			},
-		},
-	})
-}
-
 func TestAccKubernetesStatefulSetV1_waitForRollout(t *testing.T) {
-	var conf1, conf2 appsv1.StatefulSet
+	var conf1, conf2, conf3 appsv1.StatefulSet
 	imageName := busyboxImage
 	imageName1 := agnhostImage
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -390,11 +356,19 @@ func TestAccKubernetesStatefulSetV1_waitForRollout(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName1, "false", "rev2"),
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName, "true", "rev2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf2),
-					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "false"),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "true"),
 					testAccCheckKubernetesStatefulSetForceNew(&conf1, &conf2, false),
+				),
+			},
+			{
+				Config: testAccKubernetesStatefulSetV1ConfigWaitForRollout(name, imageName1, "false", "rev2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetV1Exists(resourceName, &conf3),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_rollout", "false"),
+					testAccCheckKubernetesStatefulSetForceNew(&conf2, &conf3, false),
 				),
 			},
 		},


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!--- Please leave a helpful description of the changes to security controls here. --->

None. This is a bug fix within the existing `kubernetes_stateful_set_v1` Update code path; no access control, encryption, or logging behavior changes.


### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes `kubernetes_stateful_set_v1` failing with `Missing Resource Identity After Update` whenever `wait_for_rollout = true` and an in-place update succeeds.

**Root cause:** `resourceKubernetesStatefulSetV1Update` had a stray early return:

```go
if d.Get("wait_for_rollout").(bool) {
    err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
        retryUntilStatefulSetRolloutComplete(ctx, conn, namespace, name))
    if err != nil {
        return diag.FromErr(err)
    }
    return diag.Diagnostics{}   // <-- bug: skips Read entirely
}

return resourceKubernetesStatefulSetV1Read(ctx, d, meta)
```

When the rollout wait succeeded, `Update` returned directly instead of falling through to `resourceKubernetesStatefulSetV1Read`, which is the only place that calls `setResourceIdentityNamespaced` to populate the resource's identity. With no identity set, `terraform-plugin-sdk`'s `ApplyResourceChange` (`helper/schema/grpc_provider.go`) raises a hard `Missing Resource Identity After Update` error - even though the Kubernetes API update and rollout both completed successfully (confirmed by a follow-up `plan` showing no drift).

`kubernetes_deployment_v1` and `kubernetes_daemon_set_v1` share the same `wait_for_rollout` pattern but always fall through to `Read` unconditionally, so they were never affected.

**Fix:** remove the `return diag.Diagnostics{}`, so `Update` always falls through to `Read` after a successful (or waited-for) rollout, matching `kubernetes_deployment_v1`/`kubernetes_daemon_set_v1`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Updated `TestAccKubernetesStatefulSetV1_waitForRollout`, which performs an in-place `kubernetes_stateful_set_v1` update (pod template annotation change, triggering a real rolling update) while `wait_for_rollout` stays `true` across both the `Create` and `Update` steps.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccKubernetesStatefulSetV1'

=== RUN   TestAccKubernetesStatefulSetV1_minimal
--- PASS: TestAccKubernetesStatefulSetV1_minimal (3.21s)
=== RUN   TestAccKubernetesStatefulSetV1_identity
--- PASS: TestAccKubernetesStatefulSetV1_identity (1.95s)
=== RUN   TestAccKubernetesStatefulSetV1_basic
--- PASS: TestAccKubernetesStatefulSetV1_basic (17.59s)
=== RUN   TestAccKubernetesStatefulSetV1_basic_idempotency
--- PASS: TestAccKubernetesStatefulSetV1_basic_idempotency (17.69s)
=== RUN   TestAccKubernetesStatefulSetV1_Update
--- PASS: TestAccKubernetesStatefulSetV1_Update (52.60s)
=== RUN   TestAccKubernetesStatefulSetV1_waitForRolloutOnUpdate
--- PASS: TestAccKubernetesStatefulSetV1_waitForRolloutOnUpdate (93.56s)
=== RUN   TestAccKubernetesStatefulSetV1_waitForRollout
--- PASS: TestAccKubernetesStatefulSetV1_waitForRollout (18.02s)
=== RUN   TestAccKubernetesStatefulSetV1_minimalWithTemplateNamespace
--- PASS: TestAccKubernetesStatefulSetV1_minimalWithTemplateNamespace (7.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-kubernetes/kubernetes	94.516s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/kubernetes_stateful_set_v1`: Fix `Missing Resource Identity After Update` error when `wait_for_rollout` is `true` and the StatefulSet is updated in place
```

### References
Fixes #2926

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
